### PR TITLE
[RPS-181] Remove attachment body from search scope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ branches:
   only:
     - master
 
+# tmp fix for travis error
+sudo: required
+
 addons:
   chrome: stable
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ init: .git/.local-hooks-installed
 
 ## Clean, build and start local hippo (no autoexport)
 serve:
-	MAVEN_OPTS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1" mvn clean verify -pl site,cms -am --offline -DskipTests=true
+	MAVEN_OPTS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1" mvn clean verify -pl site,cms,repository-data/development -am --offline -DskipTests=true
 	MAVEN_OPTS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1" mvn -P cargo.run,without-autoexport
 
 ## Run all tests

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ init: .git/.local-hooks-installed
 
 ## Clean, build and start local hippo (no autoexport)
 serve:
-	mvn clean verify
-	mvn -P cargo.run,without-autoexport
+	MAVEN_OPTS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1" mvn clean verify -pl site,cms -am --offline -DskipTests=true
+	MAVEN_OPTS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1" mvn -P cargo.run,without-autoexport
 
 ## Run all tests
 test:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -52,7 +52,7 @@ phases:
       # Upload tgz files to various destinations
       - ssh-agent bash -c "
         ssh-add $HOME/.ssh/nhs-ci_rsa &&
-        cd ci-cd && make ondemand.upload"
+        cd ci-cd && make ondemand.upload upload"
       # Deploy to Test Environment
       - . $HOME/rd.password && cd ci-cd && make ondemand.deploy ENV=test
       # Push tag back to github

