### PR TITLE
[RPS-141] Fix blankStaticDropdown preValidator error

### DIFF
--- a/cms/src/main/java/uk/nhs/digital/ps/BlankStaticDropdownSelectionFieldValidator.java
+++ b/cms/src/main/java/uk/nhs/digital/ps/BlankStaticDropdownSelectionFieldValidator.java
@@ -38,7 +38,7 @@ public class BlankStaticDropdownSelectionFieldValidator extends AbstractCmsValid
             throw new ValidationException(format("Required parameter ''{0}'' is missing.", FIELD_DISPLAY_NAME_KEY));
         }
 
-        final String actualFieldTypeName = fieldValidator.getFieldType().getType();
+        final String actualFieldTypeName = fieldValidator.getFieldDescriptor().getTypeDescriptor().getName();
 
         if (!SUPPORTED_FIELD_TYPE_NAME.equals(actualFieldTypeName)) {
             throw new ValidationException(format(

--- a/cms/src/test/java/uk/nhs/digital/ps/BlankStaticDropdownSelectionFieldValidatorTest.java
+++ b/cms/src/test/java/uk/nhs/digital/ps/BlankStaticDropdownSelectionFieldValidatorTest.java
@@ -74,11 +74,11 @@ public class BlankStaticDropdownSelectionFieldValidatorTest {
     public void reportsError_whenCalledForFieldOfUnsupportedType() throws Exception {
 
         // given
-        programMocksForPreValidationTest();
+        programMocksForPreValidationTestForHappyPath();
         reset(typeDescriptor);
 
         final String unsupportedFieldTypeName = "unsupportedFieldTypeName";
-        given(typeDescriptor.getType()).willReturn(unsupportedFieldTypeName);
+        given(typeDescriptor.getName()).willReturn(unsupportedFieldTypeName);
 
         expectedException.expect(ValidationException.class);
         expectedException.expectMessage(format(
@@ -99,7 +99,7 @@ public class BlankStaticDropdownSelectionFieldValidatorTest {
     public void reportsError_whenFieldNameParameterMissing() throws Exception {
 
         // given
-        programMocksForPreValidationTest();
+        programMocksForPreValidationTestForHappyPath();
         reset(pluginConfig);
 
         expectedException.expect(ValidationException.class);
@@ -178,14 +178,13 @@ public class BlankStaticDropdownSelectionFieldValidatorTest {
      * Program common mocks with default, valid behaviours.
      * Test methods that need to test error conditions may reset and then reprogram individual mocks as needed.
      */
-    private void programMocksForPreValidationTest() {
+    private void programMocksForPreValidationTestForHappyPath() {
 
         given(pluginConfig.containsKey(FIELD_DISPLAY_NAME_KEY)).willReturn(true);
 
-        given(fieldValidator.getFieldType()).willReturn(typeDescriptor);
-        given(typeDescriptor.getType()).willReturn(SUPPORTED_FIELD_TYPE_NAME);
-
         given(fieldValidator.getFieldDescriptor()).willReturn(fieldDescriptor);
+        given(fieldDescriptor.getTypeDescriptor()).willReturn(typeDescriptor);
+        given(typeDescriptor.getName()).willReturn(SUPPORTED_FIELD_TYPE_NAME);
         given(fieldDescriptor.getPath()).willReturn(newRandomString());
     }
 


### PR DESCRIPTION
Even though preValidation throws an exception, the validate method
is still called, so this question has been raised with Bloomreach.