### PR TITLE
[RPS-132] Prevent saving publication with blank Granularity field

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ContentPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ContentPage.java
@@ -59,11 +59,8 @@ public class ContentPage extends AbstractCmsPage {
             publication.getInformationType().getDisplayName()
         );
 
-        new Select(helper.findElement(
-            By.xpath(XpathSelectors.EDITOR_BODY + "//span[text()='Granularity']/../following-sibling::div//select[@class='dropdown-plugin']")
-        )).selectByVisibleText(
-            publication.getGranularity().getDisplayValue()
-        );
+        getGranularitySection().addGranularityField();
+        getGranularitySection().populateGranularityField(publication.getGranularity());
 
         helper.findElement(
             By.xpath(XpathSelectors.EDITOR_BODY + "//span[text()='Select taxonomy terms']/../..")

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/GranularitySection.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/GranularitySection.java
@@ -3,8 +3,21 @@ package uk.nhs.digital.ps.test.acceptance.pages;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.Select;
+import uk.nhs.digital.ps.test.acceptance.models.Granularity;
 
 public class GranularitySection {
+
+    /**
+     * Targets 'parent' div that _contains_ an 'h3/span' child elements, where the <span> has text 'Granularity'
+     * this is so that further searches can be performed in context of the root element.
+     */
+    private static final String ROOT_ELEMENT_XPATH = XpathSelectors.EDITOR_BODY
+        + "//div[@class='hippo-editor-field' and h3/span[text() = 'Granularity']]";
+
+    /** Targets drop-down's {@code <select>} element. */
+    private static final String DROPDOWN_XPATH = ROOT_ELEMENT_XPATH + "//select[@class='dropdown-plugin']";
+
     private final PageHelper helper;
     private final WebDriver webDriver;
 
@@ -17,15 +30,20 @@ public class GranularitySection {
         helper.executeWhenStable(() -> findAddButton().click());
     }
 
-    private WebElement findRootElement() {
-        // find 'parent' div that _contains_ an 'h3/span' child elements, where the <span> has text 'Granularity'
-        // this is so that further searches can be performed in context of the root element
-        return getWebDriver().findElement(
-            By.xpath(XpathSelectors.EDITOR_BODY + "//div[@class='hippo-editor-field' and h3/span[text() = 'Granularity']]"));
+    public void populateGranularityField(final Granularity granularity) {
+        helper.executeWhenStable(() -> findDropDown().selectByVisibleText(granularity.getDisplayValue()));
+    }
+
+    private Select findDropDown() {
+        return new Select(helper.findElement(By.xpath(DROPDOWN_XPATH)));
     }
 
     private WebElement findAddButton() {
         return helper.findElement(() -> findRootElement().findElement(By.linkText("Add")));
+    }
+
+    private WebElement findRootElement() {
+        return getWebDriver().findElement(By.xpath(ROOT_ELEMENT_XPATH));
     }
 
     private WebDriver getWebDriver() {

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
@@ -130,7 +130,6 @@ definitions:
           publicationsystem:AdministrativeSources: ''
           publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
           publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-          publicationsystem:Granularity: ['']
           publicationsystem:InformationType: ['']
           publicationsystem:KeyFacts: ''
           publicationsystem:NominalDate: 0001-01-01T12:00:00Z

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/fusce-viverra-dolor.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/fusce-viverra-dolor.yaml
@@ -18,7 +18,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: Ipsum dolor sit amet, consectetur adipiscing elit.
       Mauris mattis sodales felis, vitae ultricies turpis porttitor in. Integer sit
@@ -53,7 +52,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: Ipsum dolor sit amet, consectetur adipiscing elit.
       Mauris mattis sodales felis, vitae ultricies turpis porttitor in. Integer sit
@@ -89,7 +87,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: Ipsum dolor sit amet, consectetur adipiscing elit.
       Mauris mattis sodales felis, vitae ultricies turpis porttitor in. Integer sit

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/lorem-ipsum.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/lorem-ipsum.yaml
@@ -18,7 +18,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: ''
     publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
@@ -51,7 +50,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: ''
     publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
@@ -85,7 +83,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: ''
     publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-tempor-euismod-vehicula.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-tempor-euismod-vehicula.yaml
@@ -18,7 +18,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: ''
     publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
@@ -52,7 +51,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: ''
     publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
@@ -87,7 +85,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: ''
     publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-vitae-nunc-ac-lacus-malesuada-tempus.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-vitae-nunc-ac-lacus-malesuada-tempus.yaml
@@ -18,7 +18,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: Donec ultricies fringilla mauris nec varius.
       Pellentesque ultricies et libero et venenatis. Mauris accumsan ligula sed enim
@@ -53,7 +52,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: Donec ultricies fringilla mauris nec varius.
       Pellentesque ultricies et libero et venenatis. Mauris accumsan ligula sed enim
@@ -89,7 +87,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: Donec ultricies fringilla mauris nec varius.
       Pellentesque ultricies et libero et venenatis. Mauris accumsan ligula sed enim

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nullam-vel-ligula-dapibus.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nullam-vel-ligula-dapibus.yaml
@@ -18,7 +18,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: ""
     publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
@@ -51,7 +50,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: ""
     publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
@@ -85,7 +83,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: ""
     publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nunc-tempus-ante-nec.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nunc-tempus-ante-nec.yaml
@@ -18,7 +18,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: Quisque fermentum eros turpis, non laoreet lacus
       tempus quis. Donec eget orci at massa egestas cursus. Duis at diam et eros
@@ -54,7 +53,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: Quisque fermentum eros turpis, non laoreet lacus
       tempus quis. Donec eget orci at massa egestas cursus. Duis at diam et eros
@@ -91,7 +89,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: Quisque fermentum eros turpis, non laoreet lacus
       tempus quis. Donec eget orci at massa egestas cursus. Duis at diam et eros

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-elementum-justo-eu-tortor.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-elementum-justo-eu-tortor.yaml
@@ -18,7 +18,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: ''
     publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
@@ -51,7 +50,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: ''
     publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
@@ -85,7 +83,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: ''
     publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-nec-justo.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-nec-justo.yaml
@@ -18,7 +18,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: ''
     publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
@@ -55,7 +54,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: ''
     publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
@@ -93,7 +91,6 @@
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
     publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:Granularity: ['']
     publicationsystem:InformationType: [Official statistics]
     publicationsystem:KeyFacts: ''
     publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor.yaml
@@ -30,7 +30,6 @@
       publicationsystem:AdministrativeSources: ''
       publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
       publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-      publicationsystem:Granularity: ['']
       publicationsystem:InformationType: [Official statistics]
       publicationsystem:KeyFacts: ''
       publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
@@ -57,7 +56,6 @@
       publicationsystem:AdministrativeSources: ''
       publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
       publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-      publicationsystem:Granularity: ['']
       publicationsystem:InformationType: [Official statistics]
       publicationsystem:KeyFacts: ''
       publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
@@ -85,7 +83,6 @@
       publicationsystem:AdministrativeSources: ''
       publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
       publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-      publicationsystem:Granularity: ['']
       publicationsystem:InformationType: [Official statistics]
       publicationsystem:KeyFacts: ''
       publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/valid-publication-series.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/valid-publication-series.yaml
@@ -81,7 +81,6 @@
       publicationsystem:AdministrativeSources: ''
       publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
       publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:Granularity: ['']
       publicationsystem:InformationType: [Official statistics]
       publicationsystem:KeyFacts: ''
       publicationsystem:NominalDate: 2013-01-10T01:00:00+01:00
@@ -107,7 +106,6 @@
       publicationsystem:AdministrativeSources: ''
       publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
       publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:Granularity: ['']
       publicationsystem:InformationType: [Official statistics]
       publicationsystem:KeyFacts: ''
       publicationsystem:NominalDate: 2013-01-10T01:00:00+01:00
@@ -134,7 +132,6 @@
       publicationsystem:AdministrativeSources: ''
       publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
       publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:Granularity: ['']
       publicationsystem:InformationType: [Official statistics]
       publicationsystem:KeyFacts: ''
       publicationsystem:NominalDate: 2013-01-10T01:00:00+01:00
@@ -163,7 +160,6 @@
       publicationsystem:AdministrativeSources: ''
       publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
       publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:Granularity: ['']
       publicationsystem:InformationType: [Official statistics]
       publicationsystem:KeyFacts: ''
       publicationsystem:NominalDate: 2014-01-10T01:00:00+01:00
@@ -189,7 +185,6 @@
       publicationsystem:AdministrativeSources: ''
       publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
       publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:Granularity: ['']
       publicationsystem:InformationType: [Official statistics]
       publicationsystem:KeyFacts: ''
       publicationsystem:NominalDate: 2014-01-10T01:00:00+01:00
@@ -216,7 +211,6 @@
       publicationsystem:AdministrativeSources: ''
       publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
       publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:Granularity: ['']
       publicationsystem:InformationType: [Official statistics]
       publicationsystem:KeyFacts: ''
       publicationsystem:NominalDate: 2014-01-10T01:00:00+01:00
@@ -245,7 +239,6 @@
       publicationsystem:AdministrativeSources: ''
       publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
       publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:Granularity: ['']
       publicationsystem:InformationType: [Official statistics]
       publicationsystem:KeyFacts: ''
       publicationsystem:NominalDate: 2015-01-10T01:00:00+01:00
@@ -271,7 +264,6 @@
       publicationsystem:AdministrativeSources: ''
       publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
       publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:Granularity: ['']
       publicationsystem:InformationType: [Official statistics]
       publicationsystem:KeyFacts: ''
       publicationsystem:NominalDate: 2015-01-10T01:00:00+01:00
@@ -298,7 +290,6 @@
       publicationsystem:AdministrativeSources: ''
       publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
       publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:Granularity: ['']
       publicationsystem:InformationType: [Official statistics]
       publicationsystem:KeyFacts: ''
       publicationsystem:NominalDate: 2015-01-10T01:00:00+01:00
@@ -327,7 +318,6 @@
       publicationsystem:AdministrativeSources: ''
       publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
       publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:Granularity: ['']
       publicationsystem:InformationType: [Official statistics]
       publicationsystem:KeyFacts: ''
       publicationsystem:NominalDate: 2016-01-10T01:00:00+01:00
@@ -353,7 +343,6 @@
       publicationsystem:AdministrativeSources: ''
       publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
       publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:Granularity: ['']
       publicationsystem:InformationType: [Official statistics]
       publicationsystem:KeyFacts: ''
       publicationsystem:NominalDate: 2016-01-10T01:00:00+01:00


### PR DESCRIPTION
Removed Granularity from:
- publication.yaml prototypes so that an empty placeholder doesn't
  get automatically added to newly created documents,
- from the test 'lorem ipsum' documents.

This is a change missed from the main commit 4517457.