### PR TITLE
[RPS-170] Refactor properties to beans

### DIFF
--- a/acceptance-tests/src/test/resources/features/site/publication.feature
+++ b/acceptance-tests/src/test/resources/features/site/publication.feature
@@ -24,3 +24,9 @@ Scenario: Display Related Links list
     Then I should see publication page titled "publication with datasets"
     And I should also see "Publication Related Links" with:
         | Test google.com link  |
+
+Scenario: Display taxonomy list
+    Given I navigate to "publication with datasets" page
+    Then I should see publication page titled "publication with datasets"
+    And I should also see:
+        | Publication Taxonomy | People, patients and geography |

--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -93,8 +93,14 @@
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <forge.content-exim.version>2.0.0</forge.content-exim.version>
         <junit-dataprovider.version>1.13.1</junit-dataprovider.version>
         <hamcrest.version>1.3</hamcrest.version>
+        <powermock.version>1.7.3</powermock.version>
 
         <development-module-deploy-dir>shared/lib</development-module-deploy-dir>
 
@@ -165,9 +166,16 @@
             </dependency>
 
             <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${mockito.version}</version>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-junit4</artifactId>
+                <version>${powermock.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito2</artifactId>
+                <version>${powermock.version}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/repository-data/development/src/main/resources/hcm-config/content/taxonomies/publication_taxonomy.yaml
+++ b/repository-data/development/src/main/resources/hcm-config/content/taxonomies/publication_taxonomy.yaml
@@ -292,14 +292,14 @@ definitions:
             /en:
               jcr:primaryType: hippotaxonomy:categoryinfo
               hippotaxonomy:name: Outcomes and quality indicators
-        /people,-patients-and-georgraphy:
+        /people,-patients-and-geography:
           jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: people,-patients-and-georgraphy
+          hippotaxonomy:key: people,-patients-and-geography
           /hippotaxonomy:categoryinfos:
             jcr:primaryType: hippotaxonomy:categoryinfos
             /en:
               jcr:primaryType: hippotaxonomy:categoryinfo
-              hippotaxonomy:name: People, patients and georgraphy
+              hippotaxonomy:name: People, patients and geography
         /sevices:
           jcr:primaryType: hippotaxonomy:category
           hippotaxonomy:key: sevices
@@ -613,14 +613,14 @@ definitions:
             /en:
               jcr:primaryType: hippotaxonomy:categoryinfo
               hippotaxonomy:name: Outcomes and quality indicators
-        /people,-patients-and-georgraphy:
+        /people,-patients-and-geography:
           jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: people,-patients-and-georgraphy
+          hippotaxonomy:key: people,-patients-and-geography
           /hippotaxonomy:categoryinfos:
             jcr:primaryType: hippotaxonomy:categoryinfos
             /en:
               jcr:primaryType: hippotaxonomy:categoryinfo
-              hippotaxonomy:name: People, patients and georgraphy
+              hippotaxonomy:name: People, patients and geography
         /sevices:
           jcr:primaryType: hippotaxonomy:category
           hippotaxonomy:key: sevices
@@ -934,14 +934,14 @@ definitions:
             /en:
               jcr:primaryType: hippotaxonomy:categoryinfo
               hippotaxonomy:name: Outcomes and quality indicators
-        /people,-patients-and-georgraphy:
+        /people,-patients-and-geography:
           jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: people,-patients-and-georgraphy
+          hippotaxonomy:key: people,-patients-and-geography
           /hippotaxonomy:categoryinfos:
             jcr:primaryType: hippotaxonomy:categoryinfos
             /en:
               jcr:primaryType: hippotaxonomy:categoryinfo
-              hippotaxonomy:name: People, patients and georgraphy
+              hippotaxonomy:name: People, patients and geography
         /sevices:
           jcr:primaryType: hippotaxonomy:category
           hippotaxonomy:key: sevices

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/content.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/content.yaml
@@ -12,6 +12,7 @@
     hippostdpubwf:creationDate: 2017-11-03T13:35:36.812Z
     hippostdpubwf:lastModificationDate: 2017-11-03T13:35:36.813Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys: ['people,-patients-and-geography']
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
     publicationsystem:AdministrativeSources: ''
@@ -64,6 +65,7 @@
     hippostdpubwf:creationDate: 2017-11-03T13:35:36.812Z
     hippostdpubwf:lastModificationDate: 2017-11-03T13:37:39.777Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys: ['people,-patients-and-geography']
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
     publicationsystem:AdministrativeSources: ''
@@ -116,6 +118,7 @@
     hippostdpubwf:creationDate: 2017-11-03T13:35:36.812Z
     hippostdpubwf:lastModificationDate: 2017-11-03T13:37:39.777Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys: ['people,-patients-and-geography']
     hippostdpubwf:publicationDate: 2017-11-03T13:41:09.207Z
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/dataset.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/dataset.ftl
@@ -8,9 +8,9 @@
     <h2 class="doc-title" data-uipath="ps.dataset.title">${dataset.title}</h2>
 
     This dataset is part of <a class="label label--parent-document"
-        href="<@hst.link hippobean=parentPublication.selfLinkBean/>"
-        title="${parentPublication.title}"
-    >${parentPublication.title}</a>
+        href="<@hst.link hippobean=dataset.parentPublication.selfLinkBean/>"
+        title="${dataset.parentPublication.title}"
+    >${dataset.parentPublication.title}</a>
 
     <dl class="doc-metadata">
         <dt>Date Range</dt>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
@@ -42,11 +42,11 @@
 
         <h2 class="doc-title" data-uipath="ps.publication.title">${publication.title?html}</h2>
 
-        <#if parentSeries??>
+        <#if publication.parentSeries??>
         This is part of
-        <a class="label label--parent-document" href="<@hst.link hippobean=parentSeries.selfLinkBean/>"
-            title="${parentSeries.title}">
-        ${parentSeries.title}
+        <a class="label label--parent-document" href="<@hst.link hippobean=publication.parentSeries.selfLinkBean/>"
+            title="${publication.parentSeries.title}">
+        ${publication.parentSeries.title}
         </a>
         </#if>
 
@@ -83,10 +83,10 @@
                 </#if>
             </dd>
 
-            <#if taxonomyList??>
+            <#if publication.taxonomyList??>
                 <dt>Taxonomy</dt>
                 <dd data-uipath="ps.publication.taxonomy">
-                    <#list taxonomyList as taxonomyChain>
+                    <#list publication.taxonomyList as taxonomyChain>
                         <div>${taxonomyChain?join(" => ")}</div>
                     </#list>
                 </dd>
@@ -119,7 +119,7 @@
                 </li>
             </#list>
 
-            <#list datasets as dataset>
+            <#list publication.datasets as dataset>
                 <li class="dataset">
                     <a href="<@hst.link hippobean=dataset.selfLinkBean/>" title="${dataset.title}">${dataset.title}</a>
                 </li>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -109,8 +109,14 @@
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/site/src/main/java/uk/nhs/digital/ps/beans/Dataset.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/Dataset.java
@@ -1,5 +1,6 @@
 package uk.nhs.digital.ps.beans;
 
+import org.hippoecm.hst.content.beans.standard.HippoFolder;
 import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
 import org.hippoecm.hst.content.beans.Node;
 import java.util.Calendar;
@@ -63,5 +64,22 @@ public class Dataset extends BaseDocument {
     @HippoEssentialsGenerated(internalName = "publicationsystem:CoverageEnd")
     public Calendar getCoverageEnd() {
         return getProperty("publicationsystem:CoverageEnd");
+    }
+
+    public Publication getParentPublication() {
+        Publication publicationBean = null;
+
+        HippoFolder folder = (HippoFolder) getParentBean();
+        while (!HippoBeanHelper.isRootFolder(folder)) {
+            publicationBean = Publication.getPublicationInFolder(folder);
+
+            if (publicationBean != null) {
+                break;
+            } else {
+                folder = (HippoFolder) folder.getParentBean();
+            }
+        }
+
+        return publicationBean;
     }
 }

--- a/site/src/main/java/uk/nhs/digital/ps/beans/HippoBeanHelper.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/HippoBeanHelper.java
@@ -1,0 +1,16 @@
+package uk.nhs.digital.ps.beans;
+
+import org.hippoecm.hst.container.RequestContextProvider;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
+
+/**
+ * Static helper for {@linkplain org.hippoecm.hst.content.beans.standard.HippoBean}
+ */
+public class HippoBeanHelper {
+
+    public static boolean isRootFolder(HippoBean folder) {
+        HippoBean siteContentBaseBean = RequestContextProvider.get().getSiteContentBaseBean();
+
+        return folder.isSelf(siteContentBaseBean);
+    }
+}

--- a/site/src/main/java/uk/nhs/digital/ps/components/DatasetComponent.java
+++ b/site/src/main/java/uk/nhs/digital/ps/components/DatasetComponent.java
@@ -9,6 +9,7 @@ import org.hippoecm.hst.core.request.HstRequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.nhs.digital.ps.beans.Dataset;
+import uk.nhs.digital.ps.beans.HippoBeanHelper;
 import uk.nhs.digital.ps.beans.Publication;
 
 import java.io.IOException;
@@ -22,7 +23,7 @@ public class DatasetComponent extends BaseHstComponent {
         super.doBeforeRender(request, response);
         final HstRequestContext ctx = request.getRequestContext();
         Dataset dataset = (Dataset) ctx.getContentBean();
-        Publication publication = getParentPublication(ctx, dataset);
+        Publication publication = dataset.getParentPublication();
 
         if (!publication.isPubliclyAccessible()) {
             try {
@@ -35,31 +36,9 @@ public class DatasetComponent extends BaseHstComponent {
         }
 
         request.setAttribute("dataset", dataset);
-        request.setAttribute("parentPublication", publication);
 
         if (publication == null) {
             log.warn("Cannot find parent publication for Dataset document {}", dataset.getPath());
         }
-    }
-
-    private Publication getParentPublication(HstRequestContext ctx, Dataset dataset) {
-        Publication publicationBean = null;
-
-        HippoFolder folder = (HippoFolder) dataset.getParentBean();
-        while (!isRootFolder(folder, ctx)) {
-            publicationBean = Publication.getPublicationInFolder(folder);
-
-            if (publicationBean != null) {
-                break;
-            } else {
-                folder = (HippoFolder) folder.getParentBean();
-            }
-        }
-
-        return publicationBean;
-    }
-
-    private boolean isRootFolder(HippoFolder folder, HstRequestContext ctx) {
-        return folder.isSelf(ctx.getSiteContentBaseBean());
     }
 }

--- a/site/src/test/java/uk/nhs/digital/ps/beans/PublicationTest.java
+++ b/site/src/test/java/uk/nhs/digital/ps/beans/PublicationTest.java
@@ -3,11 +3,24 @@ package uk.nhs.digital.ps.beans;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.hippoecm.hst.container.RequestContextProvider;
+import org.hippoecm.hst.content.beans.manager.ObjectConverter;
+import org.hippoecm.hst.content.beans.query.HstQuery;
+import org.hippoecm.hst.content.beans.query.HstQueryResult;
+import org.hippoecm.hst.content.beans.query.builder.HstQueryBuilder;
+import org.hippoecm.hst.content.beans.standard.HippoFolder;
+import org.hippoecm.hst.core.request.HstRequestContext;
+import org.hippoecm.hst.mock.core.request.MockHstRequestContext;
 import org.hippoecm.hst.provider.jcr.JCRValueProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 import uk.nhs.digital.ps.site.exceptions.DataRestrictionViolationException;
 import uk.nhs.digital.ps.test.util.ReflectionHelper;
 
@@ -18,10 +31,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
@@ -29,12 +39,17 @@ import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static uk.nhs.digital.ps.beans.RestrictableDateTest.assertRestrictableDate;
 
 
-@RunWith(DataProviderRunner.class)
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore("javax.management.*")
+@PowerMockRunnerDelegate(DataProviderRunner.class)
+@PrepareForTest(HstQueryBuilder.class)
 public class PublicationTest {
 
     private static final String NOMINAL_DATE_PROPERTY_KEY = "publicationsystem:NominalDate";
@@ -46,6 +61,14 @@ public class PublicationTest {
     @Mock private JCRValueProvider valueProvider;
     @Mock private Node node;
     @Mock private NodeIterator nodeIterator;
+    @Mock private ObjectConverter objectConverter;
+    @Mock private Node folderNode;
+    @Mock private HippoFolder folder;
+
+    @Mock private HstRequestContext requestContext;
+    @Mock private HstQueryBuilder queryBuilder;
+    @Mock private HstQuery query;
+    @Mock private HstQueryResult queryResult;
 
     private final Map<String, Object> beanProperties = new HashMap<>();
     private Publication publication;
@@ -64,15 +87,32 @@ public class PublicationTest {
         publication = new Publication();
 
         given(valueProvider.getProperties()).willReturn(beanProperties);
+        given(valueProvider.getParentJcrNode()).willReturn(folderNode);
 
         given(nodeIterator.hasNext()).willReturn(false);
         given(node.getNodes(ATTACHMENTS_PROPERTY_KEY)).willReturn(nodeIterator);
         given(node.getNodes(RELATED_LINKS_PROPERTY_KEY)).willReturn(nodeIterator);
         given(node.getNodes(RESOURCE_LINKS_PROPERTY_KEY)).willReturn(nodeIterator);
 
+        given(objectConverter.getObject(folderNode)).willReturn(folder);
+        given(folderNode.getNodes()).willReturn(nodeIterator);
+        given(folder.isSelf(any())).willReturn(true); // make it look like the folder is the root folder
+
+        // Mock this static method so we can simulate the building and execution of a query
+        PowerMockito.mockStatic(HstQueryBuilder.class);
+        PowerMockito.when(HstQueryBuilder.create(folder)).thenReturn(queryBuilder);
+
+        given(queryBuilder.ofTypes(any(Class.class))).willReturn(queryBuilder);
+        given(queryBuilder.orderByDescending(anyString())).willReturn(queryBuilder);
+        given(queryBuilder.build()).willReturn(query);
+        given(query.execute()).willReturn(queryResult);
+
+        ReflectionHelper.callMethod(RequestContextProvider.class, "set", HstRequestContext.class, requestContext);
+
         ReflectionHelper.setField(publication, "name", "arbitrary-name");
         ReflectionHelper.setField(publication, "valueProvider", valueProvider);
         ReflectionHelper.setField(publication, "node", node);
+        ReflectionHelper.setField(publication, "objectConverter", objectConverter);
     }
 
     // NOTE: usually, with tests involving time, obtaining 'now' value would be facilitated via custom time provider
@@ -161,17 +201,35 @@ public class PublicationTest {
         // given
         setBeanProperty(PUBLICLY_ACCESSIBLE_PROPERTY_KEY, true);
 
+        // some getters have arguments so we need to construct mocked instances and pass them in as parameters
+        Object[] args = Arrays.stream(permittedGetter.getParameterTypes())
+            .map(PublicationTest::newInstanceForClass)
+            .toArray();
+
         try {
             // when
-            permittedGetter.invoke(publication);
+            permittedGetter.invoke(publication, args);
 
             // then
             // pass
         } catch (final Throwable e) {
+            e.printStackTrace(); // helps with debugging
             throw new AssertionError(
                 "No exception was expected to be thrown from '" + permittedGetter + "' but one was emitted;" +
                     " see stack trace below for details.", e
             );
+        }
+    }
+
+    /**
+     * Create an instance of a class that we can pass as a parameter in our calls to the getters
+     * Currently only implemented for HstRequestContext
+     */
+    private static <R> R newInstanceForClass(Class<R> cls) {
+        if (cls.equals(HstRequestContext.class)) {
+            return (R) new MockHstRequestContext();
+        } else {
+            throw new RuntimeException("Don't know how to construct class " + cls);
         }
     }
 

--- a/site/src/test/java/uk/nhs/digital/ps/test/util/ReflectionHelper.java
+++ b/site/src/test/java/uk/nhs/digital/ps/test/util/ReflectionHelper.java
@@ -3,6 +3,7 @@ package uk.nhs.digital.ps.test.util;
 import org.springframework.util.ReflectionUtils;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
 public class ReflectionHelper {
 
@@ -20,5 +21,11 @@ public class ReflectionHelper {
         } catch (final IllegalAccessException e) {
             throw new RuntimeException("Failed to assign value " + targetValue + " to field " + field);
         }
+    }
+
+    public static <T> void callMethod(Class<T> targetClass, String methodName, Class<?> argType, Object arg) throws Exception {
+        Method method = targetClass.getDeclaredMethod(methodName, argType);
+        method.setAccessible(true);
+        method.invoke(null, arg);
     }
 }


### PR DESCRIPTION
Moved a number of get methods from DatasetComponent and PublicationComponent to the relevant bean.
This is more object oriented and I've changed the freemarker templates to look at the property directly rather than inserting as a separate variable.
Also added PowerMockito to the project as I needed to mock a static method to simulate queries.