--- a/ci-cd/bin/set-commit-status
+++ b/ci-cd/bin/set-commit-status
@@ -13,8 +13,7 @@ function set_status {
     local target_url=${2-target}
     local description=${3-$state}
     local context="${4-continuous-integration/codebuild}"
-
-    local git_hash=${CODEBUILD_RESOLVED_SOURCE_VERSION:-$CODEBUILD_SOURCE_VERSION}
+    local git_hash=""
     local payload="{
   \"state\": \"${state}\",
   \"target_url\": \"${target_url}\",
@@ -22,6 +21,7 @@ function set_status {
   \"context\": \"${context}\"
 }"
 
+    git_hash=$(git rev-parse HEAD)
     curl "https://api.github.com/repos/NHS-digital-website/ps-hippo/statuses/${git_hash}?access_token=${GITHUB_TOKEN}" \
         -H "Content-Type: application/json" \
         -X POST \

--- a/cms/src/main/java/uk/nhs/digital/ps/AttachmentTextEraserDerivedDataFunction.java
+++ b/cms/src/main/java/uk/nhs/digital/ps/AttachmentTextEraserDerivedDataFunction.java
@@ -1,0 +1,22 @@
+package uk.nhs.digital.ps;
+
+import org.hippoecm.repository.ext.DerivedDataFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import javax.jcr.Value;
+import java.util.Map;
+
+public class AttachmentTextEraserDerivedDataFunction extends DerivedDataFunction {
+
+    private static final long serialVersionUID = 1;
+
+    private static Logger log = LoggerFactory.getLogger(AttachmentTextEraserDerivedDataFunction.class);
+
+    @Override
+    public Map<String, Value[]> compute(Map<String, Value[]> parameters) {
+        // erase any searchable content from "resource"
+        parameters.put("text", new Value[] { getValueFactory().createValue("") });
+
+        return parameters;
+    }
+}

--- a/cms/src/main/java/uk/nhs/digital/ps/BlankAttachmentFieldValidator.java
+++ b/cms/src/main/java/uk/nhs/digital/ps/BlankAttachmentFieldValidator.java
@@ -17,7 +17,7 @@ import static java.text.MessageFormat.format;
 
 public class BlankAttachmentFieldValidator extends AbstractCmsValidator {
 
-    private static final String HIPPO_RESOURCE_FIELD_TYPE_NAME = "hippo:resource";
+    private static final String HIPPO_RESOURCE_FIELD_TYPE_NAME = "publicationsystem:resource";
     private static final String HIPPO_FILENAME_PROPERTY_NAME = "hippo:filename";
     private static final String DEFAULT_ATTACHMENT_NAME_WHEN_NO_FILE_UPLOADED = HIPPO_RESOURCE_FIELD_TYPE_NAME;
 

--- a/cms/src/main/java/uk/nhs/digital/ps/frontend/editor/plugins/resource/ResourceUploadPlugin.java
+++ b/cms/src/main/java/uk/nhs/digital/ps/frontend/editor/plugins/resource/ResourceUploadPlugin.java
@@ -1,0 +1,91 @@
+package uk.nhs.digital.ps.frontend.editor.plugins.resource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import org.apache.jackrabbit.JcrConstants;
+import org.apache.wicket.markup.html.form.upload.FileUpload;
+import org.hippoecm.frontend.behaviors.EventStoppingBehavior;
+import org.hippoecm.frontend.editor.plugins.resource.MimeTypeHelper;
+import org.hippoecm.frontend.editor.plugins.resource.ResourceHelper;
+import org.hippoecm.frontend.model.JcrNodeModel;
+import org.hippoecm.frontend.plugin.IPluginContext;
+import org.hippoecm.frontend.plugin.config.IPluginConfig;
+import org.hippoecm.frontend.plugins.jquery.upload.FileUploadViolationException;
+import org.hippoecm.frontend.plugins.jquery.upload.single.FileUploadPanel;
+import org.hippoecm.frontend.plugins.yui.upload.validation.DefaultUploadValidationService;
+import org.hippoecm.frontend.plugins.yui.upload.validation.FileUploadValidationService;
+import org.hippoecm.frontend.service.IEditor;
+import org.hippoecm.frontend.service.render.RenderPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hippoecm.repository.api.HippoNodeType.HIPPO_TEXT;
+
+/**
+ * Plugin for uploading resources into the JCR repository.
+ * This plugin can be configured with specific types, so not all file types are allowed to be uploaded.
+ */
+public class ResourceUploadPlugin extends RenderPlugin {
+
+    static final Logger log = LoggerFactory.getLogger(ResourceUploadPlugin.class);
+    public static final String DEFAULT_ASSET_VALIDATION_SERVICE_ID = "service.gallery.asset.validation";
+
+    private final IEditor.Mode mode;
+
+    public ResourceUploadPlugin(IPluginContext context, IPluginConfig config) {
+        super(context, config);
+        log.warn(" - - - - - - CONFIG :");
+        log.warn(config.keySet().toString());
+        mode = IEditor.Mode.fromString(config.getString("mode"), IEditor.Mode.EDIT);
+        add(createFileUploadPanel());
+        add(new EventStoppingBehavior("onclick"));
+    }
+
+    private FileUploadPanel createFileUploadPanel() {
+        final FileUploadPanel panel = new FileUploadPanel("fileUpload", getPluginConfig(), getValidationService()) {
+            @Override
+            public void onFileUpload ( final FileUpload fileUpload) throws FileUploadViolationException {
+                handleUpload(fileUpload);
+            }
+        };
+        panel.setVisible(mode == IEditor.Mode.EDIT);
+        return panel;
+    }
+
+    private FileUploadValidationService getValidationService() {
+        return DefaultUploadValidationService.getValidationService(getPluginContext(), getPluginConfig(),
+            DEFAULT_ASSET_VALIDATION_SERVICE_ID);
+    }
+
+    /**
+     * Handles the file upload from the form.
+     *
+     * @param upload the {@link FileUpload} containing the upload information
+     */
+    private void handleUpload(FileUpload upload) throws FileUploadViolationException {
+        String fileName = upload.getClientFileName();
+        String mimeType = upload.getContentType();
+
+        JcrNodeModel nodeModel = (JcrNodeModel) ResourceUploadPlugin.this.getDefaultModel();
+        Node node = nodeModel.getNode();
+        try {
+            ResourceHelper.setDefaultResourceProperties(node, mimeType, upload.getInputStream(), fileName);
+            if (MimeTypeHelper.isPdfMimeType(mimeType)) {
+                InputStream inputStream = node.getProperty(JcrConstants.JCR_DATA).getBinary().getStream();
+                ResourceHelper.handlePdfAndSetHippoTextProperty(node, inputStream);
+            } else if (node.hasProperty(HIPPO_TEXT)) {
+                node.getProperty(HIPPO_TEXT).remove();
+            }
+        } catch (RepositoryException | IOException ex) {
+            if (log.isDebugEnabled()) {
+                log.error("Cannot upload resource", ex);
+            } else {
+                log.error("Cannot upload resource: {}", ex.getMessage());
+            }
+            throw new FileUploadViolationException(ex.getMessage());
+        }
+    }
+
+}

--- a/cms/src/test/java/uk/nhs/digital/ps/BlankAttachmentFieldValidatorTest.java
+++ b/cms/src/test/java/uk/nhs/digital/ps/BlankAttachmentFieldValidatorTest.java
@@ -36,7 +36,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 public class BlankAttachmentFieldValidatorTest {
 
-    private static final String HIPPO_RESOURCE_FIELD_TYPE_NAME = "hippo:resource";
+    private static final String HIPPO_RESOURCE_FIELD_TYPE_NAME = "publicationsystem:resource";
     private static final String HIPPO_FILENAME_PROPERTY_NAME = "hippo:filename";
     private static final String DEFAULT_ATTACHMENT_NAME_WHEN_NO_FILE_UPLOADED = HIPPO_RESOURCE_FIELD_TYPE_NAME;
 

--- a/repository-data/application/src/main/resources/hcm-config/configuration/derived.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/derived.yaml
@@ -1,0 +1,17 @@
+definitions:
+  config:
+    /hippo:configuration/hippo:derivatives/attachment-text-erase:
+      jcr:primaryType: hipposys:deriveddefinition
+      hipposys:classname: uk.nhs.digital.ps.AttachmentTextEraserDerivedDataFunction
+      hipposys:nodetype: publicationsystem:resource
+      hipposys:serialver: 1
+      /hipposys:accessed:
+        jcr:primaryType: hipposys:propertyreferences
+        /text:
+          jcr:primaryType: hipposys:relativepropertyreference
+          hipposys:relPath: hippo:text
+      /hipposys:derived:
+        jcr:primaryType: hipposys:propertyreferences
+        /text:
+          jcr:primaryType: hipposys:relativepropertyreference
+          hipposys:relPath: hippo:text

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/EximExport.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/EximExport.yaml
@@ -9,7 +9,7 @@ definitions:
       hipposys:dryrun: false
       hipposys:parameters: "{\r\n  \"fileInJson\": true,\r\n  \"targetBaseFolderPath\"\
         : \"file:${java.io.tmpdir}/exim-export/\"\r\n}"
-      hipposys:query: ''
+      hipposys:path: /
       hipposys:script:
         type: string
         resource: /configuration/update/EximExport.groovy

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem.cnd
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem.cnd
@@ -18,3 +18,8 @@
 
 [publicationsystem:series] > hippostd:relaxed, hippotranslation:translated, publicationsystem:basedocument
   orderable
+
+[publicationsystem:resourcenonsearchable] > nt:base
+- publicationsystem:resourcetext (binary)
+
+[publicationsystem:resource] > hippo:resource, publicationsystem:resourcenonsearchable, hippo:derived

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/dataset.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/dataset.yaml
@@ -81,7 +81,7 @@ definitions:
             hipposysedit:ordered: false
             hipposysedit:path: publicationsystem:Files
             hipposysedit:primary: false
-            hipposysedit:type: hippo:resource
+            hipposysedit:type: publicationsystem:resource
           /CoverageStart:
             jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
@@ -310,6 +310,7 @@ definitions:
             plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
             wicket.css: [attachments]
             wicket.id: ${cluster.id}.left.item
+            searchable: false
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
           /ResourceLinks:

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
@@ -115,7 +115,7 @@ definitions:
             hipposysedit:ordered: false
             hipposysedit:path: publicationsystem:attachments
             hipposysedit:primary: false
-            hipposysedit:type: hippo:resource
+            hipposysedit:type: publicationsystem:resource
             hipposysedit:validators: [publicationsystem-blank-attachment]
           /publicly_accessible:
             jcr:primaryType: hipposysedit:field

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/resource.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/resource.yaml
@@ -58,7 +58,7 @@ definitions:
             wicket.id: ${cluster.id}.field
           /upload:
             jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.resource.ResourceUploadPlugin
+            plugin.class: uk.nhs.digital.ps.frontend.editor.plugins.resource.ResourceUploadPlugin
             validator.id: service.gallery.asset.validation
             wicket.id: ${cluster.id}.field
       /hipposysedit:prototypes:

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/resource.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/resource.yaml
@@ -1,0 +1,74 @@
+---
+
+definitions:
+  config:
+    /hippo:namespaces/publicationsystem/resource:
+      jcr:primaryType: hipposysedit:templatetype
+      jcr:mixinTypes: ['editor:editable', 'mix:referenceable']
+      /hipposysedit:nodetype:
+        jcr:primaryType: hippo:handle
+        jcr:mixinTypes: ['mix:referenceable']
+        /hipposysedit:nodetype:
+          jcr:primaryType: hipposysedit:nodetype
+          jcr:mixinTypes: ['hipposysedit:remodel']
+          hipposysedit:uri: http://www.onehippo.org/jcr/hippo/nt/2.0
+          /data:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: true
+            hipposysedit:path: jcr:data
+            hipposysedit:primary: true
+            hipposysedit:type: Binary
+          /lastmodified:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: true
+            hipposysedit:path: jcr:lastModified
+            hipposysedit:type: Date
+          /mimetype:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: true
+            hipposysedit:path: jcr:mimeType
+            hipposysedit:type: String
+          /filename:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:mandatory: false
+            hipposysedit:path: hippo:filename
+            hipposysedit:type: String
+          /encoding:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:path: jcr:encoding
+            hipposysedit:type: String
+          /text:
+            jcr:primaryType: hipposysedit:field
+            hipposysedit:path: hippo:text
+            hipposysedit:type: Binary
+      /editor:templates:
+        jcr:primaryType: editor:templateset
+        /_default_:
+          jcr:primaryType: frontend:plugincluster
+          frontend:properties: [mode]
+          frontend:references: [wicket.model, model.compareTo]
+          frontend:services: [wicket.id]
+          /root:
+            jcr:primaryType: frontend:plugin
+            item: ${cluster.id}.field
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+          /display:
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.resource.ImageDisplayPlugin
+            wicket.id: ${cluster.id}.field
+          /upload:
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.resource.ResourceUploadPlugin
+            validator.id: service.gallery.asset.validation
+            wicket.id: ${cluster.id}.field
+      /hipposysedit:prototypes:
+        jcr:primaryType: hipposysedit:prototypeset
+        /hipposysedit:prototype:
+          jcr:primaryType: publicationsystem:resource
+          hippo:filename: hippo:resource
+          jcr:data:
+            type: binary
+            resource: data.bin
+          jcr:encoding: UTF-8
+          jcr:lastModified: 2008-03-26T12:03:00+01:00
+          jcr:mimeType: application/vnd.hippo.blank

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/content.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/content.yaml
@@ -40,7 +40,7 @@
       publicationsystem:linkText: Test google.com link
       publicationsystem:linkUrl: http://google.com
     /publicationsystem:attachments:
-      jcr:primaryType: hippo:resource
+      jcr:primaryType: publicationsystem:resource
       hippo:filename: attachment.pdf
       hippo:text:
         type: binary
@@ -92,7 +92,7 @@
       publicationsystem:linkText: Test google.com link
       publicationsystem:linkUrl: http://google.com
     /publicationsystem:attachments:
-      jcr:primaryType: hippo:resource
+      jcr:primaryType: publicationsystem:resource
       hippo:filename: attachment.pdf
       hippo:text:
         type: binary
@@ -145,7 +145,7 @@
       publicationsystem:linkText: Test google.com link
       publicationsystem:linkUrl: http://google.com
     /publicationsystem:attachments:
-      jcr:primaryType: hippo:resource
+      jcr:primaryType: publicationsystem:resource
       hippo:filename: attachment.pdf
       hippo:text:
         type: binary

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/datasets-subfolder/publication-with-datasets-dataset.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/datasets-subfolder/publication-with-datasets-dataset.yaml
@@ -30,7 +30,7 @@
     publicationsystem:Title: publication-with-datasets Dataset
     publicationsystem:PubliclyAccessible: true
     /publicationsystem:Files:
-      jcr:primaryType: hippo:resource
+      jcr:primaryType: publicationsystem:resource
       hippo:filename: attachment.pdf
       hippo:text:
         type: binary
@@ -67,7 +67,7 @@
     publicationsystem:Title: publication-with-datasets Dataset
     publicationsystem:PubliclyAccessible: true
     /publicationsystem:Files:
-      jcr:primaryType: hippo:resource
+      jcr:primaryType: publicationsystem:resource
       hippo:filename: attachment.pdf
       hippo:text:
         type: binary
@@ -105,7 +105,7 @@
     publicationsystem:Title: publication-with-datasets Dataset
     publicationsystem:PubliclyAccessible: true
     /publicationsystem:Files:
-      jcr:primaryType: hippo:resource
+      jcr:primaryType: publicationsystem:resource
       hippo:filename: attachment.pdf
       hippo:text:
         type: binary


### PR DESCRIPTION
This is a test approach, that uses derived content mechanism to
overwrite "hippo:text" property with empty string which makes given
resource non-searchable.

NOTE: Attachment file name is still searchable.