### PR TITLE
[RPS-140] Display list of publications - flag publication as upcoming

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/config/AcceptanceTestConfiguration.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/config/AcceptanceTestConfiguration.java
@@ -4,7 +4,6 @@ import org.slf4j.Logger;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
-import uk.nhs.digital.ps.test.acceptance.data.TestDataLoader;
 import uk.nhs.digital.ps.test.acceptance.data.TestDataRepo;
 import uk.nhs.digital.ps.test.acceptance.pages.*;
 import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/data/ExpectedTestDataProvider.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/data/ExpectedTestDataProvider.java
@@ -13,26 +13,25 @@ import static uk.nhs.digital.ps.test.acceptance.models.TimeSeriesBuilder.newTime
 
 /**
  * <p>
- * Provides methods used to create test data objects based on static resources such as Hippo CMS repository YAML files.
- * </p>
- * <p>
- * Ideally, methods of this class should read such source files (hence the 'Loader' part of the class' name) and build
- * test data 'models' dynamically based on the files' content. However, given that the implementation of reliable
- * loading mechanism could be rather involving, in the interest of time, the current implementation actually constructs
- * new test data objects in a way that they <em>match</em> the content of the YAML files, without actually reading the
- * files. Therefore, as long as this approach is followed, it's important to be careful that the factory methods
- * construct objects accurately reflecting content of the source files.
+ * Provides methods creating test data objects representing documents as defined by Hippo CMS repository YAML files.
+ * </p><p>
+ * In the future, this class could be turned into a 'loader' building the test data objects dynamically by reading
+ * and interpreting the YAML files, thus eliminating the risk that its content could get out of sync with the files,
+ * but, given that implementation of reliable loading mechanism could be rather involving, in the interest of time, the
+ * current implementation actually constructs these objcects using hardcoded definitions that <em>match</em> the content
+ * of the YAML files, without actually reading them.
+ * </p><p>
+ * Therefore, until dynamic loading is implemented, care must be taken that the implementation of individual factory
+ * methods strictly corresponds to the content of corresponding files.
  * </p>
  */
