### PR TITLE
[RPS-135] Display list of publications - published and upcoming

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/config/AcceptanceTestConfiguration.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/config/AcceptanceTestConfiguration.java
@@ -9,6 +9,7 @@ import uk.nhs.digital.ps.test.acceptance.pages.*;
 import uk.nhs.digital.ps.test.acceptance.pages.site.SitePage;
 import uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPage;
 import uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationSeriesPage;
+import uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationsOverviewPage;
 import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
 import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverServiceProvider;
 
@@ -49,6 +50,11 @@ public class AcceptanceTestConfiguration {
     public PublicationSeriesPage publicationSeriesPage(final WebDriverProvider webDriverProvider,
                                                                  final PageHelper pageHelper) {
         return new PublicationSeriesPage(webDriverProvider, pageHelper);
+    }
+
+    @Bean
+    public PublicationsOverviewPage publicationsOverviewPage(final WebDriverProvider webDriverProvider) {
+        return new PublicationsOverviewPage(webDriverProvider);
     }
 
     @Bean

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/data/ExpectedTestDataProvider.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/data/ExpectedTestDataProvider.java
@@ -6,10 +6,11 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 
 import static uk.nhs.digital.ps.test.acceptance.models.InformationType.OFFICIAL_STATISTICS;
+import static uk.nhs.digital.ps.test.acceptance.models.PublicationBuilder.collectionOf;
 import static uk.nhs.digital.ps.test.acceptance.models.PublicationBuilder.newPublication;
 import static uk.nhs.digital.ps.test.acceptance.models.PublicationState.CREATED;
 import static uk.nhs.digital.ps.test.acceptance.models.PublicationState.PUBLISHED;
-import static uk.nhs.digital.ps.test.acceptance.models.TimeSeriesBuilder.newTimeSeries;
+import static uk.nhs.digital.ps.test.acceptance.models.PublicationSeriesBuilder.newPublicationSeries;
 
 /**
  * <p>
@@ -28,12 +29,12 @@ import static uk.nhs.digital.ps.test.acceptance.models.TimeSeriesBuilder.newTime
 public class ExpectedTestDataProvider {
 
     /**
-     * @return New instance of time series corresponding to YAML definition
+     * @return New instance of publication series corresponding to YAML definition
      * {@code /content/documents/publicationsystem/publications/valid-publication-series.yaml}.
      */
-    public static TimeSeriesBuilder getValidTimeSeries() {
+    public static PublicationSeriesBuilder getValidPublicationSeries() {
 
-        return newTimeSeries()
+        return newPublicationSeries()
             .withName("valid publication series")
             .withTitle("Time Series Lorem Ipsum Dolor")
             .withPublications(
@@ -65,6 +66,100 @@ public class ExpectedTestDataProvider {
                     .withNominalDate(asInstant("2016-01-10T01:00:00+01:00"))
                     .inState(CREATED)
                     .withPubliclyAccessible(true)
+            );
+    }
+
+    /**
+     * @return New instance collection of latest 'live' documents from the ones defined in
+     * {@code /content/documents/corporate-website/publication-system}.
+     */
+    public static PublicationBuilder.Collection getRecentPublishedLivePublications() {
+        return collectionOf(
+            newPublication()
+                .withTitle("Apple orange pear")
+                .withSummary("I like pears")
+                .withNominalDate(asInstant("2017-11-08T00:00:00Z"))
+                .inState(PUBLISHED)
+                .withPubliclyAccessible(true),
+            newPublication()
+                .withTitle("No mention of interesting terms in the title")
+                .withSummary("I like apples")
+                .withNominalDate(asInstant("2017-11-08T00:00:00Z"))
+                .inState(PUBLISHED)
+                .withPubliclyAccessible(true),
+            newPublication()
+                .withTitle("Apple pear orange bear")
+                .withSummary("I like apples")
+                .withNominalDate(asInstant("2017-11-07T00:00:00Z"))
+                .inState(PUBLISHED)
+                .withPubliclyAccessible(true),
+            newPublication()
+                .withTitle("Apple orange")
+                .withSummary("I like apples")
+                .withNominalDate(asInstant("2017-11-07T00:00:00Z"))
+                .inState(PUBLISHED)
+                .withPubliclyAccessible(true),
+            newPublication()
+                .withTitle("publication with datasets")
+                .withSummary("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis convallis non massa vel " +
+                    "dictum. In vel ex sapien. Donec sit amet leo lobortis, tempor ex ut, luctus eros. In in eleifend" +
+                    " orci, nec suscipit nisi. Maecenas sed velit condimentum, lobortis tortor id, ultricies metus. " +
+                    "Integer odio ante, congue pulvinar ultrices nec, mollis vitae dolor. Curabitur euismod erat " +
+                    "elit, quis facilisis neque eleifend id. Maecenas convallis vel mi nec bibendum. Donec ut erat " +
+                    "dictum, molestie dolor non, aliquet nibh.")
+                .withNominalDate(asInstant("2017-10-10T00:00:00Z"))
+                .inState(PUBLISHED)
+                .withPubliclyAccessible(true),
+            newPublication()
+                .withTitle("series publication with datasets")
+                .withSummary("Maecenas pharetra, magna ut pulvinar mattis, augue nisi pharetra dolor, eget commodo " +
+                    "lacus arcu vitae ligula. Pellentesque condimentum tortor eu condimentum porta. Sed sit amet " +
+                    "consectetur ipsum. Integer imperdiet gravida augue in tincidunt. Donec luctus, massa sit amet " +
+                    "porttitor cursus, ante enim fringilla felis, nec elementum eros leo eu mauris.")
+                .withNominalDate(asInstant("2017-10-10T00:00:00Z"))
+                .inState(PUBLISHED)
+                .withPubliclyAccessible(true),
+            newPublication()
+                .withTitle("Fusce viverra dolor")
+                .withSummary("Maecenas laoreet ullamcorper aliquam. Sed ac nunc pellentesque, lobortis orci eu, " +
+                    "placerat nibh. Nulla est mauris, vehicula nec ornare a, lacinia vel odio. Sed et accumsan mi, " +
+                    "quis finibus orci. Integer eget tortor mauris. Cras fermentum sodales urna, ac vulputate odio " +
+                    "lobortis eget. Etiam id erat blandit, feugiat orci non, pharetra est. Sed interdum a leo " +
+                    "facilisis aliquam. Curabitur justo nisi, mattis vel neque placerat, imperdiet ultrices tortor.")
+                .withNominalDate(asInstant("2017-06-01T00:00:00Z"))
+                .inState(PUBLISHED)
+                .withPubliclyAccessible(true),
+            newPublication()
+                .withTitle("Lorem ipsum dolor sit amet.")
+                .withSummary("Maecenas laoreet ullamcorper aliquam. Sed ac nunc pellentesque, lobortis orci eu, " +
+                    "placerat lorem. Nulla est mauris, vehicula nec ornare a, lacinia vel odio. Sed et accumsan mi, " +
+                    "quis finibus orci. Integer eget tortor mauris. Cras fermentum sodales urna, ac vulputate odio " +
+                    "lobortis eget. Etiam id erat blandit, feugiat orci non, pharetra est. Sed interdum a leo " +
+                    "facilisis aliquam. Curabitur justo nisi, mattis vel neque placerat, imperdiet ultrices tortor.")
+                .withNominalDate(asInstant("2017-06-01T00:00:00Z")),
+            newPublication()
+                .withTitle("Morbi tempor euismod vehicula")
+                .withSummary("Duis vel ultricies ante. Vestibulum nec commodo justo. Donec et tellus justo. Nunc id " +
+                    "lobortis odio. Morbi quis lectus scelerisque, efficitur augue a, aliquet velit. Duis ac " +
+                    "malesuada tortor. Duis mollis lorem consectetur ipsum convallis sollicitudin. Lorem ipsum dolor " +
+                    "sit amet, consectetur adipiscing elit. Donec varius eget purus nec finibus. Cras a urna " +
+                    "vestibulum, blandit nisl sit amet, auctor augue. Ut euismod eros quis lacus ullamcorper, ut " +
+                    "mollis nunc vehicula. Ut maximus, arcu nec mollis ultricies, libero tortor porta ante, id " +
+                    "iaculis nisl est ac velit.")
+                .withNominalDate(asInstant("2017-06-01T00:00:00Z"))
+                .inState(PUBLISHED)
+                .withPubliclyAccessible(true),
+            newPublication()
+                .withTitle("Morbi vitae nunc ac lacus malesuada tempus")
+                .withSummary("Etiam tempus quam sed massa ullamcorper, in vestibulum ex ultrices. Duis ipsum, eros et" +
+                    " accumsan auctor, turpis lectus viverra urna, eu viverra neque sem at metus. Praesent lacinia " +
+                    "erat facilisis, blandit elit a, volutpat ipsum. Morbi egestas eleifend sem. Sed semper egestas " +
+                    "purus, ac tempor sem efficitur ac. Cras leo mauris, vestibulum eget turpis ut, bibendum rhoncus " +
+                    "neque. Aliquam erat volutpat. Aliquam erat volutpat. Nullam justo mi, ipsum a ante nec, " +
+                    "tincidunt eleifend tortor.")
+                .withNominalDate(asInstant("2017-06-01T00:00:00Z"))
+                .inState(PUBLISHED)
+                .withPubliclyAccessible(true)
             );
     }
 

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/data/TestDataRepo.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/data/TestDataRepo.java
@@ -2,41 +2,71 @@ package uk.nhs.digital.ps.test.acceptance.data;
 
 import uk.nhs.digital.ps.test.acceptance.models.Attachment;
 import uk.nhs.digital.ps.test.acceptance.models.Publication;
-import uk.nhs.digital.ps.test.acceptance.models.TimeSeries;
+import uk.nhs.digital.ps.test.acceptance.models.PublicationSeries;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static uk.nhs.digital.ps.test.acceptance.data.TestDataRepo.PublicationClassifier.SINGLE;
 
 public class TestDataRepo {
 
-    private Publication currentPublication;
-    private List<Attachment> currentAttachments;
-    private TimeSeries currentTimeSeries;
+    private Map<PublicationClassifier, List<Publication>> publications = new HashMap<>();
 
-    public void setCurrentPublication(final Publication publication) {
-        this.currentPublication = publication;
+    private List<Attachment> attachments;
+    private PublicationSeries publicationSeries;
+
+    public void setPublication(final Publication publication) {
+        publications.clear();
+        addPublications(SINGLE, publication);
     }
 
     public Publication getCurrentPublication() {
-        return currentPublication;
+        return publications.get(SINGLE).get(0);
+    }
+
+    public void setAttachments(final List<Attachment> attachments) {
+        this.attachments = attachments;
+    }
+
+    public List<Attachment> getAttachments() {
+        return attachments;
+    }
+
+    public void setPublicationSeries(final PublicationSeries publicationSeries) {
+        this.publicationSeries = publicationSeries;
+    }
+
+    public PublicationSeries getPublicationSeries() {
+        return publicationSeries;
+    }
+
+    public void addPublications(final PublicationClassifier publicationClassifier, final Publication... publications) {
+        addPublications(publicationClassifier, asList(publications));
+    }
+
+    public void addPublications(final PublicationClassifier publicationClassifier, final List<Publication> publications) {
+        if (!this.publications.containsKey(publicationClassifier)) {
+            this.publications.put(publicationClassifier, new ArrayList<>());
+        }
+        this.publications.get(publicationClassifier).addAll(publications);
+    }
+
+    public List<Publication> getPublications(final PublicationClassifier publicationClassifier) {
+        return publications.get(publicationClassifier);
     }
 
     public void clear() {
-        setCurrentPublication(null);
+        setPublication(null);
+        publications.clear();
     }
 
-    public void setCurrentAttachments(final List<Attachment> currentAttachments) {
-        this.currentAttachments = currentAttachments;
-    }
-
-    public List<Attachment> getCurrentAttachments() {
-        return currentAttachments;
-    }
-
-    public void setCurrentTimeSeries(final TimeSeries currentTimeSeries) {
-        this.currentTimeSeries = currentTimeSeries;
-    }
-
-    public TimeSeries getCurrentTimeSeries() {
-        return currentTimeSeries;
+    public enum PublicationClassifier {
+        SINGLE,
+        UPCOMING,
+        LIVE;
     }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/Publication.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/Publication.java
@@ -87,6 +87,10 @@ public class Publication {
         return publiclyAccessible;
     }
 
+    public String getSummaryTruncated() {
+        return truncate(getSummary(), 100);
+    }
+
     public static class NominalPublicationDate implements Comparable<NominalPublicationDate> {
 
         static final String RESTRICTED_NOMINAL_DATE_PATTERN = "MMM yyyy";
@@ -117,6 +121,10 @@ public class Publication {
             return formatInstant(instant, FULL_NOMINAL_DATE_PATTERN);
         }
 
+        public String inFormat(final String datePattern) {
+            return formatInstant(instant, datePattern);
+        }
+
         public Instant asInstant() {
             return instant;
         }
@@ -124,6 +132,17 @@ public class Publication {
         @Override
         public int compareTo(final NominalPublicationDate other) {
             return asInstant().compareTo(other.asInstant());
+        }
+    }
+
+    private String truncate(String text, final int size) {
+
+        int endIndex = Math.max(size, text.indexOf(" ", size));
+
+        if (endIndex < text.length()) {
+            return text.substring(0, endIndex) + "...";
+        } else {
+            return text;
         }
     }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/PublicationBuilder.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/PublicationBuilder.java
@@ -159,4 +159,21 @@ public class PublicationBuilder {
     interface PropertySetter {
         void setProperties(PublicationBuilder builder);
     }
+
+    public static Collection collectionOf(final PublicationBuilder... publicationBuilders) {
+        return new Collection(publicationBuilders);
+    }
+
+    public static class Collection {
+
+        private final List<PublicationBuilder> publicationBuilders;
+
+        Collection(final PublicationBuilder... publicationBuilders) {
+            this.publicationBuilders = asList(publicationBuilders);
+        }
+
+        public List<Publication> build() {
+            return publicationBuilders.stream().map(PublicationBuilder::build).collect(toList());
+        }
+    }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/PublicationSeries.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/PublicationSeries.java
@@ -6,17 +6,17 @@ import java.util.List;
 import static java.util.stream.Collectors.toList;
 import static uk.nhs.digital.ps.test.acceptance.models.PublicationState.PUBLISHED;
 
-public class TimeSeries {
+public class PublicationSeries {
 
     private String name;
     private String title;
 
     private List<Publication> publications = new ArrayList<>();
 
-    TimeSeries(final TimeSeriesBuilder timeSeriesBuilder) {
-        name = timeSeriesBuilder.getName();
-        title = timeSeriesBuilder.getTitle();
-        publications = timeSeriesBuilder.getPublications();
+    PublicationSeries(final PublicationSeriesBuilder publicationSeriesBuilder) {
+        name = publicationSeriesBuilder.getName();
+        title = publicationSeriesBuilder.getTitle();
+        publications = publicationSeriesBuilder.getPublications();
     }
 
     public String getTitle() {

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/PublicationSeriesBuilder.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/PublicationSeriesBuilder.java
@@ -7,36 +7,36 @@ import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 
 @SuppressWarnings("WeakerAccess") // builder's methods are intentionally public
-public class TimeSeriesBuilder {
+public class PublicationSeriesBuilder {
 
     private String title;
     private List<PublicationBuilder> publicationBuilders = new ArrayList<>();
     private String name;
 
-    public static TimeSeriesBuilder newTimeSeries() {
-        return new TimeSeriesBuilder();
+    public static PublicationSeriesBuilder newPublicationSeries() {
+        return new PublicationSeriesBuilder();
     }
 
     //<editor-fold desc="BUILDER METHODS">
-    public TimeSeriesBuilder withName(final String name) {
+    public PublicationSeriesBuilder withName(final String name) {
         return cloneAndAmend(builder -> builder.name = name);
     }
 
-    public TimeSeriesBuilder withTitle(final String title) {
+    public PublicationSeriesBuilder withTitle(final String title) {
         return cloneAndAmend(builder -> builder.title = title);
     }
 
-    public TimeSeriesBuilder withPublications(final List<PublicationBuilder> publicationBuilders) {
+    public PublicationSeriesBuilder withPublications(final List<PublicationBuilder> publicationBuilders) {
         return cloneAndAmend(builder -> builder.publicationBuilders = publicationBuilders);
     }
-    public TimeSeriesBuilder withPublications(final PublicationBuilder... publicationBuilders) {
+    public PublicationSeriesBuilder withPublications(final PublicationBuilder... publicationBuilders) {
         return cloneAndAmend(builder -> builder.publicationBuilders = asList(publicationBuilders));
     }
     //</editor-fold>
 
 
-    public TimeSeries build() {
-        return new TimeSeries(this);
+    public PublicationSeries build() {
+        return new PublicationSeries(this);
     }
 
     //<editor-fold desc="GETTERS" defaultstate="collapsed">
@@ -57,24 +57,24 @@ public class TimeSeriesBuilder {
     }
     //</editor-fold>
 
-    private TimeSeriesBuilder() {
+    private PublicationSeriesBuilder() {
     }
 
-    private TimeSeriesBuilder(final TimeSeriesBuilder original) {
+    private PublicationSeriesBuilder(final PublicationSeriesBuilder original) {
         name = original.getName();
         title = original.getTitle();
         publicationBuilders = original.getPublicationBuilders();
     }
 
-    private TimeSeriesBuilder cloneAndAmend(final PropertySetter propertySetter) {
-        final TimeSeriesBuilder clone = new TimeSeriesBuilder(this);
+    private PublicationSeriesBuilder cloneAndAmend(final PropertySetter propertySetter) {
+        final PublicationSeriesBuilder clone = new PublicationSeriesBuilder(this);
         propertySetter.setProperties(clone);
         return clone;
     }
 
     @FunctionalInterface
     interface PropertySetter {
-        void setProperties(TimeSeriesBuilder builder);
+        void setProperties(PublicationSeriesBuilder builder);
     }
 
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/AbstractCmsPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/AbstractCmsPage.java
@@ -12,6 +12,10 @@ public class AbstractCmsPage extends AbstractPage {
         super(webDriverProvider);
     }
 
+    public void openCms() {
+        getWebDriver().get(URL);
+    }
+
     public void logout() {
 
         new Actions(getWebDriver())

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ContentPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ContentPage.java
@@ -141,6 +141,15 @@ public class ContentPage extends AbstractCmsPage {
         waitUntilPublished();
     }
 
+    public void unpublishDocument(final String documentName) {
+        navigateToDocument(documentName);
+
+        findPublicationMenu().click();
+        findTakeOffline().click();
+
+        clickButtonOnModalDialog("OK");
+    }
+
     private void waitUntilPublished() {
 
         // Saving and closing a document leaves one of the following disclaimers. Hitting 'Publish' makes them
@@ -245,6 +254,11 @@ public class ContentPage extends AbstractCmsPage {
     private WebElement findPublish() {
         return helper.findElement(
             By.xpath(XpathSelectors.EDITOR_BODY + "//span[text()='Publish']"));
+    }
+
+    private WebElement findTakeOffline() {
+        return helper.findElement(
+            By.xpath(XpathSelectors.EDITOR_BODY + "//span[text()='Take offline...']"));
     }
 
     private void clickButtonOnModalDialog(String buttonText) {

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/PublicationSeriesPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/PublicationSeriesPage.java
@@ -2,7 +2,7 @@ package uk.nhs.digital.ps.test.acceptance.pages.site.ps;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-import uk.nhs.digital.ps.test.acceptance.models.TimeSeries;
+import uk.nhs.digital.ps.test.acceptance.models.PublicationSeries;
 import uk.nhs.digital.ps.test.acceptance.pages.PageHelper;
 import uk.nhs.digital.ps.test.acceptance.pages.site.AbstractSitePage;
 import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
@@ -22,8 +22,8 @@ public class PublicationSeriesPage extends AbstractSitePage {
         this.pageHelper = pageHelper;
     }
 
-    public void open(final TimeSeries timeSeries) {
-        getWebDriver().get(URL + "/publications/" + timeSeries.getUrlName());
+    public void open(final PublicationSeries publicationSeries) {
+        getWebDriver().get(URL + "/publications/" + publicationSeries.getUrlName());
     }
 
     public void openFirstPublication() {

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/PublicationsOverviewPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/PublicationsOverviewPage.java
@@ -1,0 +1,34 @@
+package uk.nhs.digital.ps.test.acceptance.pages.site.ps;
+
+import org.openqa.selenium.By;
+import uk.nhs.digital.ps.test.acceptance.pages.site.AbstractSitePage;
+import uk.nhs.digital.ps.test.acceptance.pages.widgets.LivePublicationOverviewWidget;
+import uk.nhs.digital.ps.test.acceptance.pages.widgets.UpcomingPublicationOverivewWidget;
+import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+public class PublicationsOverviewPage extends AbstractSitePage {
+
+    public PublicationsOverviewPage(final WebDriverProvider webDriverProvider) {
+        super(webDriverProvider);
+    }
+
+    public List<LivePublicationOverviewWidget> getLatestPublicationsWidgets() {
+        return getWebDriver()
+            .findElements(By.xpath("//*[@data-uipath='ps.overview.latest-publications.publication']"))
+            .stream()
+            .map(LivePublicationOverviewWidget::new)
+            .collect(toList());
+    }
+
+    public List<UpcomingPublicationOverivewWidget> getUpcomingPublicationsWidgets() {
+        return getWebDriver()
+            .findElements(By.xpath("//*[@data-uipath='ps.overview.upcoming-publications.publication']"))
+            .stream()
+            .map(UpcomingPublicationOverivewWidget::new)
+            .collect(toList());
+    }
+}

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/LivePublicationOverviewWidget.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/LivePublicationOverviewWidget.java
@@ -1,0 +1,96 @@
+package uk.nhs.digital.ps.test.acceptance.pages.widgets;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.hamcrest.CustomMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import uk.nhs.digital.ps.test.acceptance.models.Publication;
+
+import static java.text.MessageFormat.format;
+
+public class LivePublicationOverviewWidget {
+
+    private WebElement rootElement;
+
+    public LivePublicationOverviewWidget(final WebElement rootElement) {
+        this.rootElement = rootElement;
+    }
+
+    public String getTitle() {
+        return findElement("title").getText();
+    }
+
+    public String getDate() {
+        return findElement("nominal-publication-date").getText();
+    }
+
+    public String getSummary() {
+        return findElement("summary").getText();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append("title", getTitle())
+            .append("date", getDate())
+            .append("summary", getSummary())
+            .toString();
+    }
+
+    @Factory
+    public static Matcher matchesLivePublication(final Publication publication) {
+
+        final String expectedMessage = format(
+            "entry representing live publication with title={0}, date={1}, summary={2}",
+            publication.getTitle(),
+            publication.getNominalPublicationDate().formattedInRespectToCutOff(),
+            publication.getSummaryTruncated()
+        );
+
+        return new CustomMatcher(expectedMessage) {
+
+            private String actualTitle;
+            private String actualDate;
+            private String actualSummary;
+
+            @Override
+            public boolean matches(final Object item) {
+
+                if (item instanceof LivePublicationOverviewWidget) {
+
+                    final LivePublicationOverviewWidget widget = (LivePublicationOverviewWidget) item;
+
+                    actualTitle = widget.getTitle();
+                    actualDate = widget.getDate();
+                    actualSummary = widget.getSummary();
+
+                    return publication.getTitle().equals(actualTitle)
+                        && publication.getNominalPublicationDate().formattedInRespectToCutOff().equals(actualDate)
+                        && publication.getSummaryTruncated().equals(actualSummary)
+                        ;
+                } else {
+                    return false;
+                }
+            }
+
+            @Override
+            public void describeMismatch(final Object item, final Description description) {
+
+                description.appendText(format("got entry with title={0}, date={1}, summary={2}",
+                    actualTitle,
+                    actualDate,
+                    actualSummary
+                ));
+            }
+        };
+    }
+
+    private WebElement findElement(final String uiPathFieldSuffix) {
+        return rootElement.findElement(
+            By.xpath(".//*[@data-uipath='ps.overview.latest-publications.publication." + uiPathFieldSuffix + "']")
+        );
+    }
+}

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/UpcomingPublicationOverivewWidget.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/UpcomingPublicationOverivewWidget.java
@@ -1,0 +1,85 @@
+package uk.nhs.digital.ps.test.acceptance.pages.widgets;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.hamcrest.CustomMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import uk.nhs.digital.ps.test.acceptance.models.Publication;
+
+import static java.text.MessageFormat.format;
+
+public class UpcomingPublicationOverivewWidget {
+
+    private WebElement webDriver;
+
+    public UpcomingPublicationOverivewWidget(final WebElement rootElement) {
+        this.webDriver = rootElement;
+    }
+
+    public String getTitle() {
+        return findElement("title").getText();
+    }
+
+    public String getDate() {
+        return findElement("nominal-publication-date").getText();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append("title", getTitle())
+            .append("date", getDate())
+            .toString();
+    }
+
+    @Factory
+    public static Matcher matchesUpcomingPublication(final Publication publication) {
+
+        final String expectedMessage = format(
+            "entry representing upcoming publication with title={0}, date={1}",
+            publication.getTitle(),
+            publication.getNominalPublicationDate().formattedInRespectToCutOff()
+        );
+
+        return new CustomMatcher(expectedMessage) {
+
+            private String actualDate;
+            private String actualTitle;
+
+            @Override
+            public boolean matches(final Object item) {
+
+                if (item instanceof UpcomingPublicationOverivewWidget) {
+
+                    final UpcomingPublicationOverivewWidget widget = (UpcomingPublicationOverivewWidget) item;
+
+                    actualTitle = widget.getTitle();
+                    actualDate = widget.getDate();
+
+                    return publication.getTitle().equals(actualTitle)
+                        && publication.getNominalPublicationDate().formattedInRespectToCutOff().equals(actualDate);
+                } else {
+                    return false;
+                }
+            }
+
+            @Override
+            public void describeMismatch(final Object item, final Description description) {
+
+                description.appendText(format("got entry with title={0}, date={1}",
+                    actualTitle,
+                    actualDate
+                ));
+            }
+        };
+    }
+
+    private WebElement findElement(final String uiPathFieldSuffix) {
+        return webDriver.findElement(
+            By.xpath("//*[@data-uipath='ps.overview.upcoming-publications.publication." + uiPathFieldSuffix + "']")
+        );
+    }
+}

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/PublicationSeriesSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/PublicationSeriesSteps.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import uk.nhs.digital.ps.test.acceptance.data.ExpectedTestDataProvider;
 import uk.nhs.digital.ps.test.acceptance.data.TestDataRepo;
 import uk.nhs.digital.ps.test.acceptance.models.Publication;
-import uk.nhs.digital.ps.test.acceptance.models.TimeSeries;
+import uk.nhs.digital.ps.test.acceptance.models.PublicationSeries;
 import uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPage;
 import uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationSeriesPage;
 
@@ -19,9 +19,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.slf4j.LoggerFactory.getLogger;
 
-public class TimeSeriesSteps extends AbstractSpringSteps {
+public class PublicationSeriesSteps extends AbstractSpringSteps {
 
-    private final static Logger log = getLogger(TimeSeriesSteps.class);
+    private final static Logger log = getLogger(PublicationSeriesSteps.class);
 
     @Autowired
     private TestDataRepo testDataRepo;
@@ -32,28 +32,28 @@ public class TimeSeriesSteps extends AbstractSpringSteps {
     @Autowired
     private PublicationSeriesPage consumablePublicationSeriesPage;
 
-    // Scenario: List publications from the same time series ===========================================================
-    @Given("^I have a number of publications belonging to the same time series$")
-    public void iHaveANumberOfPublicationsBelongingToTheSameTimeSeries() throws Throwable {
+    // Scenario: List publications from the same series ===========================================================
+    @Given("^I have a number of publications belonging to the same series$")
+    public void iHaveANumberOfPublicationsBelongingToTheSameSeries() throws Throwable {
 
-        final TimeSeries timeSeries = ExpectedTestDataProvider.getValidTimeSeries().build();
-        testDataRepo.setCurrentTimeSeries(timeSeries);
+        final PublicationSeries publicationSeries = ExpectedTestDataProvider.getValidPublicationSeries().build();
+        testDataRepo.setPublicationSeries(publicationSeries);
     }
 
-    @When("^I navigate to the time series$")
-    public void iNavigateToTheTimeSeries() throws Throwable {
-        consumablePublicationSeriesPage.open(testDataRepo.getCurrentTimeSeries());
+    @When("^I navigate to the publication series$")
+    public void iNavigateToThePublicationSeries() throws Throwable {
+        consumablePublicationSeriesPage.open(testDataRepo.getPublicationSeries());
     }
 
-    @Then("^I can see a list of published publications from the time series$")
-    public void iCanSeeAListOfPublicationsFromTheTimeSeries() throws Throwable {
+    @Then("^I can see a list of published publications from the series$")
+    public void iCanSeeAListOfPublicationsFromTheSeries() throws Throwable {
 
-        final TimeSeries expectedTimeSeries = testDataRepo.getCurrentTimeSeries();
+        final PublicationSeries expectedPublicationSeries = testDataRepo.getPublicationSeries();
 
-        assertThat("Correct publication time series title is displayed.",
-            consumablePublicationSeriesPage.getSeriesTitle(), is(expectedTimeSeries.getTitle()));
+        assertThat("Correct publication series title is displayed.",
+            consumablePublicationSeriesPage.getSeriesTitle(), is(expectedPublicationSeries.getTitle()));
 
-        final List<String> expectedPublicationTitles = expectedTimeSeries.getReleasedPublicationsLatestFirst().stream()
+        final List<String> expectedPublicationTitles = expectedPublicationSeries.getReleasedPublicationsLatestFirst().stream()
             .map(Publication::getTitle)
             .collect(toList());
 
@@ -67,10 +67,10 @@ public class TimeSeriesSteps extends AbstractSpringSteps {
         consumablePublicationSeriesPage.openFirstPublication();
     }
 
-    @Then("^I can see link back to the time series")
+    @Then("^I can see link back to the series")
     public void iCanSeeLinkBack() throws Throwable {
         assertThat("Link to series document .",
-            publicationPage.getSeriesLinkTitle(), is(testDataRepo.getCurrentTimeSeries().getTitle()));
+            publicationPage.getSeriesLinkTitle(), is(testDataRepo.getPublicationSeries().getTitle()));
     }
 
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/ps/PublicationSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/ps/PublicationSteps.java
@@ -1,24 +1,35 @@
 package uk.nhs.digital.ps.test.acceptance.steps.site.ps;
 
+import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.nhs.digital.ps.test.acceptance.config.AcceptanceTestProperties;
+import uk.nhs.digital.ps.test.acceptance.data.ExpectedTestDataProvider;
 import uk.nhs.digital.ps.test.acceptance.data.TestDataRepo;
-import uk.nhs.digital.ps.test.acceptance.models.*;
-import uk.nhs.digital.ps.test.acceptance.pages.widgets.AttachmentWidget;
+import uk.nhs.digital.ps.test.acceptance.models.Attachment;
+import uk.nhs.digital.ps.test.acceptance.models.Publication;
 import uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPage;
-import uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationSeriesPage;
-import uk.nhs.digital.ps.test.acceptance.pages.ContentPage;
+import uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationsOverviewPage;
+import uk.nhs.digital.ps.test.acceptance.pages.widgets.AttachmentWidget;
+import uk.nhs.digital.ps.test.acceptance.pages.widgets.LivePublicationOverviewWidget;
+import uk.nhs.digital.ps.test.acceptance.pages.widgets.UpcomingPublicationOverivewWidget;
 import uk.nhs.digital.ps.test.acceptance.steps.AbstractSpringSteps;
 import uk.nhs.digital.ps.test.acceptance.util.FileHelper;
+
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.slf4j.LoggerFactory.getLogger;
+import static uk.nhs.digital.ps.test.acceptance.data.TestDataRepo.PublicationClassifier.LIVE;
+import static uk.nhs.digital.ps.test.acceptance.data.TestDataRepo.PublicationClassifier.UPCOMING;
+import static uk.nhs.digital.ps.test.acceptance.pages.widgets.LivePublicationOverviewWidget.matchesLivePublication;
+import static uk.nhs.digital.ps.test.acceptance.pages.widgets.UpcomingPublicationOverivewWidget
+    .matchesUpcomingPublication;
 import static uk.nhs.digital.ps.test.acceptance.util.FileHelper.readFileAsByteArray;
 import static uk.nhs.digital.ps.test.acceptance.util.FileHelper.waitUntilFileAppears;
 
@@ -33,13 +44,16 @@ public class PublicationSteps extends AbstractSpringSteps {
     private AcceptanceTestProperties acceptanceTestProperties;
 
     @Autowired
-    private ContentPage contentPage;
-
-    @Autowired
     private PublicationPage publicationPage;
 
     @Autowired
-    private PublicationSeriesPage publicationSeriesPage;
+    private PublicationsOverviewPage publicationsOverviewPage;
+
+    @Given("^Published and upcoming publications are available in the system$")
+    public void publishedAndUpcomingPublicationsAreAvailableInTheSystem() throws Throwable {
+        testDataRepo.addPublications(UPCOMING, ExpectedTestDataProvider.getPublishedUpcomingPublication().build());
+        testDataRepo.addPublications(LIVE, ExpectedTestDataProvider.getRecentPublishedLivePublications().build());
+    }
 
     @Then(("^it is visible to consumers"))
     public void thenItIsVisibleToConsumers() throws Throwable {
@@ -123,5 +137,47 @@ public class PublicationSteps extends AbstractSpringSteps {
         assertThat("Correct size of attachment " + attachment.getFullName() + " is displayed",
             attachmentWidget.getSizeText(),
             is("size: " + FileHelper.toHumanFriendlyFileSize((long) attachment.getContent().length)));
+    }
+
+    @Then("^I can see upcoming publications$")
+    public void iCanSeeUpcomingPublications() throws Throwable {
+
+        final List<Publication> expectedPublications = testDataRepo.getPublications(UPCOMING);
+
+        final List<UpcomingPublicationOverivewWidget> actualPublicationEntries =
+            publicationsOverviewPage.getUpcomingPublicationsWidgets();
+
+        assertThat("Should display correct quantity of upcoming publications.",
+            actualPublicationEntries,
+            hasSize(expectedPublications.size())
+        );
+
+        for (int i = 0; i < expectedPublications.size(); i++) {
+            assertThat("Should display upcoming publication.",
+                actualPublicationEntries.get(i),
+                matchesUpcomingPublication(expectedPublications.get(i))
+            );
+        }
+    }
+
+    @Then("^I can see recent publications$")
+    public void iCanSeeRecentPublications() throws Throwable {
+
+        final List<Publication> expectedPublications = testDataRepo.getPublications(LIVE);
+
+        final List<LivePublicationOverviewWidget> actualPublicationEntries =
+            publicationsOverviewPage.getLatestPublicationsWidgets();
+
+        assertThat("Should display correct quantity of recent live publications.",
+            actualPublicationEntries,
+            hasSize(expectedPublications.size())
+        );
+
+        for (int i = 0; i < expectedPublications.size(); i++) {
+            assertThat("Should display live publication.",
+                actualPublicationEntries.get(i),
+                matchesLivePublication(expectedPublications.get(i))
+            );
+        }
     }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
@@ -18,6 +18,9 @@ public class TestContentUrls {
     private void setup() {
         add("home", "/");
 
+        add ("publications overview",
+            "/publications");
+
         // data sets pages
         add("publication with datasets",
             "/publications/acceptance-tests/publication-with-datasets");

--- a/acceptance-tests/src/test/resources/features/createAndPublish.feature
+++ b/acceptance-tests/src/test/resources/features/createAndPublish.feature
@@ -13,6 +13,7 @@ Feature: As am author I need to create a new publication
         Then it is saved
 
     @NeedsExistingTestData
+    @TakeOfflineAfter
     Scenario: Publishing a publication
         Given I have saved a publication
         When I publish the publication

--- a/acceptance-tests/src/test/resources/features/restrictedPublicationDetailsDisplay.feature
+++ b/acceptance-tests/src/test/resources/features/restrictedPublicationDetailsDisplay.feature
@@ -1,4 +1,4 @@
-Feature: Single publication display details
+Feature: Restricted Publication details display
 
     As a compliance officer
     I need to ensure that only permitted details of individual publication are displayed to the end users
@@ -13,12 +13,14 @@ Feature: Single publication display details
         And Disclaimer "(Upcoming, not yet published)" is displayed
         And All other publication's details are hidden
 
+    @TakeOfflineAfter
     Scenario: Nominal publication date is displayed in full when it falls before 8-week cut off
         Given I have a published publication with nominal date falling before 8 weeks from now
         When I view the publication
-        Then Nominal Publication Date is displayed using format "1 Jan 2000"
+        Then Nominal Publication Date is displayed using format "d MMM yyyy"
 
+    @TakeOfflineAfter
     Scenario: Nominal publication date is displayed in part when it falls after 8-week cut off
         Given I have a published publication with nominal date falling after 8 weeks from now
         When I view the publication
-        Then Nominal Publication Date is displayed using format "Jan 2000"
+        Then Nominal Publication Date is displayed using format "MMM yyyy"

--- a/acceptance-tests/src/test/resources/features/site/publicationsOverview.feature
+++ b/acceptance-tests/src/test/resources/features/site/publicationsOverview.feature
@@ -1,0 +1,12 @@
+Feature: Publications' overview
+
+    As an end user
+    I need to have an overview of available publications
+    So that I can stay up to date with the latest and upcoming publications
+
+
+    Scenario: Upcoming and recent publications are listed in one place
+        Given Published and upcoming publications are available in the system
+        When I navigate to the "publications overview" page
+        Then I can see upcoming publications
+        And I can see recent publications

--- a/acceptance-tests/src/test/resources/features/site/timeSeriesDisplay.feature
+++ b/acceptance-tests/src/test/resources/features/site/timeSeriesDisplay.feature
@@ -1,10 +1,10 @@
-Feature: Display of publications forming a time series
+Feature: Display of publications forming a series
 
     As a content consumer
     I want to be able to see a page which lists the title of all of the available publications in a publication series
     so that I can easily identify related publications.
 
-    Scenario: List publications from the same time series
+    Scenario: List publications from the same series
         Given I navigate to the "valid publication series" page
         Then I can see "Lorem Ipsum Dolor 2014" link
         And I can see "Lorem Ipsum Dolor 2013" link

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/pages/home.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/pages/home.yaml
@@ -1,0 +1,9 @@
+definitions:
+  config:
+    /hst:hst/hst:configurations/publicationsystem/hst:pages/home:
+      jcr:primaryType: hst:component
+      hst:referencecomponent: hst:abstractpages/basepage
+      /main:
+        jcr:primaryType: hst:component
+        hst:template: publications-overview-template
+        hst:componentclassname: uk.nhs.digital.ps.components.PublicationsOverviewComponent

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/sitemap.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/sitemap.yaml
@@ -5,7 +5,6 @@ definitions:
       /root:
         jcr:primaryType: hst:sitemapitem
         hst:componentconfigurationid: hst:pages/home
-        hst:relativecontentpath: homepage
       /_any_:
         jcr:primaryType: hst:sitemapitem
         hst:relativecontentpath: ${1}

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/templates.yaml
@@ -2,6 +2,9 @@ definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:templates:
       jcr:primaryType: hst:templates
+      /publications-overview-template:
+        jcr:primaryType: hst:template
+        hst:renderpath: webfile:/freemarker/publicationsystem/publications-overview.ftl
       /dataset:
         hst:renderpath: webfile:/freemarker/publicationsystem/dataset.ftl
         jcr:primaryType: hst:template

--- a/repository-data/application/src/main/resources/hcm-config/hst/hosts.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/hosts.yaml
@@ -20,6 +20,7 @@ definitions:
             jcr:primaryType: hst:mount
             hst:homepage: root
             hst:mountpoint: /hst:hst/hst:sites/common
+            hst:alias: common-context
             /publications:
               .meta:residual-child-node-category: content
               jcr:primaryType: hst:mount

--- a/repository-data/development/src/main/resources/hcm-config/main.yaml
+++ b/repository-data/development/src/main/resources/hcm-config/main.yaml
@@ -5,4 +5,4 @@ definitions:
         operation: add
         type: string
         value: [repository-data/development]
-      autoexport:enabled: true
+      autoexport:enabled: false

--- a/repository-data/webfiles/src/main/resources/site/css/demo.css
+++ b/repository-data/webfiles/src/main/resources/site/css/demo.css
@@ -59,7 +59,17 @@ body {
     display: inline-block;
 }
 
+.column-half__left {
+    float: left;
+    clear: left;
+    width: 49%;
+}
 
+.column-half__right {
+    float: right;
+    clear: right;
+    width: 49%;
+}
 
 
 /*
@@ -124,8 +134,7 @@ input {
     display: inline;
 }
 
-.pagination li a,
- {
+.pagination li a {
     position: relative;
     float: left;
     padding: 6px 12px;

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/search.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/search.ftl
@@ -1,6 +1,8 @@
 <#include "../include/imports.ftl">
 
-<form class="navbar-form" role="search" action="<@hst.link siteMapItemRefId="search" />" method="get">
+<@hst.link siteMapItemRefId="search" mount="common-context" var="searchLink"/>
+
+<form class="navbar-form" role="search" action="${searchLink}" method="get">
     <div class="input-group">
         <input type="text" id="query" class="search-input" placeholder="Search NHS Digital" name="query" value="${query!""}">
         <input type="submit" class="search-submit" id="btnSearch" value="Search">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publications-overview.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publications-overview.ftl
@@ -1,0 +1,53 @@
+<#-- DECLARATIONS: -->
+<#include "../include/imports.ftl">
+
+<#macro restrictableDate date>
+    <#assign formatRestrictableDate="uk.nhs.digital.ps.directives.RestrictableDateFormatterDirective"?new() />
+    <#if date??>
+        <@formatRestrictableDate value=date/>
+    </#if>
+</#macro>
+
+<#-- @ftlvariable name="publication" type="uk.nhs.digital.ps.beans.Publication" -->
+
+
+<#-- CONTENT: -->
+<div class="column-half__left">
+    <h2>Latest publications</h2>
+    <#if publishedPublications??>
+        <ul>
+            <#list publishedPublications as publication>
+                <@hst.link hippobean=publication var="link"/>
+                <li data-uipath="ps.overview.latest-publications.publication">
+                    <a data-uipath="ps.overview.latest-publications.publication.hyperlink" href="${link}">
+                        <span data-uipath="ps.overview.latest-publications.publication.title">${publication.title}</span>
+                    </a>
+                    <span data-uipath="ps.overview.latest-publications.publication.nominal-publication-date">
+                        <@restrictableDate date=publication.nominalPublicationDate/>
+                    </span>
+                    <p data-uipath="ps.overview.latest-publications.publication.summary">
+                        <@truncate text=publication.summary size=100/>
+                    </p>
+                </li>
+            </#list>
+        </ul>
+    <#else>
+        (None)
+    </#if>
+</div>
+
+<div class="column-half__right">
+    <h2>Upcoming publications</h2>
+    <#if upcomingPublications??>
+        <ul>
+            <#list upcomingPublications as publication>
+                <li data-uipath="ps.overview.upcoming-publications.publication">
+                    <span data-uipath="ps.overview.upcoming-publications.publication.title">${publication.title}</span>
+                    <span data-uipath="ps.overview.upcoming-publications.publication.nominal-publication-date"><@restrictableDate date=publication.nominalPublicationDate/></span>
+                </li>
+            </#list>
+        </ul>
+    <#else>
+        (None)
+    </#if>
+</div>

--- a/site/src/main/java/uk/nhs/digital/ps/beans/BaseDocument.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/BaseDocument.java
@@ -6,11 +6,14 @@ import org.hippoecm.hst.content.beans.standard.HippoDocument;
 
 @Node(jcrType="publicationsystem:basedocument")
 public class BaseDocument extends HippoDocument {
+
     /**
+     * <p>
      * In order to keep the sitemap logic in one place, this function needs to return Hippo Bean which will be used
      * to generate link (url) to this document. In most cases this will be a "this".
      *
-     * For time series this is simply parent folder object but in other cases this can become something more convoluted.
+     * For publication series this is simply parent folder object but in other cases this can become something more
+     * convoluted.
      *
      * @return Object used to render a link to this page
      */

--- a/site/src/main/java/uk/nhs/digital/ps/components/PublicationsOverviewComponent.java
+++ b/site/src/main/java/uk/nhs/digital/ps/components/PublicationsOverviewComponent.java
@@ -1,0 +1,57 @@
+package uk.nhs.digital.ps.components;
+
+import org.hippoecm.hst.component.support.bean.BaseHstComponent;
+import org.hippoecm.hst.content.beans.query.HstQuery;
+import org.hippoecm.hst.content.beans.query.HstQueryResult;
+import org.hippoecm.hst.content.beans.query.builder.HstQueryBuilder;
+import org.hippoecm.hst.content.beans.query.builder.HstQueryBuilder.Order;
+import org.hippoecm.hst.content.beans.query.exceptions.QueryException;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
+import org.hippoecm.hst.content.beans.standard.HippoBeanIterator;
+import org.hippoecm.hst.core.component.HstComponentException;
+import org.hippoecm.hst.core.component.HstRequest;
+import org.hippoecm.hst.core.component.HstResponse;
+import org.hippoecm.hst.core.request.HstRequestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.nhs.digital.ps.beans.Publication;
+
+import static org.hippoecm.hst.content.beans.query.builder.ConstraintBuilder.constraint;
+
+public class PublicationsOverviewComponent extends BaseHstComponent {
+
+    private static final Logger log = LoggerFactory.getLogger(PublicationsOverviewComponent.class);
+
+    private static final int ITEMS_PER_PAGE_COUNT = 10;
+
+    @Override
+    public void doBeforeRender(final HstRequest request, final HstResponse response) throws HstComponentException {
+        super.doBeforeRender(request, response);
+        final HstRequestContext requestContext = request.getRequestContext();
+
+        request.setAttribute("publishedPublications", getPublicationBeans(requestContext, true, Order.DESC));
+        request.setAttribute("upcomingPublications", getPublicationBeans(requestContext, false, Order.ASC));
+    }
+
+    private HippoBeanIterator getPublicationBeans(HstRequestContext requestContext, boolean isLive, final Order order) {
+        try {
+            HippoBean baseFolder = requestContext.getSiteContentBaseBean();
+
+            final HstQuery hstQuery = HstQueryBuilder.create(baseFolder)
+                .ofTypes(Publication.class)
+                .orderBy(order, "publicationsystem:NominalDate")
+                .where(constraint("publicationsystem:PubliclyAccessible").equalTo(isLive))
+                .limit(ITEMS_PER_PAGE_COUNT)
+                .build();
+
+            HstQueryResult hstQueryResult = hstQuery.execute();
+
+            return hstQueryResult.getHippoBeans();
+        } catch (QueryException e) {
+            log.error("Error getting list of published publications", e);
+            return null;
+        }
+    }
+}
+
+

--- a/site/src/main/java/uk/nhs/digital/ps/directives/FileSizeFormatterDirective.java
+++ b/site/src/main/java/uk/nhs/digital/ps/directives/FileSizeFormatterDirective.java
@@ -9,18 +9,19 @@ import java.util.Map;
 import static java.text.MessageFormat.format;
 
 /**
+ * <p>
  * Converts byte count to a human-readable value; for example, value 1536 displays as "1.5 KiB".
- *
- * Required parameter: {@code bytesCount}.
- *
+ * </p><p>
+ * Required template parameter: {@code bytesCount}.
+ * </p><p>
  * Example usage in Freemarker template:
+ * </p>
  * <pre>
  *
  *     <#assign formatFileSize="uk.nhs.digital.ps.directives.FileSizeFormatterDirective"?new() >
- *         ...
- *     &lt;span&gt;size: <@formatFileSize bytesCount=attachment.length/>.&lt;/span&gt;
+ *     ...
+ *     &lt;span&gt;size: <@formatFileSize bytesCount=attachment.length/>&lt;/span&gt;
  * </pre>
- *
  */
 public class FileSizeFormatterDirective implements TemplateDirectiveModel {
 

--- a/site/src/main/java/uk/nhs/digital/ps/directives/RestrictableDateFormatterDirective.java
+++ b/site/src/main/java/uk/nhs/digital/ps/directives/RestrictableDateFormatterDirective.java
@@ -18,8 +18,20 @@ import java.util.Optional;
 
 import static java.text.MessageFormat.format;
 
-/**
+ /**
+ * <p>
  * Formats instances of {@linkplain RestrictableDate} for display.
+ * </p><p>
+ * Required template parameter: {@code value}. Can be {@code null} in which case a zero-length string will be generated.
+ * </p><p>
+ * Example usage in Freemarker template:
+ * </p>
+ * <pre>
+
+ *     <#assign formatRestrictableDate="uk.nhs.digital.ps.directives.RestrictableDateFormatterDirective"?new() />
+ *     ...
+ *     &lt;span&gt;Date: <@formatRestrictableDate value=document.nominalPublicationDate/>&lt;/span&gt;
+ * </pre>
  */
 public class RestrictableDateFormatterDirective implements TemplateDirectiveModel {
 


### PR DESCRIPTION
1:
/publications now displays 'overview' page (effectively, a homepage for
Publications System), listing published publications, separating
'upcoming' from 'live' ones depending on a dedicated boolean flag set
by authors in CMS.

2:
Search box now always submits queries to root '/search'
rather than (sometimes) resolving to '/publications/search' ('action'
attribute in search.ftl).

This is resolved dynamically based on 'common-context' alias to 'root'
mountpoint in 'common' site configuration.

This was following instructions from section
'Create a URL for a siteMapItemRefId' of
https://www.onehippo.org/library/concepts/links-and-urls/hst-2-urls.html