### PR TITLE
[RPS-71] Specify geographical coverage for publication

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/Publication.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/Publication.java
@@ -8,15 +8,18 @@ public class Publication {
     private String publicationTitle;
     private String publicationSummary;
     private Attachment attachment;
+    private String geographicCoverage;
 
     private Publication(final String publicationName,
                         final String publicationTitle,
                         final String publicationSummary,
-                        final Attachment attachment) {
+                        final Attachment attachment,
+                        final String geographicCoverage) {
         this.publicationName = publicationName;
         this.publicationTitle = publicationTitle;
         this.publicationSummary = publicationSummary;
         this.attachment = attachment;
+        this.geographicCoverage = geographicCoverage;
     }
 
     public String getPublicationName() {
@@ -29,6 +32,10 @@ public class Publication {
 
     public String getPublicationSummary() {
         return publicationSummary;
+    }
+
+    public String getGeographicCoverage() {
+        return geographicCoverage;
     }
 
     public String getPublicationUrl() {
@@ -48,7 +55,8 @@ public class Publication {
             RandomHelper.newRandomString(),
             RandomHelper.newRandomString(),
             RandomHelper.newRandomString(),
-            Attachment.createNew()
+            Attachment.createNew(),
+            "UK"
         );
     }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ConsumablePublicationPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ConsumablePublicationPage.java
@@ -39,4 +39,8 @@ public class ConsumablePublicationPage extends AbstractPage {
         return helper.findElement(By.className("fileSize")).getText();
     }
 
+    public String getGeographicCoverage() {
+        return helper.findElement(By.id("geographic-coverage")).getText();
+    }
+
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ContentPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ContentPage.java
@@ -64,6 +64,11 @@ public class ContentPage extends AbstractPage {
             getWebDriver().findElement(By.cssSelector("input[type=file]"))
                 .sendKeys(attachmentPath.toAbsolutePath().toString());
         }
+
+        WebElement geographicCoverage = editorBody.findElement(By.xpath("//span[text()='Geographic Coverage']/../following-sibling::div//select[@class='dropdown-plugin']"));
+        Select dropdown = new Select(geographicCoverage );
+        dropdown.selectByVisibleText(publication.getGeographicCoverage());
+
     }
 
     public void savePublication() {

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/ContentSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/ContentSteps.java
@@ -140,5 +140,9 @@ public class ContentSteps extends AbstractSpringSteps {
                 is(publication.getAttachment().getContent())
             );
         }
+
+        assertThat("Geographic coverage is as expected",consumablePublicationPage.getGeographicCoverage(),
+            is("Geographic coverage:\n" + publication.getGeographicCoverage()));
+
     }
 }

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
@@ -11,7 +11,7 @@ definitions:
         /hipposysedit:nodetype:
           jcr:primaryType: hipposysedit:nodetype
           jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          jcr:uuid: 5c69cdaa-ebd3-4293-816d-9b3044e1399f
+          jcr:uuid: 4b214c41-2115-4c0d-b1da-13ae76e19d2f
           hipposysedit:node: true
           hipposysedit:supertype: ['hippotranslation:translated', 'hippotaxonomy:classifiable',
             'publicationsystem:basedocument', 'hippostd:relaxed']
@@ -131,7 +131,7 @@ definitions:
           hippotranslation:id: document-type-locale-id
           hippotranslation:locale: document-type-locale
           jcr:mixinTypes: ['mix:referenceable', 'hippotaxonomy:classifiable']
-          jcr:uuid: c8d9ab7e-1afd-485a-bd07-95d519916624
+          jcr:uuid: 8f13caa4-1816-4a29-9d03-4ba1115f3ba5
           hippostdpubwf:lastModificationDate: 2017-09-26T16:14:40.971+01:00
           hippostdpubwf:creationDate: 2017-09-26T16:14:40.972+01:00
           publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
@@ -261,7 +261,7 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
               selectable.options: England,England and Northern Ireland,England and
-                Scotland,England and Wales,England, Scotland and Northern Ireland,England,
+                Scotland,England and Wales,England Scotland and Northern Ireland,England
                 Wales and Northern Ireland,Great Britain,International,Northern Ireland,Scotland,UK,Wales
           /Granularity:
             jcr:primaryType: frontend:plugin


### PR DESCRIPTION
Individual geographical coverage options tweaked slightly due to some
values having commas in the text. To revisit. Include test for
selected geographic coverage value.