### PR TITLE
[RPS-167] wrong resources file type

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/dataset.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/dataset.ftl
@@ -51,7 +51,6 @@ This data set is part of <a class="label label--parent-document"
     <h3>Resources</h3>
     <#list dataset.files as attachment>
         <li class="attachment">
-            <i class="icon icon--xxx">[pdf]</i>
             <a title="${attachment.filename}" href="<@hst.link hippobean=attachment/>">${attachment.filename}</a>;
             <span class="fileSize">size: <@formatFileSize bytesCount=attachment.length/></span>
         </li>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
@@ -96,7 +96,6 @@
         <ul data-uipath="ps.publication.resources">
             <#list publication.attachments as attachment>
                 <li class="attachment">
-                    <i class="icon icon--xxx">[pdf]</i>
                     <a class="attachment-hyperlink" href="<@hst.link hippobean=attachment/>">${attachment.filename}</a>;
                     <span class="fileSize">size: <@formatFileSize bytesCount=attachment.length/></span>
                 </li>
@@ -104,7 +103,6 @@
 
             <#list publication.relatedLinks as link>
                 <li>
-                    <i class="icon icon--link">[link]</i>
                     <a href="${link.linkUrl}">${link.linkText}</a>
                 </li>
             </#list>
@@ -135,7 +133,7 @@
     This is part of
     <a class="label label--parent-document" href="<@hst.link hippobean=parentSeries.selfLinkBean/>"
         title="${parentSeries.title}">
-    ${parentSeries.title}l
+    ${parentSeries.title}
     </a>
     </#if>
 


### PR DESCRIPTION
Removed the resource type indicators for links and files on the publication and the dataset template. Leaving an indicator for datasets on the publication template to distinguish these from links.

Also removed a trailing 'l' that was getting incorrectly added to the end of the publication title.