-public class TestDataLoader {
+public class ExpectedTestDataProvider {
 
     /**
      * @return New instance of time series corresponding to YAML definition
-     * {@code /content/documents/publicationsystem/publications/valid-publication-series} in {@code publication.yaml}
+     * {@code /content/documents/publicationsystem/publications/valid-publication-series.yaml}.
      */
-    public static TimeSeriesBuilder loadValidTimeSeries() {
-
-        // KEEP IN SYNC WITH publications.yaml OR IMPLEMENT DYNAMIC BUILDING FROM THE FILE
+    public static TimeSeriesBuilder getValidTimeSeries() {
 
         return newTimeSeries()
             .withName("valid publication series")
@@ -43,26 +42,44 @@ public class TestDataLoader {
                     .withSummary("A released publication")
                     .withInformationType(OFFICIAL_STATISTICS)
                     .withNominalDate(asInstant("2013-01-10T01:00:00+01:00"))
-                    .withStatus(PUBLISHED),
+                    .inStatus(PUBLISHED)
+                    .withPubliclyAccessible(true),
                 newPublication()
                     .withTitle("Lorem Ipsum Dolor 2013")
                     .withSummary("A released publication 2013")
                     .withInformationType(OFFICIAL_STATISTICS)
                     .withNominalDate(asInstant("2014-01-10T01:00:00+01:00"))
-                    .withStatus(PUBLISHED),
+                    .inStatus(PUBLISHED)
+                    .withPubliclyAccessible(true),
                 newPublication()
                     .withTitle("Lorem Ipsum Dolor 2014")
                     .withSummary("Released 2014 stats.")
                     .withInformationType(OFFICIAL_STATISTICS)
                     .withNominalDate(asInstant("2015-01-10T01:00:00+01:00"))
-                    .withStatus(PUBLISHED),
+                    .inStatus(PUBLISHED)
+                    .withPubliclyAccessible(true),
                 newPublication()
                     .withTitle("Lorem Ipsum Dolor 2015")
                     .withSummary("Released 2015 stats.")
                     .withInformationType(OFFICIAL_STATISTICS)
                     .withNominalDate(asInstant("2016-01-10T01:00:00+01:00"))
-                    .withStatus(CREATED)
+                    .inStatus(CREATED)
+                    .withPubliclyAccessible(true)
             );
+    }
+
+    /**
+     * @return New instance of a released publication flagged as 'upcoming', corresponding to YAML definition
+     * {@code /content/documents/corporate-website/publication-system/released-upcoming-publication.yaml}.
+     */
+    public static PublicationBuilder getReleasedUpcomingPublication() {
+        return newPublication()
+            .withName("released-upcoming-publication")
+            .withTitle("Released Upcoming Publication")
+            .withInformationType(InformationType.OFFICIAL_STATISTICS)
+            .withNominalDate(asInstant("2017-06-01T09:30:00.000+01:00"))
+            .inStatus(PUBLISHED)
+            .withPubliclyAccessible(false);
     }
 
     private static Instant asInstant(final String timestamp) {

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/data/TestDataFactory.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/data/TestDataFactory.java
@@ -38,6 +38,7 @@ public class TestDataFactory {
             .withGeographicCoverage(getRandomEnumConstant(GeographicCoverage.class))
             .withInformationType(getRandomEnumConstant(InformationType.class))
             .withGranularity(getRandomEnumConstant(Granularity.class))
+            .withPubliclyAccessible(true)
             .withTaxonomy(Taxonomy.createNew("Conditions", "Accidents and injuries", "Falls"));
     }
 

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/Publication.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/Publication.java
@@ -1,7 +1,10 @@
 package uk.nhs.digital.ps.test.acceptance.models;
 
+import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 public class Publication {
@@ -13,6 +16,7 @@ public class Publication {
     private InformationType informationType;
     private Granularity granularity;
     private Instant nominalDate;
+    boolean publiclyAccessible;
 
     private List<Attachment> attachments = new ArrayList<>();
 
@@ -30,6 +34,7 @@ public class Publication {
         nominalDate = builder.getNominalDate();
         taxonomy = builder.getTaxonomy();
         attachments = builder.getAttachments();
+        publiclyAccessible = builder.isPubliclyAccessible();
 
         status = builder.getStatus();
     }
@@ -62,6 +67,18 @@ public class Publication {
         return nominalDate;
     }
 
+    public String getNominalDateFormatted() {
+        final int weeksUntilCutOff = 8;
+        final int daysInAWeek = 7;
+        final int daysUntilCutOff = weeksUntilCutOff * daysInAWeek;
+
+        String pattern = nominalDate.isAfter(Instant.now().plus(daysUntilCutOff, ChronoUnit.DAYS))
+            ? "MMM yyyy"
+            : "d MMM yyyy";
+
+        return new SimpleDateFormat(pattern).format(new Date(nominalDate.toEpochMilli()));
+    }
+
     public List<Attachment> getAttachments() {
         return new ArrayList<>(attachments);
     }
@@ -77,4 +94,10 @@ public class Publication {
     public PublicationStatus getStatus() {
         return status;
     }
+
+    public boolean isPubliclyAccessible() {
+        return publiclyAccessible;
+    }
+
+
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/PublicationBuilder.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/PublicationBuilder.java
@@ -17,6 +17,7 @@ public class PublicationBuilder {
     private InformationType informationType;
     private Granularity granularity;
     private Instant nominalDate;
+    private boolean publiclyAccessible;
     private List<AttachmentBuilder> attachmentBuilders = new ArrayList<>();
     private Taxonomy taxonomy;
 
@@ -62,20 +63,24 @@ public class PublicationBuilder {
         return cloneAndAmend(builder -> builder.attachmentBuilders = asList(attachmentBuilders));
     }
 
-    public PublicationBuilder withStatus(final PublicationStatus status) {
+    public PublicationBuilder inStatus(final PublicationStatus status) {
         return cloneAndAmend(builder -> builder.status = status);
     }
 
     public PublicationBuilder withTaxonomy(final Taxonomy taxonomy) {
         return cloneAndAmend(builder -> builder.taxonomy = taxonomy);
     }
+
+    public PublicationBuilder withPubliclyAccessible(final boolean publiclyAccessible) {
+        return cloneAndAmend(builder -> builder.publiclyAccessible = publiclyAccessible);
+    }
     //</editor-fold>
 
     public Publication build() {
         return new Publication(this);
     }
-    //<editor-fold desc="GETTERS" defaultstate="collapsed">
 
+    //<editor-fold desc="GETTERS" defaultstate="collapsed">
     String getName() {
         return name;
     }
@@ -119,6 +124,10 @@ public class PublicationBuilder {
     PublicationStatus getStatus() {
         return status;
     }
+
+    public boolean isPubliclyAccessible() {
+        return publiclyAccessible;
+    }
     //</editor-fold>
 
     private PublicationBuilder(final PublicationBuilder original) {
@@ -129,6 +138,7 @@ public class PublicationBuilder {
         informationType = original.getInformationType();
         granularity = original.getGranularity();
         nominalDate = original.getNominalDate();
+        publiclyAccessible = original.isPubliclyAccessible();
         taxonomy = original.getTaxonomy();
         attachmentBuilders = original.getAttachmentBuilders();
 

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ConsumablePublicationPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ConsumablePublicationPage.java
@@ -4,12 +4,30 @@ import uk.nhs.digital.ps.test.acceptance.models.Publication;
 import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
 import org.openqa.selenium.*;
 
+import java.util.Collection;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 
 
 public class ConsumablePublicationPage extends AbstractConsumablePage {
+
+    private static final By TITLE_SELECTOR = By.id("title");
+    private static final By SERIES_LINK_SELECTOR = By.className("label--series");
+
+    private static final By SUMMARY_SELECTOR = By.id("summary");
+    private static final By ATTACHMENTS_SELECTOR = By.cssSelector("li[class~='attachment']");
+    private static final By GEOGRAPHIC_COVERAGE_SELECTOR = By.id("geographic-coverage");
+    private static final By INFORMATION_TYPE_SELECTOR = By.id("information-types");
+    private static final By GRANULARITY_SELECTOR = By.id("granularity");
+    private static final By TAXONOMY_SELECTOR = By.id("taxonomy");
+    private static final By NOMINAL_PUBLICATION_DATE_SELECTOR = By.id("nominal-date");
+    private static final By NOMINAL_PUBLICATION_DATE_VALUE_SELECTOR = By.id("nominal-date-value");
+    private static final By COVERAGE_START_DATE_SELECTOR = By.id("coverage-start");
+    private static final By COVERAGE_END_DATE_SELECTOR = By.id("coverage-end");
+    private static final By RELATED_LINKS_SELECTOR = By.id("related-links");
+    private static final By ADMINISTRATIVE_SOURCES_SELECTOR = By.id("administrative-sources");
 
     private PageHelper helper;
 
@@ -23,15 +41,15 @@ public class ConsumablePublicationPage extends AbstractConsumablePage {
     }
 
     public String getTitleText() {
-        return helper.findElement(By.id("title")).getText();
+        return helper.findElement(TITLE_SELECTOR).getText();
     }
 
     public String getSummaryText() {
-        return helper.findElement(By.id("summary")).getText();
+        return helper.findElement(SUMMARY_SELECTOR).getText();
     }
 
     public List<ConsumableAttachmentElement> getAttachments() {
-        return getWebDriver().findElements(By.cssSelector("li[class~='attachment']")).stream()
+        return getWebDriver().findElements(ATTACHMENTS_SELECTOR).stream()
             .map(webElement -> new ConsumableAttachmentElement(getWebDriver(), webElement))
             .collect(toList());
     }
@@ -44,23 +62,52 @@ public class ConsumablePublicationPage extends AbstractConsumablePage {
     }
 
     public String getGeographicCoverage() {
-        return helper.findElement(By.id("geographic-coverage")).getText();
+        return helper.findElement(GEOGRAPHIC_COVERAGE_SELECTOR).getText();
     }
 
     public String getInformationType() {
-        return helper.findElement(By.id("information-types")).getText();
+        return helper.findElement(INFORMATION_TYPE_SELECTOR).getText();
     }
 
     public String getGranularity() {
-        return helper.findElement(By.id("granularity")).getText();
+        return helper.findElement(GRANULARITY_SELECTOR).getText();
     }
 
     public String getTaxonomy() {
-        return helper.findElement(By.id("taxonomy")).getText();
+        return helper.findElement(TAXONOMY_SELECTOR).getText();
     }
 
     public String getSeriesLinkTitle() {
-        return helper.findElement(By.className("label--series")).getText();
+        return helper.findElement(SERIES_LINK_SELECTOR).getText();
     }
 
+    public boolean hasDisclaimer(final String disclaimer) {
+        return helper.findElement(
+            By.xpath("//*[@class='empty-field-disclaimer' and text()='" + disclaimer + "']")
+        ) != null;
+    }
+
+    public Collection<WebElement> getElementsHiddenWhenUpcoming() {
+
+        final List<By> selectorsOfFieldsHiddenForUpcoming = asList(
+            SUMMARY_SELECTOR,
+            ATTACHMENTS_SELECTOR,
+            GEOGRAPHIC_COVERAGE_SELECTOR,
+            INFORMATION_TYPE_SELECTOR,
+            GRANULARITY_SELECTOR,
+            TAXONOMY_SELECTOR,
+            COVERAGE_START_DATE_SELECTOR,
+            COVERAGE_END_DATE_SELECTOR,
+            RELATED_LINKS_SELECTOR,
+            ADMINISTRATIVE_SOURCES_SELECTOR
+        );
+
+        return selectorsOfFieldsHiddenForUpcoming.stream()
+            .flatMap(selector -> getWebDriver().findElements(selector).stream())
+            .collect(toList());
+    }
+
+    public String getNominalDate() {
+        return helper.findElement(NOMINAL_PUBLICATION_DATE_VALUE_SELECTOR).getText();
+    }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ContentPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ContentPage.java
@@ -7,8 +7,6 @@ import uk.nhs.digital.ps.test.acceptance.models.Publication;
 import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
 
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 
@@ -47,6 +45,8 @@ public class ContentPage extends AbstractCmsPage {
         populatePublicationTitle(publication.getTitle());
         populatePublicationSummary(publication.getSummary());
 
+        findPubliclyAccessibleRadioButton().select(publication.isPubliclyAccessible());
+
         new Select(helper.findElement(
             By.xpath(XpathSelectors.EDITOR_BODY + "//span[text()='Geographic Coverage']/../following-sibling::div//select[@class='dropdown-plugin']")
         )).selectByVisibleText(
@@ -62,9 +62,16 @@ public class ContentPage extends AbstractCmsPage {
         getGranularitySection().addGranularityField();
         getGranularitySection().populateGranularityField(publication.getGranularity());
 
+        populateTaxonomy(publication);
+
+        getAttachmentsSection().uploadAttachments(publication.getAttachments());
+    }
+
+    private void populateTaxonomy(final Publication publication) {
         helper.findElement(
             By.xpath(XpathSelectors.EDITOR_BODY + "//span[text()='Select taxonomy terms']/../..")
         ).click();
+
         helper.findElement(
             By.xpath(XpathSelectors.TAXONOMY_PICKER + "//span[text()='" + publication.getTaxonomy().getLevel1() + "']/..")
         ).click();
@@ -77,8 +84,10 @@ public class ContentPage extends AbstractCmsPage {
         helper.findElement(By.cssSelector("a[class~='category-add']")).click();
 
         findOk().click();
+    }
 
-        getAttachmentsSection().uploadAttachments(publication.getAttachments());
+    private PubliclyAccessibleRadioButton findPubliclyAccessibleRadioButton() {
+        return new PubliclyAccessibleRadioButton(helper);
     }
 
     public void populatePublicationTitle(final String publicationTitle) {

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/PubliclyAccessibleRadioButton.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/PubliclyAccessibleRadioButton.java
@@ -1,0 +1,32 @@
+package uk.nhs.digital.ps.test.acceptance.pages;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+public class PubliclyAccessibleRadioButton {
+
+    private final PageHelper helper;
+
+    public PubliclyAccessibleRadioButton(final PageHelper helper) {
+        this.helper = helper;
+    }
+
+    private WebElement findLiveOption() {
+        return findRadioButtonByLabelText("LIVE (Full content publicly accessible)");
+    }
+
+    private WebElement findUpcomingOption() {
+        return findRadioButtonByLabelText("UPCOMING (Show in upcoming publications list only)");
+    }
+
+    public void select(final boolean publiclyAccessible) {
+        WebElement option = publiclyAccessible ? findLiveOption() : findUpcomingOption();
+
+        option.click();
+    }
+
+    private WebElement findRadioButtonByLabelText(final String labelText) {
+        return helper.findElement(By.xpath("//input[@type='radio' and following-sibling::label[text() = '" + labelText + "']]"));
+    }
+
+}

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/ContentSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/ContentSteps.java
@@ -8,7 +8,7 @@ import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.nhs.digital.ps.test.acceptance.config.AcceptanceTestProperties;
 import uk.nhs.digital.ps.test.acceptance.data.TestDataFactory;
-import uk.nhs.digital.ps.test.acceptance.data.TestDataLoader;
+import uk.nhs.digital.ps.test.acceptance.data.ExpectedTestDataProvider;
 import uk.nhs.digital.ps.test.acceptance.data.TestDataRepo;
 import uk.nhs.digital.ps.test.acceptance.models.*;
 import uk.nhs.digital.ps.test.acceptance.pages.ConsumableAttachmentElement;
@@ -25,11 +25,9 @@ import java.util.List;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.slf4j.LoggerFactory.getLogger;
 import static uk.nhs.digital.ps.test.acceptance.util.AssertionHelper.assertWithinTimeoutThat;
 import static uk.nhs.digital.ps.test.acceptance.util.FileHelper.readFileAsByteArray;
@@ -288,4 +286,42 @@ public class ContentSteps extends AbstractSpringSteps {
         contentPage.getRelatedLinksSection().addRelatedLinkField();
     }
 
+
+    @Given("^I have a published publication flagged as upcoming$")
+    public void iHaveAReleasedPublicationFlaggedAsUpcoming() throws Throwable {
+        final Publication publication = ExpectedTestDataProvider.getReleasedUpcomingPublication().build();
+        testDataRepo.setCurrentPublication(publication);
+    }
+
+    @When("^I view the publication$")
+    public void iViewThePublication() throws Throwable {
+        consumablePublicationPage.open(testDataRepo.getCurrentPublication());
+    }
+
+    @Then("^Title is shown$")
+    public void titleIsVisible() throws Throwable {
+        assertThat("Title is shown.",
+            consumablePublicationPage.getTitleText(), is(testDataRepo.getCurrentPublication().getTitle())
+        );
+    }
+
+    @Then("^Nominal Publication Date field is shown$")
+    public void nominalPublicationDateFieldIsVisible() throws Throwable {
+        assertThat("Nominal Publication Date field is shown.",
+            consumablePublicationPage.getNominalDate(),
+            is(testDataRepo.getCurrentPublication().getNominalDateFormatted())
+        );
+    }
+
+    @Then("^Disclaimer \"([^\"]*)\" is displayed$")
+    public void disclaimerIsDisplayed(final String disclaimer) throws Throwable {
+        assertTrue("Disclaimer is displayed: " + disclaimer, consumablePublicationPage.hasDisclaimer(disclaimer));
+    }
+
+    @Then("^All other publication's details are hidden$")
+    public void allOtherDetailsAreHidden() throws Throwable {
+        assertThat("Fields that should be hidden for upcoming publication are hidden.",
+            consumablePublicationPage.getElementsHiddenWhenUpcoming(), is(empty())
+        );
+    }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/TimeSeriesSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/TimeSeriesSteps.java
@@ -6,7 +6,7 @@ import cucumber.api.java.en.When;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.nhs.digital.ps.test.acceptance.config.AcceptanceTestProperties;
-import uk.nhs.digital.ps.test.acceptance.data.TestDataLoader;
+import uk.nhs.digital.ps.test.acceptance.data.ExpectedTestDataProvider;
 import uk.nhs.digital.ps.test.acceptance.data.TestDataRepo;
 import uk.nhs.digital.ps.test.acceptance.models.*;
 import uk.nhs.digital.ps.test.acceptance.pages.ConsumablePublicationPage;
@@ -45,7 +45,7 @@ public class TimeSeriesSteps extends AbstractSpringSteps {
     @Given("^I have a number of publications belonging to the same time series$")
     public void iHaveANumberOfPublicationsBelongingToTheSameTimeSeries() throws Throwable {
 
-        final TimeSeries timeSeries = TestDataLoader.loadValidTimeSeries().build();
+        final TimeSeries timeSeries = ExpectedTestDataProvider.getValidTimeSeries().build();
         testDataRepo.setCurrentTimeSeries(timeSeries);
     }
 

--- a/acceptance-tests/src/test/resources/features/createAndPublish.feature
+++ b/acceptance-tests/src/test/resources/features/createAndPublish.feature
@@ -1,19 +1,27 @@
 Feature: As am author I need to create a new publication
     so that it is visible to end users
 
-@DiscardAfter
-Scenario: New Publication screen
-    Given I am on the content page
-    When I create a new publication
-    Then an edit screen is displayed which allows me to populate details of the publication
+    @DiscardAfter
+    Scenario: New Publication screen
+        Given I am on the content page
+        When I create a new publication
+        Then an edit screen is displayed which allows me to populate details of the publication
 
-Scenario: Saving a publication
-    Given I am on the edit screen
-    When I populate and save the publication
-    Then it is saved
+    Scenario: Saving a publication
+        Given I am on the edit screen
+        When I populate and save the publication
+        Then it is saved
 
-@NeedsExistingTestData
-Scenario: Publishing a publication
-    Given I have saved a publication
-    When I publish the publication
-    Then it is visible to consumers
+    @NeedsExistingTestData
+    Scenario: Publishing a publication
+        Given I have saved a publication
+        When I publish the publication
+        Then it is visible to consumers
+
+    Scenario: Details are hidden from the end users in a released upcoming publication
+        Given I have a published publication flagged as upcoming
+        When I view the publication
+        Then Title is shown
+        And Nominal Publication Date field is shown
+        And Disclaimer "(Upcoming, not yet published)" is displayed
+        And All other publication's details are hidden

--- a/acceptance-tests/src/test/resources/features/editScreenValidation.feature
+++ b/acceptance-tests/src/test/resources/features/editScreenValidation.feature
@@ -17,7 +17,7 @@ Feature: Edit screen - validation
         Given I am on the edit screen
         When I populate the summary with text longer than the maximum allowed limit of 1000 characters
         And I save the publication
-        Then the save is rejected with error message containing "must be less then 1000 characters"
+        Then the save is rejected with error message containing "Summary must be 1000 characters or less"
 
 
     @DiscardAfter
@@ -47,7 +47,7 @@ Feature: Edit screen - validation
         Given I have a publication opened for editing
         When I add an empty Granularity field
         And I save the publication
-        Then the save is rejected with error message containing "Field 'Granularity' has a placeholder without a value. Please remove it or select a value."
+        Then the save is rejected with error message containing "Granularity has a 'Choose One' placeholder without a value. Please remove the placeholder or select a value."
 
 
     @DiscardAfter

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
@@ -115,6 +115,15 @@ definitions:
             hipposysedit:primary: false
             hipposysedit:type: hippo:resource
             hipposysedit:validators: [publicationsystem-blank-attachment]
+          /publicly_accessible:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:PubliclyAccessible
+            hipposysedit:primary: false
+            hipposysedit:type: selection:BooleanRadioGroup
+            hipposysedit:validators: [required]
       /hipposysedit:prototypes:
         jcr:primaryType: hipposysedit:prototypeset
         /hipposysedit:prototype:
@@ -136,6 +145,7 @@ definitions:
           publicationsystem:NominalDate: 0001-01-01T12:00:00Z
           publicationsystem:Summary: ''
           publicationsystem:Title: ''
+          publicationsystem:PubliclyAccessible: false
       /editor:templates:
         jcr:primaryType: editor:templateset
         /_default_:
@@ -200,6 +210,17 @@ definitions:
             wicket.id: ${cluster.id}.left.item
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+          /publicly_accessible:
+            jcr:primaryType: frontend:plugin
+            caption: Publicly Accessible
+            field: publicly_accessible
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.left.item
+            hint: ''
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+              trueLabel: LIVE (Full content publicly accessible)
+              falseLabel: UPCOMING (Show in upcoming publications list only)
           /Summary:
             jcr:primaryType: frontend:plugin
             caption: Summary

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/lorem-ipsum.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/lorem-ipsum.yaml
@@ -35,6 +35,7 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true
   /lorem-ipsum[2]:
     jcr:primaryType: publicationsystem:publication
     jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
@@ -67,6 +68,7 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true
   /lorem-ipsum[3]:
     jcr:primaryType: publicationsystem:publication
     jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
@@ -100,3 +102,4 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-tempor-euismod-vehicula.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-tempor-euismod-vehicula.yaml
@@ -36,6 +36,7 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true
   /morbi-tempor-euismod-vehicula[2]:
     jcr:primaryType: publicationsystem:publication
     jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
@@ -69,6 +70,7 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true
   /morbi-tempor-euismod-vehicula[3]:
     jcr:primaryType: publicationsystem:publication
     jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
@@ -103,3 +105,4 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-vitae-nunc-ac-lacus-malesuada-tempus.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-vitae-nunc-ac-lacus-malesuada-tempus.yaml
@@ -37,6 +37,7 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true
   /morbi-vitae-nunc-ac-lacus-malesuada-tempus[2]:
     jcr:primaryType: publicationsystem:publication
     jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
@@ -71,6 +72,7 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true
   /morbi-vitae-nunc-ac-lacus-malesuada-tempus[3]:
     jcr:primaryType: publicationsystem:publication
     jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
@@ -106,3 +108,4 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nullam-vel-ligula-dapibus.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nullam-vel-ligula-dapibus.yaml
@@ -35,6 +35,7 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true
   /nullam-vel-ligula-dapibus[2]:
     jcr:primaryType: publicationsystem:publication
     jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
@@ -67,6 +68,7 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true
   /nullam-vel-ligula-dapibus[3]:
     jcr:primaryType: publicationsystem:publication
     jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
@@ -100,3 +102,4 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nunc-tempus-ante-nec.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nunc-tempus-ante-nec.yaml
@@ -38,6 +38,7 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true
   /nunc-tempus-ante-nec[2]:
     jcr:primaryType: publicationsystem:publication
     jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
@@ -73,6 +74,7 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true
   /nunc-tempus-ante-nec[3]:
     jcr:primaryType: publicationsystem:publication
     jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
@@ -109,3 +111,4 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-elementum-justo-eu-tortor.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-elementum-justo-eu-tortor.yaml
@@ -35,6 +35,7 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true
   /proin-elementum-justo-eu-tortor[2]:
     jcr:primaryType: publicationsystem:publication
     jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
@@ -67,6 +68,7 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true
   /proin-elementum-justo-eu-tortor[3]:
     jcr:primaryType: publicationsystem:publication
     jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
@@ -100,3 +102,4 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-nec-justo.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-nec-justo.yaml
@@ -39,6 +39,7 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true
   /proin-nec-justo[2]:
     jcr:primaryType: publicationsystem:publication
     jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
@@ -75,6 +76,7 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true
   /proin-nec-justo[3]:
     jcr:primaryType: publicationsystem:publication
     jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
@@ -112,3 +114,4 @@
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
+    publicationsystem:PubliclyAccessible: true

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/released-upcoming-publication.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/released-upcoming-publication.yaml
@@ -1,9 +1,9 @@
 ---
 
-/content/documents/corporate-website/publication-system/lorem-ipsum-content/fusce-viverra-dolor:
+/content/documents/corporate-website/publication-system/released-upcoming-publication:
   jcr:primaryType: hippo:handle
   jcr:mixinTypes: ['mix:referenceable']
-  /fusce-viverra-dolor[1]:
+  /released-upcoming-publication[1]:
     jcr:primaryType: publicationsystem:publication
     jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
     hippo:availability: []
@@ -23,22 +23,10 @@
       Mauris mattis sodales felis, vitae ultricies turpis porttitor in. Integer sit
       amet efficitur urna.
     publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc
-      pellentesque, lobortis orci eu, placerat nibh. Nulla est mauris, vehicula
-      nec ornare a, lacinia vel odio. Sed et accumsan mi, quis finibus orci. Integer
-      eget tortor mauris. Cras fermentum sodales urna, ac vulputate odio lobortis
-      eget. Etiam id erat blandit, feugiat orci non, pharetra est. Sed interdum
-      a leo facilisis aliquam. Curabitur justo nisi, mattis vel neque placerat,
-      imperdiet ultrices tortor.
-    publicationsystem:Title: Fusce viverra dolor
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /fusce-viverra-dolor[2]:
+    publicationsystem:Summary: Released Upcoming Publication summary.
+    publicationsystem:Title: Released Upcoming Publication
+    publicationsystem:PubliclyAccessible: false
+  /released-upcoming-publication[2]:
     jcr:primaryType: publicationsystem:publication
     jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
     hippo:availability: [preview]
@@ -58,22 +46,10 @@
       Mauris mattis sodales felis, vitae ultricies turpis porttitor in. Integer sit
       amet efficitur urna.
     publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc
-      pellentesque, lobortis orci eu, placerat nibh. Nulla est mauris, vehicula
-      nec ornare a, lacinia vel odio. Sed et accumsan mi, quis finibus orci. Integer
-      eget tortor mauris. Cras fermentum sodales urna, ac vulputate odio lobortis
-      eget. Etiam id erat blandit, feugiat orci non, pharetra est. Sed interdum
-      a leo facilisis aliquam. Curabitur justo nisi, mattis vel neque placerat,
-      imperdiet ultrices tortor.
-    publicationsystem:Title: Fusce viverra dolor
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /fusce-viverra-dolor[3]:
+    publicationsystem:Summary: Released Upcoming Publication summary.
+    publicationsystem:Title: Released Upcoming Publication
+    publicationsystem:PubliclyAccessible: false
+  /released-upcoming-publication[3]:
     jcr:primaryType: publicationsystem:publication
     jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
     hippo:availability: [live]
@@ -94,18 +70,6 @@
       Mauris mattis sodales felis, vitae ultricies turpis porttitor in. Integer sit
       amet efficitur urna.
     publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc
-      pellentesque, lobortis orci eu, placerat nibh. Nulla est mauris, vehicula
-      nec ornare a, lacinia vel odio. Sed et accumsan mi, quis finibus orci. Integer
-      eget tortor mauris. Cras fermentum sodales urna, ac vulputate odio lobortis
-      eget. Etiam id erat blandit, feugiat orci non, pharetra est. Sed interdum
-      a leo facilisis aliquam. Curabitur justo nisi, mattis vel neque placerat,
-      imperdiet ultrices tortor.
-    publicationsystem:Title: Fusce viverra dolor
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Released Upcoming Publication summary.
+    publicationsystem:Title: Released Upcoming Publication
+    publicationsystem:PubliclyAccessible: false

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor.yaml
@@ -41,6 +41,7 @@
         publicationsystem:linkUrl: ''
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
+      publicationsystem:PubliclyAccessible: true
     /loremipsumdolor[2]:
       jcr:primaryType: publicationsystem:publication
       jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
@@ -67,6 +68,7 @@
         publicationsystem:linkUrl: ''
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
+      publicationsystem:PubliclyAccessible: true
     /loremipsumdolor[3]:
       jcr:primaryType: publicationsystem:publication
       jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
@@ -94,3 +96,4 @@
         publicationsystem:linkUrl: ''
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
+      publicationsystem:PubliclyAccessible: true

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/valid-publication-series.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/valid-publication-series.yaml
@@ -92,6 +92,7 @@
         publicationsystem:linkUrl: ''
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
+      publicationsystem:PubliclyAccessible: true
     /2012[2]:
       jcr:primaryType: publicationsystem:publication
       jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
@@ -117,6 +118,7 @@
         publicationsystem:linkUrl: ''
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
+      publicationsystem:PubliclyAccessible: true
     /2012[3]:
       jcr:primaryType: publicationsystem:publication
       jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
@@ -143,6 +145,7 @@
         publicationsystem:linkUrl: ''
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
+      publicationsystem:PubliclyAccessible: true
   /2013:
     jcr:primaryType: hippo:handle
     jcr:mixinTypes: ['mix:referenceable']
@@ -171,6 +174,7 @@
         publicationsystem:linkUrl: ''
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
+      publicationsystem:PubliclyAccessible: true
     /2013[2]:
       jcr:primaryType: publicationsystem:publication
       jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
@@ -196,6 +200,7 @@
         publicationsystem:linkUrl: ''
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
+      publicationsystem:PubliclyAccessible: true
     /2013[3]:
       jcr:primaryType: publicationsystem:publication
       jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
@@ -222,6 +227,7 @@
         publicationsystem:linkUrl: ''
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
+      publicationsystem:PubliclyAccessible: true
   /2014:
     jcr:primaryType: hippo:handle
     jcr:mixinTypes: ['mix:referenceable']
@@ -250,6 +256,7 @@
         publicationsystem:linkUrl: ''
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
+      publicationsystem:PubliclyAccessible: true
     /2014[2]:
       jcr:primaryType: publicationsystem:publication
       jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
@@ -275,6 +282,7 @@
         publicationsystem:linkUrl: ''
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
+      publicationsystem:PubliclyAccessible: true
     /2014[3]:
       jcr:primaryType: publicationsystem:publication
       jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
@@ -301,6 +309,7 @@
         publicationsystem:linkUrl: ''
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
+      publicationsystem:PubliclyAccessible: true
   /2015:
     jcr:primaryType: hippo:handle
     jcr:mixinTypes: ['mix:referenceable']
@@ -329,6 +338,7 @@
         publicationsystem:linkUrl: ''
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
+      publicationsystem:PubliclyAccessible: true
     /2015[2]:
       jcr:primaryType: publicationsystem:publication
       jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
@@ -354,3 +364,4 @@
         publicationsystem:linkUrl: ''
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
+      publicationsystem:PubliclyAccessible: true

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
@@ -4,15 +4,29 @@
 <#assign formatFileSize="uk.nhs.digital.ps.directives.FileSizeFormatterDirective"?new() >
 <#assign formatRestrictableDate="uk.nhs.digital.ps.directives.RestrictableDateFormatterDirective"?new() />
 
-<#if document??>
-    <#if parentSeries??>
-    This document is part of Series
-    <a class="label label--series" href="<@hst.link hippobean=parentSeries.selfLink/>"
-        title="${parentSeries.title}">
-    ${parentSeries.title}
-    </a>
-    </#if>
-    <h1 class="doc-title" id="title">${document.title?html}</h1>
+<#macro nominalPublicationdate>
+<div id="nominal-date">
+    <h4>Nominal Publication Date:</h4>
+    <span id="nominal-date-value">
+        <#if document.nominalPublicationDate??>
+            <@formatRestrictableDate value=document.nominalPublicationDate/>
+        <#else>
+            (Not specified)
+        </#if>
+    <span>
+</div>
+</#macro>
+
+<#if parentSeries??>
+This document is part of Series
+<a class="label label--series" href="<@hst.link hippobean=parentSeries.selfLink/>"
+    title="${parentSeries.title}">
+${parentSeries.title}
+</a>
+</#if>
+<h1 class="doc-title" id="title">${document.title?html}</h1>
+
+<#if document.publiclyAccessible>
     <p class="doc-summary" id="summary">${document.summary?html}</p>
 
     <div id="taxonomy">
@@ -25,14 +39,7 @@
             (None specified)
         </#if>
     </div>
-    <div id="nominal-date">
-        <h4>Nominal publication date:</h4>
-        <#if document.nominalPublicationDate??>
-            <@formatRestrictableDate value=document.nominalPublicationDate/>
-        <#else>
-            (Not specified)
-        </#if>
-    </div>
+    <@nominalPublicationdate/>
     <div id="information-types">
         <h4>Information types:</h4>
         <#list document.informationType as type><#if type?index != 0>, </#if>${type?html}</#list>
@@ -107,8 +114,16 @@
     </div>
     <div id="administrative-sources">
         <h4>Administrative sources:</h4>
-        ${document.administrativeSources?html}
+        <#if document.administrativeSources?has_content >
+            ${document.administrativeSources?html}
+        <#else>
+            (No sources)
+        </#if>
     </div>
+<#else>
+    <p class="empty-field-disclaimer">(Upcoming, not yet published)</p>
+
+    <@nominalPublicationdate/>
 </#if>
 </body>
 </html>

--- a/site/src/main/java/uk/nhs/digital/ps/beans/Publication.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/Publication.java
@@ -1,14 +1,20 @@
 package uk.nhs.digital.ps.beans;
 
 import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
 import org.hippoecm.hst.content.beans.standard.HippoResourceBean;
 import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+import uk.nhs.digital.ps.site.exceptions.DataRestrictionViolationException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+
 
 @HippoEssentialsGenerated(internalName = "publicationsystem:publication")
 @Node(jcrType = "publicationsystem:publication")
@@ -16,26 +22,32 @@ public class Publication extends BaseDocument {
 
     private static final int WEEKS_TO_CUTOFF = 8;
 
+    private static final Collection<String> propertiesPermittedWhenUpcoming = asList(
+        PropertyKeys.TITLE,
+        PropertyKeys.NOMINAL_DATE,
+        PropertyKeys.PUBLICLY_ACCESSIBLE
+    );
+
     private RestrictableDate nominalPublicationDate;
 
-    @HippoEssentialsGenerated(internalName = "hippotaxonomy:keys")
+    @HippoEssentialsGenerated(internalName = PropertyKeys.TAXONOMY)
     public String[] getKeys() {
-        return getProperty("hippotaxonomy:keys");
+        return getPropertyIfPermitted(PropertyKeys.TAXONOMY);
     }
 
-    @HippoEssentialsGenerated(internalName = "publicationsystem:Summary")
+    @HippoEssentialsGenerated(internalName = PropertyKeys.SUMMARY)
     public String getSummary() {
-        return getProperty("publicationsystem:Summary");
+        return getPropertyIfPermitted(PropertyKeys.SUMMARY);
     }
 
-    @HippoEssentialsGenerated(internalName = "publicationsystem:KeyFacts")
+    @HippoEssentialsGenerated(internalName = PropertyKeys.KEY_FACTS)
     public String getKeyFacts() {
-        return getProperty("publicationsystem:KeyFacts");
+        return getPropertyIfPermitted(PropertyKeys.KEY_FACTS);
     }
 
-    @HippoEssentialsGenerated(internalName = "publicationsystem:InformationType")
+    @HippoEssentialsGenerated(internalName = PropertyKeys.INFORMATION_TYPE)
     public String[] getInformationType() {
-        return getProperty("publicationsystem:InformationType");
+        return getPropertyIfPermitted(PropertyKeys.INFORMATION_TYPE);
     }
 
     /**
@@ -49,79 +61,119 @@ public class Publication extends BaseDocument {
      * Any other place (such as view template or component) would offer less protection against the leak.
      * They are still free to implement their custom logic depending on value returned by {@linkplain
      * RestrictableDate#isRestricted()}, though.
-     * </p><p>
-     * The returned object expresses date in time zone '{@code UTC}'.
      * </p>
      */
     public RestrictableDate getNominalPublicationDate() {
         if (nominalPublicationDate == null) {
-            final Calendar nominalPublicationDateCalendar = getProperty("publicationsystem:NominalDate");
-
-            if (nominalPublicationDateCalendar != null) {
-                nominalPublicationDate = toRestrictedDate(nominalPublicationDateCalendar);
-            }
+            nominalPublicationDate = Optional.ofNullable(getProperty(PropertyKeys.NOMINAL_DATE))
+                .map(object -> (Calendar)object)
+                .map(this::nominalPublicationDateCalendarToRestrictedDate)
+                .orElse(null);
         }
         return nominalPublicationDate;
     }
 
-    @HippoEssentialsGenerated(internalName = "publicationsystem:CoverageStart")
+    @HippoEssentialsGenerated(internalName = PropertyKeys.COVERAGE_START)
     public Calendar getCoverageStart() {
-        return getProperty("publicationsystem:CoverageStart");
+        return getPropertyIfPermitted(PropertyKeys.COVERAGE_START);
     }
 
-    @HippoEssentialsGenerated(internalName = "publicationsystem:CoverageEnd")
+    @HippoEssentialsGenerated(internalName = PropertyKeys.COVERAGE_END)
     public Calendar getCoverageEnd() {
-        return getProperty("publicationsystem:CoverageEnd");
+        return getPropertyIfPermitted(PropertyKeys.COVERAGE_END);
     }
 
-    @HippoEssentialsGenerated(internalName = "publicationsystem:GeographicCoverage")
+    @HippoEssentialsGenerated(internalName = PropertyKeys.GEOGRAPHIC_COVERAGE)
     public String getGeographicCoverage() {
-        return getProperty("publicationsystem:GeographicCoverage");
+        return getPropertyIfPermitted(PropertyKeys.GEOGRAPHIC_COVERAGE);
     }
 
-    @HippoEssentialsGenerated(internalName = "publicationsystem:Granularity")
+    @HippoEssentialsGenerated(internalName = PropertyKeys.GRANULARITY)
     public String[] getGranularity() {
-        return getProperty("publicationsystem:Granularity");
+        return getPropertyIfPermitted(PropertyKeys.GRANULARITY);
     }
 
-    @HippoEssentialsGenerated(internalName = "publicationsystem:AdministrativeSources")
+    @HippoEssentialsGenerated(internalName = PropertyKeys.ADMINISTRATIVE_SOURCES)
     public String getAdministrativeSources() {
-        return getProperty("publicationsystem:AdministrativeSources");
+        return getPropertyIfPermitted(PropertyKeys.ADMINISTRATIVE_SOURCES);
     }
 
-    @HippoEssentialsGenerated(internalName = "publicationsystem:Title")
+    @HippoEssentialsGenerated(internalName = PropertyKeys.TITLE)
     public String getTitle() {
-        return getProperty("publicationsystem:Title");
+        return getPropertyIfPermitted(PropertyKeys.TITLE);
     }
 
-    @HippoEssentialsGenerated(internalName = "publicationsystem:RelatedLinks")
+    public boolean isPubliclyAccessible() {
+        return getPropertyIfPermitted(PropertyKeys.PUBLICLY_ACCESSIBLE);
+    }
+
+    @HippoEssentialsGenerated(internalName = PropertyKeys.RELATED_LINKS)
     public List<Relatedlink> getRelatedLinks() {
-        return getChildBeansByName("publicationsystem:RelatedLinks",
-                Relatedlink.class);
+        return getChildBeansIfPermitted(PropertyKeys.RELATED_LINKS, Relatedlink.class);
     }
 
-    @HippoEssentialsGenerated(internalName = "publicationsystem:attachments")
+    @HippoEssentialsGenerated(internalName = PropertyKeys.ATTACHMENTS)
     public List<HippoResourceBean> getAttachments() {
-        return getChildBeansByName("publicationsystem:attachments", HippoResourceBean.class);
+        return getChildBeansIfPermitted(PropertyKeys.ATTACHMENTS, HippoResourceBean.class);
+    }
+
+    private <T extends HippoBean> List<T> getChildBeansIfPermitted(final String propertyName, final
+    Class<T> beanMappingClass) {
+        assertPropertyPermitted(propertyName);
+
+        return getChildBeansByName(propertyName, beanMappingClass);
+    }
+
+    private <T> T getPropertyIfPermitted(final String propertyName) {
+        assertPropertyPermitted(propertyName);
+
+        return getProperty(propertyName);
+    }
+
+    private void assertPropertyPermitted(final String propertyKey) {
+
+        final boolean isPropertyPermitted = PropertyKeys.PUBLICLY_ACCESSIBLE.equals(propertyKey)
+            || isPubliclyAccessible()
+            || propertiesPermittedWhenUpcoming.contains(propertyKey);
+
+        if (!isPropertyPermitted) {
+            throw new DataRestrictionViolationException(
+                "Property is not available when publication is flagged as 'not publicly accessible': " + propertyKey
+            );
+        }
     }
 
     /**
-     * Converts given {@linkplain Calendar} to {@linkplain RestrictableDate}, where the returned object expresses date
-     * in time zone '{@code UTC}'.
+     * Converts given {@linkplain Calendar} to {@linkplain RestrictableDate}.
      */
-    private RestrictableDate toRestrictedDate(final Calendar nominalPublicationDateCalendar) {
+    private RestrictableDate nominalPublicationDateCalendarToRestrictedDate(final Calendar calendar) {
 
-        final LocalDate nominalPublicationDate = LocalDate.from(
-            LocalDateTime.ofInstant(
-                nominalPublicationDateCalendar.toInstant(),
-                ZoneId.of("UTC")
-            )
-        );
+        final LocalDate nominalPublicationDate = LocalDateTime.ofInstant(
+                calendar.toInstant(),
+                calendar.getTimeZone().toZoneId()
+            ).toLocalDate();
 
         final LocalDate cutOffPoint = LocalDate.now().plusWeeks(WEEKS_TO_CUTOFF);
 
         return nominalPublicationDate.isAfter(cutOffPoint)
             ? RestrictableDate.restrictedDateFrom(nominalPublicationDate)
             : RestrictableDate.fullDateFrom(nominalPublicationDate);
+    }
+
+    interface PropertyKeys {
+        String TAXONOMY = "hippotaxonomy:keys";
+        String SUMMARY = "publicationsystem:Summary";
+        String KEY_FACTS = "publicationsystem:KeyFacts";
+        String INFORMATION_TYPE = "publicationsystem:InformationType";
+        String NOMINAL_DATE = "publicationsystem:NominalDate";
+        String COVERAGE_START = "publicationsystem:CoverageStart";
+        String COVERAGE_END = "publicationsystem:CoverageEnd";
+        String GEOGRAPHIC_COVERAGE = "publicationsystem:GeographicCoverage";
+        String GRANULARITY = "publicationsystem:Granularity";
+        String ADMINISTRATIVE_SOURCES = "publicationsystem:AdministrativeSources";
+        String TITLE = "publicationsystem:Title";
+        String PUBLICLY_ACCESSIBLE = "publicationsystem:PubliclyAccessible";
+        String RELATED_LINKS = "publicationsystem:RelatedLinks";
+        String ATTACHMENTS = "publicationsystem:attachments";
     }
 }


### PR DESCRIPTION
Publications can now be designated as 'upcoming' (default for newly
created publications) and 'live'. Only a small subset of details gets
displayed for an upcoming released publication; released publication
flagged as 'live' has all its details displayed.

This is ensured both at the 'domain' and 'presentation' layer; the
former is achieved via checks in Publication bean class, the latter
through the conditional logic in publication.ftl template.