### PR TITLE
[RPS-173] Added a script to format yaml files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,13 @@ help:
 ## Initialise local project
 init: .git/.local-hooks-installed
 
-## Clean, build and start local hippo (no autoexport)
+## Clean, build and start local hippo
 serve:
+	mvn clean verify
+	mvn -P cargo.run
+
+## Serve without allowing auto-export
+serve.noexport:
 	mvn clean verify
 	mvn -P cargo.run,without-autoexport
 
@@ -29,6 +34,11 @@ test.site-running:
 
 test.%:
 	$(MAKE) -C ci-cd/ $@
+
+## Format YAML files, run after exporting to reduce changes
+format-yaml:
+	mvn groovy:execute -Dsource=repository-data/development/src/main/script/YamlFormatter.groovy -pl repository-data/development
+
 
 # install hooks and local git config
 .git/.local-hooks-installed:

--- a/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms-validators.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms-validators.yaml
@@ -1,28 +1,24 @@
+---
 definitions:
   config:
-    /hippo:configuration/hippo:frontend/cms/cms-validators/publicationsystem-title:
+    /hippo:configuration/hippo:frontend/cms/cms-validators/publicationsystem-blank-attachment:
       jcr:primaryType: frontend:plugin
-      max_length: 250
-      plugin.class: uk.nhs.digital.ps.TextLengthValidator
-
+      plugin.class: uk.nhs.digital.ps.BlankAttachmentFieldValidator
+    /hippo:configuration/hippo:frontend/cms/cms-validators/publicationsystem-blank-granularity:
+      fieldDisplayName: Granularity
+      jcr:primaryType: frontend:plugin
+      plugin.class: uk.nhs.digital.ps.BlankStaticDropdownSelectionFieldValidator
+    /hippo:configuration/hippo:frontend/cms/cms-validators/publicationsystem-blank-related-link:
+      jcr:primaryType: frontend:plugin
+      plugin.class: uk.nhs.digital.ps.BlankRelatedLinkFieldValidator
     /hippo:configuration/hippo:frontend/cms/cms-validators/publicationsystem-summary:
       jcr:primaryType: frontend:plugin
       max_length: 1000
       plugin.class: uk.nhs.digital.ps.TextLengthValidator
-
-    /hippo:configuration/hippo:frontend/cms/cms-validators/publicationsystem-blank-attachment:
+    /hippo:configuration/hippo:frontend/cms/cms-validators/publicationsystem-title:
       jcr:primaryType: frontend:plugin
-      plugin.class: uk.nhs.digital.ps.BlankAttachmentFieldValidator
-
-    /hippo:configuration/hippo:frontend/cms/cms-validators/publicationsystem-blank-granularity:
-      jcr:primaryType: frontend:plugin
-      plugin.class: uk.nhs.digital.ps.BlankStaticDropdownSelectionFieldValidator
-      fieldDisplayName: Granularity
-
-    /hippo:configuration/hippo:frontend/cms/cms-validators/publicationsystem-blank-related-link:
-      jcr:primaryType: frontend:plugin
-      plugin.class: uk.nhs.digital.ps.BlankRelatedLinkFieldValidator
-
+      max_length: 250
+      plugin.class: uk.nhs.digital.ps.TextLengthValidator
     /hippo:configuration/hippo:frontend/cms/cms-validators/valid-url:
       jcr:primaryType: frontend:plugin
       plugin.class: org.hippoecm.frontend.editor.validator.plugins.RegExCmsValidator

--- a/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms.yaml
@@ -1,19 +1,27 @@
+---
 definitions:
   config:
+    /hippo:configuration/hippo:frontend/cms/cms-services/assetValidationService:
+      extensions.allowed:
+      - doc
+      - docx
+      - xls
+      - xlsx
+      - pdf
+      - csv
+      - zip
+      - txt
+      - rar
+      - ppt
+      - pptx
+      max.file.size: 100M
+    /hippo:configuration/hippo:frontend/cms/cms-services/hstRestProxyService:
+      context.path: ''
+      rest.uri: http://127.0.0.1:8080/_cmsrest
     /hippo:configuration/hippo:frontend/cms/cms-services/localeProviderService:
+      /en:
+        country: gb
+        jcr:primaryType: frontend:pluginconfig
+        language: en
       jcr:primaryType: frontend:plugin
       plugin.class: org.hippoecm.frontend.translation.LocaleProviderPlugin
-      /en:
-        jcr:primaryType: frontend:pluginconfig
-        country: gb
-        language: en
-
-    /hippo:configuration/hippo:frontend/cms/cms-services/assetValidationService:
-      max.file.size: 100M
-      extensions.allowed: [doc, docx, xls, xlsx, pdf, csv, zip, txt, rar, ppt, pptx]
-
-    # For more information about deploying site as ROOT app please visit:
-    # https://www.onehippo.org/library/deployment/configuring/deploy-application-as-root_war.html
-    /hippo:configuration/hippo:frontend/cms/cms-services/hstRestProxyService:
-      rest.uri: http://127.0.0.1:8080/_cmsrest
-      context.path: ''

--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/autoexport-module.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/autoexport-module.yaml
@@ -1,5 +1,7 @@
+---
 definitions:
   config:
     /hippo:configuration/hippo:modules/autoexport:
       /hippo:moduleconfig:
-        autoexport:modules: ['repository-data/application:/']
+        autoexport:modules:
+        - repository-data/application:/

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/cms.yaml
@@ -1,12 +1,13 @@
+---
 definitions:
   config:
     /hippo:configuration/hippo:translations/hippo:cms/validators/en:
-      publicationsystem-title: Title must be 250 characters or less
-      publicationsystem-summary: Summary must be 1000 characters or less
       publicationsystem-blank-attachment: There is an attachment field without an
         attachment. Please remove it or upload a file.
-      publicationsystem-blank-staticdropdown: '{0} has a ''''Choose One'''' placeholder
-        without a value. Please remove the placeholder or select a value.'
       publicationsystem-blank-related-link: There is a related link field with no
         URL provided. Please remove it or enter a URL.
+      publicationsystem-blank-staticdropdown: '{0} has a ''''Choose One'''' placeholder
+        without a value. Please remove the placeholder or select a value.'
+      publicationsystem-summary: Summary must be 1000 characters or less
+      publicationsystem-title: Title must be 250 characters or less
       valid-url: Link URL must start with http:// or https://

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update.yaml
@@ -1,9 +1,9 @@
 ---
-
 definitions:
   config:
     /hippo:configuration/hippo:update:
-      jcr:primaryType: hipposys:update
-      jcr:mixinTypes: ['hippo:lockable']
       /hippo:registry:
         jcr:primaryType: hipposys:updaterfolder
+      jcr:mixinTypes:
+      - hippo:lockable
+      jcr:primaryType: hipposys:update

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/EximExport.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/EximExport.yaml
@@ -1,9 +1,7 @@
 ---
-
 definitions:
   config:
     /hippo:configuration/hippo:update/hippo:registry/EximExport:
-      jcr:primaryType: hipposys:updaterinfo
       hipposys:batchsize: 10
       hipposys:description: ''
       hipposys:dryrun: false
@@ -11,6 +9,7 @@ definitions:
         : \"file:${java.io.tmpdir}/exim-export/\"\r\n}"
       hipposys:query: ''
       hipposys:script:
-        type: string
         resource: /configuration/update/EximExport.groovy
+        type: string
       hipposys:throttle: 1000
+      jcr:primaryType: hipposys:updaterinfo

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/EximImport.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/EximImport.yaml
@@ -1,9 +1,7 @@
 ---
-
 definitions:
   config:
     /hippo:configuration/hippo:update/hippo:registry/EximImport:
-      jcr:primaryType: hipposys:updaterinfo
       hipposys:batchsize: 10
       hipposys:description: ''
       hipposys:dryrun: false
@@ -11,6 +9,7 @@ definitions:
         : \"file:${java.io.tmpdir}/exim-import/\"\r\n}"
       hipposys:path: /
       hipposys:script:
-        type: string
         resource: /configuration/update/EximImport.groovy
+        type: string
       hipposys:throttle: 1000
+      jcr:primaryType: hipposys:updaterinfo

--- a/repository-data/application/src/main/resources/hcm-config/content/taxonomies.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/content/taxonomies.yaml
@@ -1,5 +1,4 @@
 ---
-
 definitions:
   config:
     /content/taxonomies:

--- a/repository-data/application/src/main/resources/hcm-config/content/taxonomies/publication_taxonomy.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/content/taxonomies/publication_taxonomy.yaml
@@ -1,39 +1,50 @@
 ---
-
 definitions:
   config:
     /content/taxonomies/publication_taxonomy:
-      jcr:primaryType: hippo:handle
       /publication_taxonomy[1]:
-        jcr:primaryType: hippotaxonomy:taxonomy
-        jcr:mixinTypes: ['hippostd:publishableSummary', 'mix:versionable']
-        hippo:availability: [live]
+        hippo:availability:
+        - live
         hippostd:state: published
         hippostdpubwf:createdBy: admin
-        hippostdpubwf:creationDate: 2017-10-05T14:22:23.191+01:00
-        hippostdpubwf:lastModificationDate: 2017-10-12T12:30:15.855+01:00
+        hippostdpubwf:creationDate: 2017-10-05T13:22:23.191Z
+        hippostdpubwf:lastModificationDate: 2017-10-12T11:30:15.855Z
         hippostdpubwf:lastModifiedBy: admin
-        hippostdpubwf:publicationDate: 2017-10-12T12:33:08.848+01:00
-        hippotaxonomy:locales: [en]
-      /publication_taxonomy[2]:
+        hippostdpubwf:publicationDate: 2017-10-12T11:33:08.848Z
+        hippotaxonomy:locales:
+        - en
+        jcr:mixinTypes:
+        - hippostd:publishableSummary
+        - mix:versionable
         jcr:primaryType: hippotaxonomy:taxonomy
-        jcr:mixinTypes: ['hippostd:publishableSummary', 'mix:referenceable', 'mix:versionable']
-        hippo:availability: [preview]
+      /publication_taxonomy[2]:
+        hippo:availability:
+        - preview
         hippostd:state: unpublished
         hippostdpubwf:createdBy: admin
-        hippostdpubwf:creationDate: 2017-10-05T14:22:23.191+01:00
-        hippostdpubwf:lastModificationDate: 2017-10-12T12:30:15.855+01:00
+        hippostdpubwf:creationDate: 2017-10-05T13:22:23.191Z
+        hippostdpubwf:lastModificationDate: 2017-10-12T11:30:15.855Z
         hippostdpubwf:lastModifiedBy: admin
-        hippostdpubwf:publicationDate: 2017-10-12T12:33:08.848+01:00
-        hippotaxonomy:locales: [en]
-      /publication_taxonomy[3]:
+        hippostdpubwf:publicationDate: 2017-10-12T11:33:08.848Z
+        hippotaxonomy:locales:
+        - en
+        jcr:mixinTypes:
+        - hippostd:publishableSummary
+        - mix:referenceable
+        - mix:versionable
         jcr:primaryType: hippotaxonomy:taxonomy
-        jcr:mixinTypes: ['hippostd:publishableSummary', 'mix:referenceable']
+      /publication_taxonomy[3]:
         hippo:availability: []
         hippostd:state: draft
         hippostdpubwf:createdBy: admin
-        hippostdpubwf:creationDate: 2017-10-05T14:22:23.191+01:00
-        hippostdpubwf:lastModificationDate: 2017-10-12T12:30:15.855+01:00
+        hippostdpubwf:creationDate: 2017-10-05T13:22:23.191Z
+        hippostdpubwf:lastModificationDate: 2017-10-12T11:30:15.855Z
         hippostdpubwf:lastModifiedBy: admin
-        hippostdpubwf:publicationDate: 2017-10-12T12:33:08.848+01:00
-        hippotaxonomy:locales: [en]
+        hippostdpubwf:publicationDate: 2017-10-12T11:33:08.848Z
+        hippotaxonomy:locales:
+        - en
+        jcr:mixinTypes:
+        - hippostd:publishableSummary
+        - mix:referenceable
+        jcr:primaryType: hippotaxonomy:taxonomy
+      jcr:primaryType: hippo:handle

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations.yaml
@@ -1,8 +1,10 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations:
       /common:
         jcr:primaryType: hst:configuration
       /publicationsystem:
+        hst:inheritsfrom:
+        - ../common
         jcr:primaryType: hst:configuration
-        hst:inheritsfrom: [../common]

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/abstractpages.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/abstractpages.yaml
@@ -1,5 +1,4 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:abstractpages:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/abstractpages/basepage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/abstractpages/basepage.yaml
@@ -1,13 +1,14 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:abstractpages/basepage:
-      jcr:primaryType: hst:component
-      hst:template: base
-      /top:
-        jcr:primaryType: hst:component
-        hst:componentclassname: org.onehippo.cms7.essentials.components.EssentialsSearchComponent
-        hst:template: search
       /left:
-        jcr:primaryType: hst:component
         hst:componentclassname: uk.nhs.digital.common.components.FacetComponent
         hst:template: facets
+        jcr:primaryType: hst:component
+      /top:
+        hst:componentclassname: org.onehippo.cms7.essentials.components.EssentialsSearchComponent
+        hst:template: search
+        jcr:primaryType: hst:component
+      hst:template: base
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/catalog.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/catalog.yaml
@@ -1,8 +1,7 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:catalog:
-      jcr:primaryType: hst:catalog
       /publicationsystem-catalog:
         jcr:primaryType: hst:containeritempackage
+      jcr:primaryType: hst:catalog

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/components.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/components.yaml
@@ -1,5 +1,4 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:components:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/pages.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/pages.yaml
@@ -1,5 +1,4 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:pages:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/pages/404.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/pages/404.yaml
@@ -1,7 +1,6 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:pages/404:
-      jcr:primaryType: hst:component
       hst:template: '404'
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/pages/home.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/pages/home.yaml
@@ -1,9 +1,10 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:pages/home:
-      jcr:primaryType: hst:component
-      hst:referencecomponent: hst:abstractpages/basepage
       /main:
-        jcr:primaryType: hst:component
-        hst:template: homepage
         hst:referencecomponent: hst:components/publicationcomponent
+        hst:template: homepage
+        jcr:primaryType: hst:component
+      hst:referencecomponent: hst:abstractpages/basepage
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/pages/search.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/pages/search.yaml
@@ -1,11 +1,16 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:pages/search:
-      jcr:primaryType: hst:component
-      hst:referencecomponent: hst:abstractpages/basepage
       /main:
-        jcr:primaryType: hst:component
         hst:componentclassname: uk.nhs.digital.common.components.SearchComponent
-        hst:parameternames: [pageSize, showPagination]
-        hst:parametervalues: ['10', 'true']
+        hst:parameternames:
+        - pageSize
+        - showPagination
+        hst:parametervalues:
+        - '10'
+        - 'true'
         hst:template: searchresults
+        jcr:primaryType: hst:component
+      hst:referencecomponent: hst:abstractpages/basepage
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/prototypepages.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/prototypepages.yaml
@@ -1,5 +1,4 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:prototypepages:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
@@ -1,25 +1,23 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:sitemap:
-      jcr:primaryType: hst:sitemap
-      /root:
+      /error:
+        /404:
+          hst:componentconfigurationid: hst:pages/404
+          jcr:primaryType: hst:sitemapitem
         jcr:primaryType: hst:sitemapitem
+      /root:
         hst:componentconfigurationid: hst:pages/home
         hst:relativecontentpath: publications/test-document
-      /search:
         jcr:primaryType: hst:sitemapitem
+      /search:
+        /_any_:
+          hst:componentconfigurationid: hst:pages/search
+          hst:relativecontentpath: facet/${1}
+          jcr:primaryType: hst:sitemapitem
         hst:componentconfigurationid: hst:pages/search
         hst:refId: search
         hst:relativecontentpath: facet
-        /_any_:
-          jcr:primaryType: hst:sitemapitem
-          hst:componentconfigurationid: hst:pages/search
-          hst:relativecontentpath: facet/${1}
-      /error:
         jcr:primaryType: hst:sitemapitem
-        /404:
-          jcr:primaryType: hst:sitemapitem
-          hst:componentconfigurationid: hst:pages/404
-
+      jcr:primaryType: hst:sitemap

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/sitemenus.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/sitemenus.yaml
@@ -1,5 +1,4 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:sitemenus:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates.yaml
@@ -1,9 +1,8 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:templates:
-      jcr:primaryType: hst:templates
       /facets:
-        jcr:primaryType: hst:template
         hst:renderpath: webfile:/freemarker/common/facets.ftl
+        jcr:primaryType: hst:template
+      jcr:primaryType: hst:templates

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates/404.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates/404.yaml
@@ -1,7 +1,6 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:templates/404:
-       jcr:primaryType: hst:template
-       hst:renderpath: webfile:/freemarker/common/404.ftl
+      hst:renderpath: webfile:/freemarker/common/404.ftl
+      jcr:primaryType: hst:template

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates/base.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates/base.yaml
@@ -1,7 +1,6 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:templates/base:
-      jcr:primaryType: hst:template
       hst:renderpath: webfile:/freemarker/common/base-layout.ftl
+      jcr:primaryType: hst:template

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates/homepage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates/homepage.yaml
@@ -1,7 +1,6 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:templates/homepage:
-      jcr:primaryType: hst:template
       hst:renderpath: webfile:/freemarker/publicationsystem/publication.ftl
+      jcr:primaryType: hst:template

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates/search.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates/search.yaml
@@ -1,7 +1,6 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:templates/search:
-      jcr:primaryType: hst:template
       hst:renderpath: webfile:/freemarker/common/search.ftl
+      jcr:primaryType: hst:template

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates/searchresults.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates/searchresults.yaml
@@ -1,7 +1,6 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:templates/searchresults:
-      jcr:primaryType: hst:template
       hst:renderpath: webfile:/freemarker/common/searchresults.ftl
+      jcr:primaryType: hst:template

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/workspace.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/workspace.yaml
@@ -1,5 +1,4 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:workspace:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/workspace/channel.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/workspace/channel.yaml
@@ -1,7 +1,8 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:workspace/hst:channel:
       .meta:residual-child-node-category: content
-      jcr:primaryType: hst:channel
       hst:name: NHS Digital Website
       hst:type: website
+      jcr:primaryType: hst:channel

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/workspace/containers.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/workspace/containers.yaml
@@ -1,3 +1,4 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:workspace/hst:containers:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/workspace/pages.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/workspace/pages.yaml
@@ -1,3 +1,4 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:workspace/hst:pages:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/workspace/sitemap.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/workspace/sitemap.yaml
@@ -1,3 +1,4 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:workspace/hst:sitemap:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/workspace/sitemenus.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/workspace/sitemenus.yaml
@@ -1,3 +1,4 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:workspace/hst:sitemenus:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/abstractpages.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/abstractpages.yaml
@@ -1,3 +1,4 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:abstractpages:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/abstractpages/basepage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/abstractpages/basepage.yaml
@@ -1,9 +1,10 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:abstractpages/basepage:
-      jcr:primaryType: hst:component
-      hst:template: base
       /top:
-        jcr:primaryType: hst:component
-        hst:template: search
         hst:componentclassname: org.onehippo.cms7.essentials.components.EssentialsSearchComponent
+        hst:template: search
+        jcr:primaryType: hst:component
+      hst:template: base
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/catalog.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/catalog.yaml
@@ -1,6 +1,7 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:catalog:
-      jcr:primaryType: hst:catalog
       /publicationsystem-catalog:
         jcr:primaryType: hst:containeritempackage
+      jcr:primaryType: hst:catalog

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/components.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/components.yaml
@@ -1,3 +1,4 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:components:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/components/publication.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/components/publication.yaml
@@ -1,7 +1,10 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:components/publication:
-      jcr:primaryType: hst:component
       hst:componentclassname: uk.nhs.digital.ps.components.PublicationComponent
-      hst:parameternames: [taxonomyName]
-      hst:parametervalues: [publication_taxonomy]
+      hst:parameternames:
+      - taxonomyName
+      hst:parametervalues:
+      - publication_taxonomy
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/pages.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/pages.yaml
@@ -1,3 +1,4 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:pages:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/pages/dataset.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/pages/dataset.yaml
@@ -1,11 +1,10 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:pages/dataset:
-      jcr:primaryType: hst:component
-      hst:referencecomponent: hst:abstractpages/basepage
       /main:
-        jcr:primaryType: hst:component
         hst:componentclassname: uk.nhs.digital.ps.components.DatasetComponent
         hst:template: dataset
+        jcr:primaryType: hst:component
+      hst:referencecomponent: hst:abstractpages/basepage
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/pages/folder.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/pages/folder.yaml
@@ -1,11 +1,10 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:pages/folder:
-      jcr:primaryType: hst:component
-      hst:referencecomponent: hst:abstractpages/basepage
       /main:
-        jcr:primaryType: hst:component
         hst:componentclassname: uk.nhs.digital.ps.components.FolderComponent
         hst:template: folder
+        jcr:primaryType: hst:component
+      hst:referencecomponent: hst:abstractpages/basepage
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/pages/home.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/pages/home.yaml
@@ -1,9 +1,10 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:pages/home:
-      jcr:primaryType: hst:component
-      hst:referencecomponent: hst:abstractpages/basepage
       /main:
-        jcr:primaryType: hst:component
-        hst:template: publications-overview-template
         hst:componentclassname: uk.nhs.digital.ps.components.PublicationsOverviewComponent
+        hst:template: publications-overview-template
+        jcr:primaryType: hst:component
+      hst:referencecomponent: hst:abstractpages/basepage
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/pages/publication.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/pages/publication.yaml
@@ -1,11 +1,10 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:pages/publication:
-      jcr:primaryType: hst:component
-      hst:referencecomponent: hst:abstractpages/basepage
       /main:
-        jcr:primaryType: hst:component
         hst:componentclassname: uk.nhs.digital.ps.components.PublicationComponent
         hst:template: publication
+        jcr:primaryType: hst:component
+      hst:referencecomponent: hst:abstractpages/basepage
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/pages/series.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/pages/series.yaml
@@ -1,11 +1,10 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:pages/series:
-      jcr:primaryType: hst:component
-      hst:referencecomponent: hst:abstractpages/basepage
       /main:
-        jcr:primaryType: hst:component
         hst:componentclassname: uk.nhs.digital.ps.components.SeriesComponent
         hst:template: series
+        jcr:primaryType: hst:component
+      hst:referencecomponent: hst:abstractpages/basepage
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/prototypepages.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/prototypepages.yaml
@@ -1,3 +1,4 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:prototypepages:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/sitemap.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/sitemap.yaml
@@ -1,20 +1,21 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:sitemap:
-      jcr:primaryType: hst:sitemap
-      /root:
-        jcr:primaryType: hst:sitemapitem
-        hst:componentconfigurationid: hst:pages/home
       /_any_:
-        jcr:primaryType: hst:sitemapitem
-        hst:relativecontentpath: ${1}
         hst:componentconfigurationmappingnames:
-          - publicationsystem:dataset
-          - hippostd:folder
-          - publicationsystem:publication
-          - publicationsystem:series
+        - publicationsystem:dataset
+        - hippostd:folder
+        - publicationsystem:publication
+        - publicationsystem:series
         hst:componentconfigurationmappingvalues:
-          - hst:pages/dataset
-          - hst:pages/folder
-          - hst:pages/publication
-          - hst:pages/series
+        - hst:pages/dataset
+        - hst:pages/folder
+        - hst:pages/publication
+        - hst:pages/series
+        hst:relativecontentpath: ${1}
+        jcr:primaryType: hst:sitemapitem
+      /root:
+        hst:componentconfigurationid: hst:pages/home
+        jcr:primaryType: hst:sitemapitem
+      jcr:primaryType: hst:sitemap

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/sitemenus.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/sitemenus.yaml
@@ -1,3 +1,4 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:sitemenus:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/templates.yaml
@@ -1,10 +1,7 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:templates:
-      jcr:primaryType: hst:templates
-      /publications-overview-template:
-        jcr:primaryType: hst:template
-        hst:renderpath: webfile:/freemarker/publicationsystem/publications-overview.ftl
       /dataset:
         hst:renderpath: webfile:/freemarker/publicationsystem/dataset.ftl
         jcr:primaryType: hst:template
@@ -14,6 +11,10 @@ definitions:
       /publication:
         hst:renderpath: webfile:/freemarker/publicationsystem/publication.ftl
         jcr:primaryType: hst:template
+      /publications-overview-template:
+        hst:renderpath: webfile:/freemarker/publicationsystem/publications-overview.ftl
+        jcr:primaryType: hst:template
       /series:
         hst:renderpath: webfile:/freemarker/publicationsystem/series.ftl
         jcr:primaryType: hst:template
+      jcr:primaryType: hst:templates

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/workspace.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/workspace.yaml
@@ -1,3 +1,4 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:workspace:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/workspace/channel.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/workspace/channel.yaml
@@ -1,7 +1,8 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:workspace/hst:channel:
       .meta:residual-child-node-category: content
-      jcr:primaryType: hst:channel
       hst:name: NHS Digital Publication System
       hst:type: website
+      jcr:primaryType: hst:channel

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/workspace/containers.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/workspace/containers.yaml
@@ -1,3 +1,4 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:workspace/hst:containers:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/workspace/pages.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/workspace/pages.yaml
@@ -1,3 +1,4 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:workspace/hst:pages:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/workspace/sitemap.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/workspace/sitemap.yaml
@@ -1,3 +1,4 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:workspace/hst:sitemap:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/workspace/sitemenus.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/workspace/sitemenus.yaml
@@ -1,3 +1,4 @@
+---
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:workspace/hst:sitemenus:

--- a/repository-data/application/src/main/resources/hcm-config/hst/hosts.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/hosts.yaml
@@ -1,123 +1,117 @@
+---
 definitions:
   config:
     /hst:hst/hst:hosts:
       .meta:residual-child-node-category: content
-      jcr:primaryType: hst:virtualhosts
-      # this deploys "site" as root application
-      hst:defaultcontextpath: ""
-
-      # locahost
-      /localhost:
-        .meta:residual-child-node-category: content
-        jcr:primaryType: hst:virtualhostgroup
-        hst:cmslocation: http://localhost:8080/cms
-        hst:defaultport: 8080
-        /localhost:
-          .meta:residual-child-node-category: content
-          jcr:primaryType: hst:virtualhost
-          /hst:root:
-            .meta:residual-child-node-category: content
-            jcr:primaryType: hst:mount
-            hst:homepage: root
-            hst:mountpoint: /hst:hst/hst:sites/common
-            hst:alias: common-context
-            /publications:
-              .meta:residual-child-node-category: content
-              jcr:primaryType: hst:mount
-              hst:homepage: root
-              hst:mountpoint: /hst:hst/hst:sites/publicationsystem
-
-      # For local testing in Vagrant
-      /vagrant:
-        .meta:residual-child-node-category: content
-        jcr:primaryType: hst:virtualhostgroup
-        hst:cmslocation: http://hippo-authoring.int:8080/cms
-        hst:defaultport: 8080
-        /int:
-          .meta:residual-child-node-category: content
-          jcr:primaryType: hst:virtualhost
-          hst:showcontextpath: false
-          /hippo-delivery:
-            .meta:residual-child-node-category: content
-            jcr:primaryType: hst:virtualhost
-            /hst:root:
-              .meta:residual-child-node-category: content
-              jcr:primaryType: hst:mount
-              hst:homepage: root
-              hst:mountpoint: /hst:hst/hst:sites/common
-              hst:alias: common-context
-              /publications:
-                .meta:residual-child-node-category: content
-                jcr:primaryType: hst:mount
-                hst:homepage: root
-                hst:mountpoint: /hst:hst/hst:sites/publicationsystem
-
       /dev:
         .meta:residual-child-node-category: content
-        jcr:primaryType: hst:virtualhostgroup
-        hst:cmslocation: http://hippo-authoring.dev.ps.digital.nhsd.uk/cms
-        hst:defaultport: 8080
         /io:
           .meta:residual-child-node-category: content
-          jcr:primaryType: hst:virtualhost
-          hst:showcontextpath: false
           /nhsd:
             .meta:residual-child-node-category: content
-            jcr:primaryType: hst:virtualhost
             /ps:
               .meta:residual-child-node-category: content
-              jcr:primaryType: hst:virtualhost
               /dev:
                 .meta:residual-child-node-category: content
-                jcr:primaryType: hst:virtualhost
                 /web:
                   .meta:residual-child-node-category: content
-                  jcr:primaryType: hst:virtualhost
                   /hippo-delivery:
                     .meta:residual-child-node-category: content
-                    jcr:primaryType: hst:virtualhost
                     /hst:root:
                       .meta:residual-child-node-category: content
-                      jcr:primaryType: hst:mount
-                      hst:homepage: root
-                      hst:mountpoint: /hst:hst/hst:sites/common
-                      hst:alias: common-context
                       /publications:
                         .meta:residual-child-node-category: content
-                        jcr:primaryType: hst:mount
                         hst:homepage: root
                         hst:mountpoint: /hst:hst/hst:sites/publicationsystem
-
+                        jcr:primaryType: hst:mount
+                      hst:alias: common-context
+                      hst:homepage: root
+                      hst:mountpoint: /hst:hst/hst:sites/common
+                      jcr:primaryType: hst:mount
+                    jcr:primaryType: hst:virtualhost
+                  jcr:primaryType: hst:virtualhost
+                jcr:primaryType: hst:virtualhost
+              jcr:primaryType: hst:virtualhost
+            jcr:primaryType: hst:virtualhost
+          hst:showcontextpath: false
+          jcr:primaryType: hst:virtualhost
+        hst:cmslocation: http://hippo-authoring.dev.ps.digital.nhsd.uk/cms
+        hst:defaultport: 8080
+        jcr:primaryType: hst:virtualhostgroup
+      /localhost:
+        .meta:residual-child-node-category: content
+        /localhost:
+          .meta:residual-child-node-category: content
+          /hst:root:
+            .meta:residual-child-node-category: content
+            /publications:
+              .meta:residual-child-node-category: content
+              hst:homepage: root
+              hst:mountpoint: /hst:hst/hst:sites/publicationsystem
+              jcr:primaryType: hst:mount
+            hst:alias: common-context
+            hst:homepage: root
+            hst:mountpoint: /hst:hst/hst:sites/common
+            jcr:primaryType: hst:mount
+          jcr:primaryType: hst:virtualhost
+        hst:cmslocation: http://localhost:8080/cms
+        hst:defaultport: 8080
+        jcr:primaryType: hst:virtualhostgroup
       /ondemand:
         .meta:residual-child-node-category: content
-        jcr:primaryType: hst:virtualhostgroup
-        hst:cmslocation: https://cms-nhs.test.onehippo.com/?0
-        hst:defaultport: 8080
         /com:
           .meta:residual-child-node-category: content
-          jcr:primaryType: hst:virtualhost
           /onehippo:
             .meta:residual-child-node-category: content
-            jcr:primaryType: hst:virtualhost
             /test:
               .meta:residual-child-node-category: content
-              jcr:primaryType: hst:virtualhost
               /nhs:
                 .meta:residual-child-node-category: content
-                jcr:primaryType: hst:virtualhost
                 /www:
                   .meta:residual-child-node-category: content
-                  jcr:primaryType: hst:virtualhost
                   /hst:root:
                     .meta:residual-child-node-category: content
-                    jcr:primaryType: hst:mount
-                    hst:contextpath: /site
-                    hst:showcontextpath: false
-                    hst:homepage: root
-                    hst:mountpoint: /hst:hst/hst:sites/common
-                    hst:alias: common-context
                     /publications:
                       .meta:residual-child-node-category: content
-                      jcr:primaryType: hst:mount
                       hst:homepage: root
                       hst:mountpoint: /hst:hst/hst:sites/publicationsystem
+                      jcr:primaryType: hst:mount
+                    hst:alias: common-context
+                    hst:contextpath: /site
+                    hst:homepage: root
+                    hst:mountpoint: /hst:hst/hst:sites/common
+                    hst:showcontextpath: false
+                    jcr:primaryType: hst:mount
+                  jcr:primaryType: hst:virtualhost
+                jcr:primaryType: hst:virtualhost
+              jcr:primaryType: hst:virtualhost
+            jcr:primaryType: hst:virtualhost
+          jcr:primaryType: hst:virtualhost
+        hst:cmslocation: https://cms-nhs.test.onehippo.com/?0
+        hst:defaultport: 8080
+        jcr:primaryType: hst:virtualhostgroup
+      /vagrant:
+        .meta:residual-child-node-category: content
+        /int:
+          .meta:residual-child-node-category: content
+          /hippo-delivery:
+            .meta:residual-child-node-category: content
+            /hst:root:
+              .meta:residual-child-node-category: content
+              /publications:
+                .meta:residual-child-node-category: content
+                hst:homepage: root
+                hst:mountpoint: /hst:hst/hst:sites/publicationsystem
+                jcr:primaryType: hst:mount
+              hst:alias: common-context
+              hst:homepage: root
+              hst:mountpoint: /hst:hst/hst:sites/common
+              jcr:primaryType: hst:mount
+            jcr:primaryType: hst:virtualhost
+          hst:showcontextpath: false
+          jcr:primaryType: hst:virtualhost
+        hst:cmslocation: http://hippo-authoring.int:8080/cms
+        hst:defaultport: 8080
+        jcr:primaryType: hst:virtualhostgroup
+      hst:defaultcontextpath: ''
+      jcr:primaryType: hst:virtualhosts

--- a/repository-data/application/src/main/resources/hcm-config/hst/sites.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/sites.yaml
@@ -1,11 +1,12 @@
+---
 definitions:
   config:
     /hst:hst/hst:sites:
       .meta:residual-child-node-category: content
-      jcr:primaryType: hst:sites
       /common:
-        jcr:primaryType: hst:site
         hst:content: /content/documents/corporate-website
-      /publicationsystem:
         jcr:primaryType: hst:site
+      /publicationsystem:
         hst:content: /content/documents/corporate-website/publication-system
+        jcr:primaryType: hst:site
+      jcr:primaryType: hst:sites

--- a/repository-data/application/src/main/resources/hcm-config/main.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/main.yaml
@@ -1,41 +1,49 @@
+---
 definitions:
-  namespace:
-    publicationsystem:
-      uri: http://digital.nhs.uk/jcr/publicationsystem/nt/1.0
-      cnd: namespaces/publicationsystem.cnd
-    common:
-      uri: http://digital.nhs.uk/jcr/common/nt/1.0
-      cnd: namespaces/common.cnd
   config:
-    /hippo:configuration/hippo:modules/webfiles/hippo:moduleconfig:
-      watchedModules: [repository-data/webfiles]
-    /hippo:configuration/hippo:groups/author:
-      hipposys:members:
-        operation: add
-        type: string
-        value: [author]
-    /hippo:configuration/hippo:groups/editor:
-      hipposys:members:
-        operation: add
-        type: string
-        value: [editor]
-    /hippo:configuration/hippo:groups/webmaster:
-      hipposys:members:
-        operation: add
-        type: string
-        value: [editor]
     /hippo:configuration/hippo:domains/hippofolders/readonly:
       hipposys:groups:
         operation: add
         type: string
-        value: [sitewriters]
-    /hippo:configuration/hippo:domains/preview-documents/readonly:
-      hipposys:groups:
-        operation: add
-        type: string
-        value: [previewusers]
+        value:
+        - sitewriters
     /hippo:configuration/hippo:domains/live-documents/readonly:
       hipposys:groups:
         operation: add
         type: string
-        value: [liveusers]
+        value:
+        - liveusers
+    /hippo:configuration/hippo:domains/preview-documents/readonly:
+      hipposys:groups:
+        operation: add
+        type: string
+        value:
+        - previewusers
+    /hippo:configuration/hippo:groups/author:
+      hipposys:members:
+        operation: add
+        type: string
+        value:
+        - author
+    /hippo:configuration/hippo:groups/editor:
+      hipposys:members:
+        operation: add
+        type: string
+        value:
+        - editor
+    /hippo:configuration/hippo:groups/webmaster:
+      hipposys:members:
+        operation: add
+        type: string
+        value:
+        - editor
+    /hippo:configuration/hippo:modules/webfiles/hippo:moduleconfig:
+      watchedModules:
+      - repository-data/webfiles
+  namespace:
+    common:
+      cnd: namespaces/common.cnd
+      uri: http://digital.nhs.uk/jcr/common/nt/1.0
+    publicationsystem:
+      cnd: namespaces/publicationsystem.cnd
+      uri: http://digital.nhs.uk/jcr/publicationsystem/nt/1.0

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/common.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/common.yaml
@@ -1,5 +1,7 @@
+---
 definitions:
   config:
     /hippo:namespaces/common:
+      jcr:mixinTypes:
+      - mix:referenceable
       jcr:primaryType: hipposysedit:namespace
-      jcr:mixinTypes: ['mix:referenceable']

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/common/basedocument.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/common/basedocument.yaml
@@ -1,13 +1,20 @@
+---
 definitions:
   config:
     /hippo:namespaces/common/basedocument:
-      jcr:primaryType: hipposysedit:templatetype
-      jcr:mixinTypes: ['mix:referenceable']
       /hipposysedit:nodetype:
-        jcr:primaryType: hippo:handle
-        jcr:mixinTypes: ['mix:referenceable']
         /hipposysedit:nodetype:
-          jcr:primaryType: hipposysedit:nodetype
-          jcr:mixinTypes: ['hipposysedit:remodel']
-          hipposysedit:supertype: ['hippo:document', 'hippostdpubwf:document', 'hippostd:publishableSummary']
+          hipposysedit:supertype:
+          - hippo:document
+          - hippostdpubwf:document
+          - hippostd:publishableSummary
           hipposysedit:uri: http://digital.nhs.uk/jcr/common/nt/1.0
+          jcr:mixinTypes:
+          - hipposysedit:remodel
+          jcr:primaryType: hipposysedit:nodetype
+        jcr:mixinTypes:
+        - mix:referenceable
+        jcr:primaryType: hippo:handle
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: hipposysedit:templatetype

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem.yaml
@@ -1,5 +1,7 @@
+---
 definitions:
   config:
     /hippo:namespaces/publicationsystem:
+      jcr:mixinTypes:
+      - mix:referenceable
       jcr:primaryType: hipposysedit:namespace
-      jcr:mixinTypes: ['mix:referenceable']

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/basedocument.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/basedocument.yaml
@@ -1,15 +1,20 @@
 ---
-
 definitions:
   config:
     /hippo:namespaces/publicationsystem/basedocument:
-      jcr:primaryType: hipposysedit:templatetype
-      jcr:mixinTypes: ['mix:referenceable']
       /hipposysedit:nodetype:
-        jcr:primaryType: hippo:handle
-        jcr:mixinTypes: ['mix:referenceable']
         /hipposysedit:nodetype:
-          jcr:primaryType: hipposysedit:nodetype
-          jcr:mixinTypes: ['hipposysedit:remodel']
-          hipposysedit:supertype: ['hippo:document', 'hippostdpubwf:document', 'hippostd:publishableSummary']
+          hipposysedit:supertype:
+          - hippo:document
+          - hippostdpubwf:document
+          - hippostd:publishableSummary
           hipposysedit:uri: http://digital.nhs.uk/jcr/publicationsystem/nt/1.0
+          jcr:mixinTypes:
+          - hipposysedit:remodel
+          jcr:primaryType: hipposysedit:nodetype
+        jcr:mixinTypes:
+        - mix:referenceable
+        jcr:primaryType: hippo:handle
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: hipposysedit:templatetype

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/dataset.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/dataset.yaml
@@ -1,109 +1,242 @@
 ---
-
 definitions:
   config:
     /hippo:namespaces/publicationsystem/dataset:
-      jcr:primaryType: hipposysedit:templatetype
-      jcr:mixinTypes: ['editor:editable', 'mix:referenceable']
-      jcr:uuid: 6f16a60c-223e-4306-a942-b6dc5a5fcfd7
-      /hipposysedit:nodetype:
-        jcr:primaryType: hippo:handle
-        jcr:mixinTypes: ['mix:referenceable']
-        jcr:uuid: e073635b-5526-45a3-8084-38e62c62b2ce
-        /hipposysedit:nodetype:
-          jcr:primaryType: hipposysedit:nodetype
-          jcr:mixinTypes: ['hipposysedit:remodel', 'mix:referenceable']
-          jcr:uuid: cdf14d25-0161-43e4-b6b6-b86daabd379c
-          hipposysedit:node: true
-          hipposysedit:supertype: ['publicationsystem:basedocument', 'hippostd:relaxed',
-            'hippotranslation:translated', 'hippotaxonomy:classifiable']
-          hipposysedit:uri: http://digital.nhs.uk/jcr/publicationsystem/nt/1.0
-          /Title:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:Title
-            hipposysedit:primary: false
-            hipposysedit:type: String
-          /Summary:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:Summary
-            hipposysedit:primary: false
-            hipposysedit:type: Text
-          /Purpose:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:Purpose
-            hipposysedit:primary: false
-            hipposysedit:type: Text
-          /NominalDate:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:NominalDate
-            hipposysedit:primary: false
-            hipposysedit:type: CalendarDate
-          /NextPublicationDate:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:NextPublicationDate
-            hipposysedit:primary: false
-            hipposysedit:type: CalendarDate
-          /GeographicCoverage:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:GeographicCoverage
-            hipposysedit:primary: false
-            hipposysedit:type: StaticDropdown
-          /Granularity:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: true
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:Granularity
-            hipposysedit:primary: false
-            hipposysedit:type: StaticDropdown
-          /Files:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: true
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:Files
-            hipposysedit:primary: false
-            hipposysedit:type: hippo:resource
-          /CoverageStart:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:CoverageStart
-            hipposysedit:primary: false
-            hipposysedit:type: CalendarDate
+      /editor:templates:
+        /_default_:
           /CoverageEnd:
-            jcr:primaryType: hipposysedit:field
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Coverage End
+            field: CoverageEnd
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.right.item
+          /CoverageStart:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Coverage Start
+            field: CoverageStart
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.right.item
+          /Files:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Files
+            field: Files
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.left.item
+          /GeographicCoverage:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+              selectable.options: England,England and Northern Ireland,England and
+                Scotland,England and Wales,England Scotland and Northern Ireland,England
+                Wales and Northern Ireland,Great Britain,International,Northern Ireland,Scotland,UK,Wales
+            caption: Geographic Coverage
+            field: GeographicCoverage
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.right.item
+          /Granularity:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+              selectable.options: Ambulance Trusts,Cancer networks,Care Trusts,Census
+                Area Statistics Wards,Clinical Commissioning Groups,Community health
+                services,Councils with Social Services Responsibilities,Country,County,Dental
+                practices,Government Office Regions,GP practices,Health Education
+                England Region,Hospital and Community Health Services,Hospital Trusts,Independent
+                Sector Health Care Providers,Local Authorities,Mental Health Trusts,Middle
+                Layer Super Output Areas,NHS Health Boards,NHS Trusts,Parliamentary
+                constituency,Pharmacies and clinics,Primary Care Organisations,Primary
+                Care Trusts,Regional health body,Regions,Strategic Health Authorities,Sustainability
+                and Transformation Partnerships
+            caption: Granularity
+            field: Granularity
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.right.item
+          /NextPublicationDate:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Next Publication Date
+            field: NextPublicationDate
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.right.item
+          /NominalDate:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Nominal Date
+            field: NominalDate
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.right.item
+          /Purpose:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Purpose
+            field: Purpose
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.left.item
+          /Summary:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Summary
+            field: Summary
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.left.item
+          /Title:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Title
+            field: Title
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.left.item
+          /classifiable:
+            /cluster.options:
+              caption: Taxonomy
+              jcr:primaryType: frontend:pluginconfig
+              taxonomy.name: publication_taxonomy
+            jcr:primaryType: frontend:plugin
+            mixin: hippotaxonomy:classifiable
+            plugin.class: org.hippoecm.frontend.editor.plugins.mixin.MixinLoaderPlugin
+            wicket.id: ${cluster.id}.right.item
+          /left:
+            item: ${cluster.id}.left.item
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+            wicket.id: ${cluster.id}.left
+          /right:
+            item: ${cluster.id}.right.item
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+            wicket.id: ${cluster.id}.right
+          /root:
+            extension.left: ${cluster.id}.left
+            extension.right: ${cluster.id}.right
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.layout.TwoColumn
+            wicket.extensions:
+            - extension.left
+            - extension.right
+          frontend:properties:
+          - mode
+          frontend:references:
+          - wicket.model
+          - model.compareTo
+          - engine
+          - validator.id
+          frontend:services:
+          - wicket.id
+          - validator.id
+          jcr:primaryType: frontend:plugincluster
+        jcr:primaryType: editor:templateset
+      /hipposysedit:nodetype:
+        /hipposysedit:nodetype:
+          /CoverageEnd:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
             hipposysedit:ordered: false
             hipposysedit:path: publicationsystem:CoverageEnd
             hipposysedit:primary: false
             hipposysedit:type: CalendarDate
+            jcr:primaryType: hipposysedit:field
+          /CoverageStart:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:CoverageStart
+            hipposysedit:primary: false
+            hipposysedit:type: CalendarDate
+            jcr:primaryType: hipposysedit:field
+          /Files:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: true
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:Files
+            hipposysedit:primary: false
+            hipposysedit:type: hippo:resource
+            jcr:primaryType: hipposysedit:field
+          /GeographicCoverage:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:GeographicCoverage
+            hipposysedit:primary: false
+            hipposysedit:type: StaticDropdown
+            jcr:primaryType: hipposysedit:field
+          /Granularity:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: true
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:Granularity
+            hipposysedit:primary: false
+            hipposysedit:type: StaticDropdown
+            jcr:primaryType: hipposysedit:field
+          /NextPublicationDate:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:NextPublicationDate
+            hipposysedit:primary: false
+            hipposysedit:type: CalendarDate
+            jcr:primaryType: hipposysedit:field
+          /NominalDate:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:NominalDate
+            hipposysedit:primary: false
+            hipposysedit:type: CalendarDate
+            jcr:primaryType: hipposysedit:field
+          /Purpose:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:Purpose
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          /Summary:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:Summary
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          /Title:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:Title
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            jcr:primaryType: hipposysedit:field
+          hipposysedit:node: true
+          hipposysedit:supertype:
+          - publicationsystem:basedocument
+          - hippostd:relaxed
+          - hippotranslation:translated
+          - hippotaxonomy:classifiable
+          hipposysedit:uri: http://digital.nhs.uk/jcr/publicationsystem/nt/1.0
+          jcr:mixinTypes:
+          - hipposysedit:remodel
+          - mix:referenceable
+          jcr:primaryType: hipposysedit:nodetype
+        jcr:mixinTypes:
+        - mix:referenceable
+        jcr:primaryType: hippo:handle
       /hipposysedit:prototypes:
-        jcr:primaryType: hipposysedit:prototypeset
         /hipposysedit:prototype:
-          jcr:primaryType: publicationsystem:dataset
-          jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-          jcr:uuid: 27a03d99-1030-44e2-a49e-d3c6ccb8807e
           hippostd:holder: holder
           hippostd:state: draft
           hippostdpubwf:createdBy: ''
@@ -112,138 +245,21 @@ definitions:
           hippostdpubwf:lastModifiedBy: ''
           hippotranslation:id: document-type-locale-id
           hippotranslation:locale: document-type-locale
+          jcr:mixinTypes:
+          - hippotaxonomy:classifiable
+          - mix:referenceable
+          jcr:primaryType: publicationsystem:dataset
           publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
           publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-          publicationsystem:Granularity: ['']
+          publicationsystem:Granularity:
+          - ''
           publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
           publicationsystem:NominalDate: 0001-01-01T12:00:00Z
           publicationsystem:Purpose: ''
           publicationsystem:Summary: ''
           publicationsystem:Title: ''
-      /editor:templates:
-        jcr:primaryType: editor:templateset
-        /_default_:
-          jcr:primaryType: frontend:plugincluster
-          frontend:properties: [mode]
-          frontend:references: [wicket.model, model.compareTo, engine, validator.id]
-          frontend:services: [wicket.id, validator.id]
-          /root:
-            jcr:primaryType: frontend:plugin
-            extension.left: ${cluster.id}.left
-            extension.right: ${cluster.id}.right
-            plugin.class: org.hippoecm.frontend.editor.layout.TwoColumn
-            wicket.extensions: [extension.left, extension.right]
-          /left:
-            jcr:primaryType: frontend:plugin
-            item: ${cluster.id}.left.item
-            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
-            wicket.id: ${cluster.id}.left
-          /right:
-            jcr:primaryType: frontend:plugin
-            item: ${cluster.id}.right.item
-            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
-            wicket.id: ${cluster.id}.right
-          /Title:
-            jcr:primaryType: frontend:plugin
-            caption: Title
-            field: Title
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.left.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /Summary:
-            jcr:primaryType: frontend:plugin
-            caption: Summary
-            field: Summary
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.left.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /classifiable:
-            jcr:primaryType: frontend:plugin
-            mixin: hippotaxonomy:classifiable
-            plugin.class: org.hippoecm.frontend.editor.plugins.mixin.MixinLoaderPlugin
-            wicket.id: ${cluster.id}.right.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-              caption: Taxonomy
-              taxonomy.name: publication_taxonomy
-          /Purpose:
-            jcr:primaryType: frontend:plugin
-            caption: Purpose
-            field: Purpose
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.left.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /Files:
-            jcr:primaryType: frontend:plugin
-            caption: Files
-            field: Files
-            hint: ''
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
-            wicket.id: ${cluster.id}.left.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /NominalDate:
-            jcr:primaryType: frontend:plugin
-            caption: Nominal Date
-            field: NominalDate
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.right.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /NextPublicationDate:
-            jcr:primaryType: frontend:plugin
-            caption: Next Publication Date
-            field: NextPublicationDate
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.right.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /CoverageStart:
-            jcr:primaryType: frontend:plugin
-            caption: Coverage Start
-            field: CoverageStart
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.right.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /CoverageEnd:
-            jcr:primaryType: frontend:plugin
-            caption: Coverage End
-            field: CoverageEnd
-            hint: ''
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.right.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /GeographicCoverage:
-            jcr:primaryType: frontend:plugin
-            caption: Geographic Coverage
-            field: GeographicCoverage
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.right.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-              selectable.options: England,England and Northern Ireland,England and Scotland,England
-                and Wales,England Scotland and Northern Ireland,England Wales and Northern
-                Ireland,Great Britain,International,Northern Ireland,Scotland,UK,Wales
-          /Granularity:
-            jcr:primaryType: frontend:plugin
-            caption: Granularity
-            field: Granularity
-            hint: ''
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.right.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-              selectable.options: Ambulance Trusts,Cancer networks,Care Trusts,Census
-                Area Statistics Wards,Clinical Commissioning Groups,Community health services,Councils
-                with Social Services Responsibilities,Country,County,Dental practices,Government Office
-                Regions,GP practices,Health Education
-                England Region,Hospital and Community Health Services,Hospital Trusts,Independent
-                Sector Health Care Providers,Local Authorities,Mental Health Trusts,Middle
-                Layer Super Output Areas,NHS Health Boards,NHS Trusts,Parliamentary constituency,Pharmacies
-                and clinics,Primary Care Organisations,Primary Care Trusts,Regional health body,Regions,Strategic
-                Health Authorities,Sustainability and Transformation Partnerships
+        jcr:primaryType: hipposysedit:prototypeset
+      jcr:mixinTypes:
+      - editor:editable
+      - mix:referenceable
+      jcr:primaryType: hipposysedit:templatetype

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
@@ -1,343 +1,387 @@
 ---
-
 definitions:
   config:
     /hippo:namespaces/publicationsystem/publication:
-      jcr:primaryType: hipposysedit:templatetype
-      jcr:mixinTypes: ['editor:editable', 'mix:referenceable']
-      /hipposysedit:nodetype:
-        jcr:primaryType: hippo:handle
-        jcr:mixinTypes: ['mix:referenceable']
-        /hipposysedit:nodetype:
-          jcr:primaryType: hipposysedit:nodetype
-          jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          hipposysedit:node: true
-          hipposysedit:supertype: ['hippotranslation:translated', 'hippotaxonomy:classifiable',
-            'publicationsystem:basedocument', 'hippostd:relaxed']
-          hipposysedit:uri: http://digital.nhs.uk/jcr/publicationsystem/nt/1.0
-          /summary:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:Summary
-            hipposysedit:primary: false
-            hipposysedit:type: Text
-            hipposysedit:validators: [non-empty, required, publicationsystem-summary]
-          /key_facts:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:KeyFacts
-            hipposysedit:primary: false
-            hipposysedit:type: Text
-          /information_type:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: true
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:InformationType
-            hipposysedit:primary: false
-            hipposysedit:type: StaticDropdown
-            hipposysedit:validators: [non-empty, required]
-          /nominal_date:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:NominalDate
-            hipposysedit:primary: false
-            hipposysedit:type: CalendarDate
-          /coverage_start:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:CoverageStart
-            hipposysedit:primary: false
-            hipposysedit:type: CalendarDate
-          /coverage_end:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:CoverageEnd
-            hipposysedit:primary: false
-            hipposysedit:type: CalendarDate
-          /geographic_coverage:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:GeographicCoverage
-            hipposysedit:primary: false
-            hipposysedit:type: StaticDropdown
-          /granularity:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: true
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:Granularity
-            hipposysedit:primary: false
-            hipposysedit:type: StaticDropdown
-            hipposysedit:validators: [publicationsystem-blank-granularity]
-          /related_links:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: true
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:RelatedLinks
-            hipposysedit:primary: false
-            hipposysedit:type: publicationsystem:relatedlink
-            hipposysedit:validators: [publicationsystem-blank-related-link]
-          /administrative_sources:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:AdministrativeSources
-            hipposysedit:primary: false
-            hipposysedit:type: Text
-          /title:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: true
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:Title
-            hipposysedit:primary: false
-            hipposysedit:type: String
-            hipposysedit:validators: [non-empty, required, publicationsystem-title]
-          /attachments:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: true
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:attachments
-            hipposysedit:primary: false
-            hipposysedit:type: hippo:resource
-            hipposysedit:validators: [publicationsystem-blank-attachment]
-          /publicly_accessible:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:PubliclyAccessible
-            hipposysedit:primary: false
-            hipposysedit:type: selection:BooleanRadioGroup
-            hipposysedit:validators: [required]
+      /editor:templates:
+        /_default_:
+          /AdministrativeSources:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Administrative Sources
+            field: administrative_sources
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.css:
+            - administrative-sources
+            wicket.id: ${cluster.id}.left.item
+          /CoverageEnd:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Coverage End
+            field: coverage_end
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.css:
+            - coverage-end
+            wicket.id: ${cluster.id}.right.item
+          /CoverageStart:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Coverage Start
+            field: coverage_start
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.css:
+            - coverage-start
+            wicket.id: ${cluster.id}.right.item
+          /GeographicCoverage:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+              selectable.options: England,England and Northern Ireland,England and
+                Scotland,England and Wales,England Scotland and Northern Ireland,England
+                Wales and Northern Ireland,Great Britain,International,Northern Ireland,Scotland,UK,Wales
+            caption: Geographic Coverage
+            field: geographic_coverage
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.css:
+            - geographic-coverage
+            wicket.id: ${cluster.id}.right.item
+          /Granularity:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+              selectable.options: Ambulance Trusts,Cancer networks,Care Trusts,Census
+                Area Statistics Wards,Clinical Commissioning Groups,Community health
+                services,Councils with Social Services Responsibilities,Country,County,Dental
+                practices,Government Office Regions,GP practices,Health Education
+                England Region,Hospital and Community Health Services,Hospital Trusts,Independent
+                Sector Health Care Providers,Local Authorities,Mental Health Trusts,Middle
+                Layer Super Output Areas,NHS Health Boards,NHS Trusts,Parliamentary
+                constituency,Pharmacies and clinics,Primary Care Organisations,Primary
+                Care Trusts,Regional health body,Regions,Strategic Health Authorities,Sustainability
+                and Transformation Partnerships
+            caption: Granularity
+            field: granularity
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.css:
+            - granularity
+            wicket.id: ${cluster.id}.right.item
+          /InformationType:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+              selectable.options: Audit,Experimental statistics,National statistics,Official
+                statistics,Open data,Other reports and statistics,Survey
+            caption: Information Type
+            field: information_type
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.css:
+            - information-type
+            wicket.id: ${cluster.id}.right.item
+          /KeyFacts:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Key Facts
+            field: key_facts
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.css:
+            - key-facts
+            wicket.id: ${cluster.id}.left.item
+          /NominalDate:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Nominal Publication Date
+            field: nominal_date
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.css:
+            - nominal-date
+            wicket.id: ${cluster.id}.right.item
+          /RelatedLinks:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Related Links
+            field: related_links
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.css:
+            - related-links
+            wicket.id: ${cluster.id}.left.item
           /ResourceLinks:
-            jcr:primaryType: hipposysedit:field
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Resource Links
+            field: ResourceLinks
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.left.item
+          /Summary:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+              rows: ''
+            caption: Summary
+            field: summary
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.css:
+            - publication-summary
+            wicket.id: ${cluster.id}.left.item
+          /Title:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Title
+            field: title
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.css:
+            - publication-title
+            wicket.id: ${cluster.id}.left.item
+          /attachments:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Attachments
+            field: attachments
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.css:
+            - attachments
+            wicket.id: ${cluster.id}.left.item
+          /classifiable:
+            /cluster.options:
+              caption: Taxonomy
+              jcr:primaryType: frontend:pluginconfig
+              taxonomy.name: publication_taxonomy
+            essentials-taxonomy-name: publication_taxonomy
+            jcr:primaryType: frontend:plugin
+            mixin: hippotaxonomy:classifiable
+            plugin.class: org.hippoecm.frontend.editor.plugins.mixin.MixinLoaderPlugin
+            wicket.id: ${cluster.id}.right.item
+          /left:
+            item: ${cluster.id}.left.item
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+            wicket.id: ${cluster.id}.left
+          /publicly_accessible:
+            /cluster.options:
+              falseLabel: UPCOMING (Show in upcoming publications list only)
+              jcr:primaryType: frontend:pluginconfig
+              trueLabel: LIVE (Full content publicly accessible)
+            caption: Publicly Accessible
+            field: publicly_accessible
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.left.item
+          /right:
+            item: ${cluster.id}.right.item
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+            wicket.id: ${cluster.id}.right
+          /root:
+            extension.left: ${cluster.id}.left
+            extension.right: ${cluster.id}.right
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.layout.TwoColumn
+            wicket.extensions:
+            - extension.left
+            - extension.right
+          frontend:properties:
+          - mode
+          frontend:references:
+          - wicket.model
+          - model.compareTo
+          - engine
+          - validator.id
+          frontend:services:
+          - wicket.id
+          - validator.id
+          jcr:primaryType: frontend:plugincluster
+        jcr:primaryType: editor:templateset
+      /hipposysedit:nodetype:
+        /hipposysedit:nodetype:
+          /ResourceLinks:
             hipposysedit:mandatory: false
             hipposysedit:multiple: true
             hipposysedit:ordered: false
             hipposysedit:path: publicationsystem:ResourceLinks
             hipposysedit:primary: false
             hipposysedit:type: publicationsystem:relatedlink
+            jcr:primaryType: hipposysedit:field
+          /administrative_sources:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:AdministrativeSources
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          /attachments:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: true
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:attachments
+            hipposysedit:primary: false
+            hipposysedit:type: hippo:resource
+            hipposysedit:validators:
+            - publicationsystem-blank-attachment
+            jcr:primaryType: hipposysedit:field
+          /coverage_end:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:CoverageEnd
+            hipposysedit:primary: false
+            hipposysedit:type: CalendarDate
+            jcr:primaryType: hipposysedit:field
+          /coverage_start:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:CoverageStart
+            hipposysedit:primary: false
+            hipposysedit:type: CalendarDate
+            jcr:primaryType: hipposysedit:field
+          /geographic_coverage:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:GeographicCoverage
+            hipposysedit:primary: false
+            hipposysedit:type: StaticDropdown
+            jcr:primaryType: hipposysedit:field
+          /granularity:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: true
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:Granularity
+            hipposysedit:primary: false
+            hipposysedit:type: StaticDropdown
+            hipposysedit:validators:
+            - publicationsystem-blank-granularity
+            jcr:primaryType: hipposysedit:field
+          /information_type:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: true
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:InformationType
+            hipposysedit:primary: false
+            hipposysedit:type: StaticDropdown
+            hipposysedit:validators:
+            - non-empty
+            - required
+            jcr:primaryType: hipposysedit:field
+          /key_facts:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:KeyFacts
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          /nominal_date:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:NominalDate
+            hipposysedit:primary: false
+            hipposysedit:type: CalendarDate
+            jcr:primaryType: hipposysedit:field
+          /publicly_accessible:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:PubliclyAccessible
+            hipposysedit:primary: false
+            hipposysedit:type: selection:BooleanRadioGroup
+            hipposysedit:validators:
+            - required
+            jcr:primaryType: hipposysedit:field
+          /related_links:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: true
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:RelatedLinks
+            hipposysedit:primary: false
+            hipposysedit:type: publicationsystem:relatedlink
+            hipposysedit:validators:
+            - publicationsystem-blank-related-link
+            jcr:primaryType: hipposysedit:field
+          /summary:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:Summary
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            hipposysedit:validators:
+            - non-empty
+            - required
+            - publicationsystem-summary
+            jcr:primaryType: hipposysedit:field
+          /title:
+            hipposysedit:mandatory: true
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:Title
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            hipposysedit:validators:
+            - non-empty
+            - required
+            - publicationsystem-title
+            jcr:primaryType: hipposysedit:field
+          hipposysedit:node: true
+          hipposysedit:supertype:
+          - hippotranslation:translated
+          - hippotaxonomy:classifiable
+          - publicationsystem:basedocument
+          - hippostd:relaxed
+          hipposysedit:uri: http://digital.nhs.uk/jcr/publicationsystem/nt/1.0
+          jcr:mixinTypes:
+          - mix:referenceable
+          - hipposysedit:remodel
+          jcr:primaryType: hipposysedit:nodetype
+        jcr:mixinTypes:
+        - mix:referenceable
+        jcr:primaryType: hippo:handle
       /hipposysedit:prototypes:
-        jcr:primaryType: hipposysedit:prototypeset
         /hipposysedit:prototype:
-          jcr:primaryType: publicationsystem:publication
-          jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
           hippostd:holder: holder
           hippostd:state: draft
           hippostdpubwf:createdBy: ''
-          hippostdpubwf:creationDate: 2017-09-26T16:14:40.972+01:00
-          hippostdpubwf:lastModificationDate: 2017-09-26T16:14:40.971+01:00
+          hippostdpubwf:creationDate: 2017-09-26T15:14:40.972Z
+          hippostdpubwf:lastModificationDate: 2017-09-26T15:14:40.971Z
           hippostdpubwf:lastModifiedBy: ''
           hippotranslation:id: document-type-locale-id
           hippotranslation:locale: document-type-locale
+          jcr:mixinTypes:
+          - hippotaxonomy:classifiable
+          - mix:referenceable
+          jcr:primaryType: publicationsystem:publication
           publicationsystem:AdministrativeSources: ''
           publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
           publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-          publicationsystem:InformationType: ['']
+          publicationsystem:InformationType:
+          - ''
           publicationsystem:KeyFacts: ''
           publicationsystem:NominalDate: 0001-01-01T12:00:00Z
+          publicationsystem:PubliclyAccessible: false
           publicationsystem:Summary: ''
           publicationsystem:Title: ''
-          publicationsystem:PubliclyAccessible: false
-      /editor:templates:
-        jcr:primaryType: editor:templateset
-        /_default_:
-          jcr:primaryType: frontend:plugincluster
-          frontend:properties: [mode]
-          frontend:references: [wicket.model, model.compareTo, engine, validator.id]
-          frontend:services: [wicket.id, validator.id]
-          /root:
-            jcr:primaryType: frontend:plugin
-            extension.left: ${cluster.id}.left
-            extension.right: ${cluster.id}.right
-            plugin.class: org.hippoecm.frontend.editor.layout.TwoColumn
-            wicket.extensions: [extension.left, extension.right]
-          /left:
-            jcr:primaryType: frontend:plugin
-            item: ${cluster.id}.left.item
-            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
-            wicket.id: ${cluster.id}.left
-          /right:
-            jcr:primaryType: frontend:plugin
-            item: ${cluster.id}.right.item
-            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
-            wicket.id: ${cluster.id}.right
-          /InformationType:
-            jcr:primaryType: frontend:plugin
-            caption: Information Type
-            field: information_type
-            hint: ''
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.css: [information-type]
-            wicket.id: ${cluster.id}.right.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-              selectable.options: Audit,Experimental statistics,National statistics,Official
-                statistics,Open data,Other reports and statistics,Survey
-          /classifiable:
-            jcr:primaryType: frontend:plugin
-            essentials-taxonomy-name: publication_taxonomy
-            mixin: hippotaxonomy:classifiable
-            plugin.class: org.hippoecm.frontend.editor.plugins.mixin.MixinLoaderPlugin
-            wicket.id: ${cluster.id}.right.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-              caption: Taxonomy
-              taxonomy.name: publication_taxonomy
-          /NominalDate:
-            jcr:primaryType: frontend:plugin
-            caption: Nominal Publication Date
-            field: nominal_date
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.css: [nominal-date]
-            wicket.id: ${cluster.id}.right.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /Title:
-            jcr:primaryType: frontend:plugin
-            caption: Title
-            field: title
-            hint: ''
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.css: [publication-title]
-            wicket.id: ${cluster.id}.left.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /publicly_accessible:
-            jcr:primaryType: frontend:plugin
-            caption: Publicly Accessible
-            field: publicly_accessible
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.left.item
-            hint: ''
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-              trueLabel: LIVE (Full content publicly accessible)
-              falseLabel: UPCOMING (Show in upcoming publications list only)
-          /Summary:
-            jcr:primaryType: frontend:plugin
-            caption: Summary
-            field: summary
-            hint: ''
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.css: [publication-summary]
-            wicket.id: ${cluster.id}.left.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-              rows: ''
-          /CoverageStart:
-            jcr:primaryType: frontend:plugin
-            caption: Coverage Start
-            field: coverage_start
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.css: [coverage-start]
-            wicket.id: ${cluster.id}.right.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /CoverageEnd:
-            jcr:primaryType: frontend:plugin
-            caption: Coverage End
-            field: coverage_end
-            hint: ''
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.css: [coverage-end]
-            wicket.id: ${cluster.id}.right.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /GeographicCoverage:
-            jcr:primaryType: frontend:plugin
-            caption: Geographic Coverage
-            field: geographic_coverage
-            hint: ''
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.css: [geographic-coverage]
-            wicket.id: ${cluster.id}.right.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-              selectable.options: England,England and Northern Ireland,England and Scotland,England
-                and Wales,England Scotland and Northern Ireland,England Wales and Northern
-                Ireland,Great Britain,International,Northern Ireland,Scotland,UK,Wales
-          /Granularity:
-            jcr:primaryType: frontend:plugin
-            caption: Granularity
-            field: granularity
-            hint: ''
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.css: [granularity]
-            wicket.id: ${cluster.id}.right.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-              selectable.options: Ambulance Trusts,Cancer networks,Care Trusts,Census
-                Area Statistics Wards,Clinical Commissioning Groups,Community health services,Councils
-                with Social Services Responsibilities,Country,County,Dental practices,Government Office
-                Regions,GP practices,Health Education England Region,Hospital and Community Health
-                Services,Hospital Trusts,Independent Sector Health Care Providers,Local Authorities,Mental
-                Health Trusts,Middle Layer Super Output Areas,NHS Health Boards,NHS Trusts,Parliamentary
-                constituency,Pharmacies and clinics,Primary Care Organisations,Primary Care Trusts,Regional
-                health body,Regions,Strategic Health Authorities,Sustainability and Transformation
-                Partnerships
-          /KeyFacts:
-            jcr:primaryType: frontend:plugin
-            caption: Key Facts
-            field: key_facts
-            hint: ''
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.css: [key-facts]
-            wicket.id: ${cluster.id}.left.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /attachments:
-            jcr:primaryType: frontend:plugin
-            caption: Attachments
-            field: attachments
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
-            wicket.css: [attachments]
-            wicket.id: ${cluster.id}.left.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /ResourceLinks:
-            jcr:primaryType: frontend:plugin
-            caption: Resource Links
-            field: ResourceLinks
-            hint: ''
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
-            wicket.id: ${cluster.id}.left.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /RelatedLinks:
-            jcr:primaryType: frontend:plugin
-            caption: Related Links
-            field: related_links
-            hint: ''
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
-            wicket.css: [related-links]
-            wicket.id: ${cluster.id}.left.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /AdministrativeSources:
-            jcr:primaryType: frontend:plugin
-            caption: Administrative Sources
-            field: administrative_sources
-            hint: ''
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.css: [administrative-sources]
-            wicket.id: ${cluster.id}.left.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
+        jcr:primaryType: hipposysedit:prototypeset
+      jcr:mixinTypes:
+      - editor:editable
+      - mix:referenceable
+      jcr:primaryType: hipposysedit:templatetype

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/relatedlink.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/relatedlink.yaml
@@ -1,70 +1,88 @@
 ---
-
 definitions:
   config:
     /hippo:namespaces/publicationsystem/relatedlink:
-      jcr:primaryType: hipposysedit:templatetype
-      jcr:mixinTypes: ['editor:editable', 'mix:referenceable']
+      /editor:templates:
+        /_default_:
+          /linkText:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Link Text
+            field: link_text
+            hint: If not provided, the URL will be displayed
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.css:
+            - link-text
+            wicket.id: ${cluster.id}.field
+          /linkUrl:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Link URL
+            field: link_url
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.css:
+            - link-url
+            wicket.id: ${cluster.id}.field
+          /root:
+            item: ${cluster.id}.field
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+          frontend:properties:
+          - mode
+          frontend:references:
+          - wicket.model
+          - model.compareTo
+          - engine
+          - validator.id
+          frontend:services:
+          - wicket.id
+          - validator.id
+          jcr:primaryType: frontend:plugincluster
+        jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
-        jcr:primaryType: hippo:handle
-        jcr:mixinTypes: ['mix:referenceable']
         /hipposysedit:nodetype:
-          jcr:primaryType: hipposysedit:nodetype
-          jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          hipposysedit:node: true
-          hipposysedit:supertype: ['hippo:compound', 'hippostd:relaxed']
-          hipposysedit:uri: http://digital.nhs.uk/jcr/publicationsystem/nt/1.0
           /link_text:
-            jcr:primaryType: hipposysedit:field
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
             hipposysedit:ordered: false
             hipposysedit:path: publicationsystem:linkText
             hipposysedit:primary: false
             hipposysedit:type: String
-          /link_url:
             jcr:primaryType: hipposysedit:field
+          /link_url:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
             hipposysedit:ordered: false
             hipposysedit:path: publicationsystem:linkUrl
             hipposysedit:primary: false
             hipposysedit:type: String
-            hipposysedit:validators: [non-empty, required, valid-url]
+            hipposysedit:validators:
+            - non-empty
+            - required
+            - valid-url
+            jcr:primaryType: hipposysedit:field
+          hipposysedit:node: true
+          hipposysedit:supertype:
+          - hippo:compound
+          - hippostd:relaxed
+          hipposysedit:uri: http://digital.nhs.uk/jcr/publicationsystem/nt/1.0
+          jcr:mixinTypes:
+          - mix:referenceable
+          - hipposysedit:remodel
+          jcr:primaryType: hipposysedit:nodetype
+        jcr:mixinTypes:
+        - mix:referenceable
+        jcr:primaryType: hippo:handle
       /hipposysedit:prototypes:
-        jcr:primaryType: hipposysedit:prototypeset
         /hipposysedit:prototype:
           jcr:primaryType: publicationsystem:relatedlink
-          publicationsystem:linkUrl: ''
           publicationsystem:linkText: ''
-      /editor:templates:
-        jcr:primaryType: editor:templateset
-        /_default_:
-          jcr:primaryType: frontend:plugincluster
-          frontend:properties: [mode]
-          frontend:references: [wicket.model, model.compareTo, engine, validator.id]
-          frontend:services: [wicket.id, validator.id]
-          /root:
-            jcr:primaryType: frontend:plugin
-            item: ${cluster.id}.field
-            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
-          /linkText:
-            jcr:primaryType: frontend:plugin
-            caption: Link Text
-            field: link_text
-            hint: If not provided, the URL will be displayed
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.css: [link-text]
-            wicket.id: ${cluster.id}.field
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /linkUrl:
-            jcr:primaryType: frontend:plugin
-            caption: Link URL
-            field: link_url
-            hint: ''
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.css: [link-url]
-            wicket.id: ${cluster.id}.field
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
+          publicationsystem:linkUrl: ''
+        jcr:primaryType: hipposysedit:prototypeset
+      jcr:mixinTypes:
+      - editor:editable
+      - mix:referenceable
+      jcr:primaryType: hipposysedit:templatetype

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/series.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/series.yaml
@@ -1,92 +1,114 @@
 ---
-
 definitions:
   config:
     /hippo:namespaces/publicationsystem/series:
-      jcr:primaryType: hipposysedit:templatetype
-      jcr:mixinTypes: ['editor:editable', 'mix:referenceable']
-      /hipposysedit:nodetype:
-        jcr:primaryType: hippo:handle
-        jcr:mixinTypes: ['mix:referenceable']
-        /hipposysedit:nodetype:
-          jcr:primaryType: hipposysedit:nodetype
-          jcr:mixinTypes: ['mix:referenceable', 'hipposysedit:remodel']
-          hipposysedit:node: true
-          hipposysedit:supertype: ['publicationsystem:basedocument', 'hippostd:relaxed',
-            'hippotranslation:translated']
-          hipposysedit:uri: http://digital.nhs.uk/jcr/publicationsystem/nt/1.0
-          /title:
-            jcr:primaryType: hipposysedit:field
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:Title
-            hipposysedit:primary: false
-            hipposysedit:type: Text
-            hipposysedit:validators: [non-empty, required, publicationsystem-title]
+      /editor:templates:
+        /_default_:
           /Summary:
-            jcr:primaryType: hipposysedit:field
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Summary
+            field: Summary
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.left.item
+          /Title:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Title
+            field: title
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.left.item
+          /left:
+            item: ${cluster.id}.left.item
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+            wicket.id: ${cluster.id}.left
+          /right:
+            item: ${cluster.id}.right.item
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+            wicket.id: ${cluster.id}.right
+          /root:
+            extension.left: ${cluster.id}.left
+            extension.right: ${cluster.id}.right
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.layout.TwoColumn
+            wicket.extensions:
+            - extension.left
+            - extension.right
+          frontend:properties:
+          - mode
+          frontend:references:
+          - wicket.model
+          - model.compareTo
+          - engine
+          - validator.id
+          frontend:services:
+          - wicket.id
+          - validator.id
+          jcr:primaryType: frontend:plugincluster
+        jcr:primaryType: editor:templateset
+      /hipposysedit:nodetype:
+        /hipposysedit:nodetype:
+          /Summary:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
             hipposysedit:ordered: false
             hipposysedit:path: publicationsystem:Summary
             hipposysedit:primary: false
             hipposysedit:type: Text
-            hipposysedit:validators: [non-empty, required, publicationsystem-summary]
+            hipposysedit:validators:
+            - non-empty
+            - required
+            - publicationsystem-summary
+            jcr:primaryType: hipposysedit:field
+          /title:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:Title
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            hipposysedit:validators:
+            - non-empty
+            - required
+            - publicationsystem-title
+            jcr:primaryType: hipposysedit:field
+          hipposysedit:node: true
+          hipposysedit:supertype:
+          - publicationsystem:basedocument
+          - hippostd:relaxed
+          - hippotranslation:translated
+          hipposysedit:uri: http://digital.nhs.uk/jcr/publicationsystem/nt/1.0
+          jcr:mixinTypes:
+          - mix:referenceable
+          - hipposysedit:remodel
+          jcr:primaryType: hipposysedit:nodetype
+        jcr:mixinTypes:
+        - mix:referenceable
+        jcr:primaryType: hippo:handle
       /hipposysedit:prototypes:
-        jcr:primaryType: hipposysedit:prototypeset
         /hipposysedit:prototype:
-          jcr:primaryType: publicationsystem:series
-          jcr:mixinTypes: ['mix:referenceable']
           hippostd:holder: holder
           hippostd:state: draft
           hippostdpubwf:createdBy: ''
-          hippostdpubwf:creationDate: 2017-10-16T12:49:42.988+02:00
-          hippostdpubwf:lastModificationDate: 2017-10-16T12:49:42.988+02:00
+          hippostdpubwf:creationDate: 2017-10-16T10:49:42.988Z
+          hippostdpubwf:lastModificationDate: 2017-10-16T10:49:42.988Z
           hippostdpubwf:lastModifiedBy: ''
           hippotranslation:id: document-type-locale-id
           hippotranslation:locale: document-type-locale
+          jcr:mixinTypes:
+          - mix:referenceable
+          jcr:primaryType: publicationsystem:series
           publicationsystem:Summary: ''
           publicationsystem:Title: ''
           publicationsystem:title: ''
-      /editor:templates:
-        jcr:primaryType: editor:templateset
-        /_default_:
-          jcr:primaryType: frontend:plugincluster
-          frontend:properties: [mode]
-          frontend:references: [wicket.model, model.compareTo, engine, validator.id]
-          frontend:services: [wicket.id, validator.id]
-          /root:
-            jcr:primaryType: frontend:plugin
-            extension.left: ${cluster.id}.left
-            extension.right: ${cluster.id}.right
-            plugin.class: org.hippoecm.frontend.editor.layout.TwoColumn
-            wicket.extensions: [extension.left, extension.right]
-          /left:
-            jcr:primaryType: frontend:plugin
-            item: ${cluster.id}.left.item
-            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
-            wicket.id: ${cluster.id}.left
-          /right:
-            jcr:primaryType: frontend:plugin
-            item: ${cluster.id}.right.item
-            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
-            wicket.id: ${cluster.id}.right
-          /Title:
-            jcr:primaryType: frontend:plugin
-            caption: Title
-            field: title
-            hint: ''
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.left.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-          /Summary:
-            jcr:primaryType: frontend:plugin
-            caption: Summary
-            field: Summary
-            hint: ''
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.left.item
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
+        jcr:primaryType: hipposysedit:prototypeset
+      jcr:mixinTypes:
+      - editor:editable
+      - mix:referenceable
+      jcr:primaryType: hipposysedit:templatetype

--- a/repository-data/application/src/main/resources/hcm-config/security/configuser-read-everywhere.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/security/configuser-read-everywhere.yaml
@@ -1,6 +1,8 @@
+---
 definitions:
   config:
     /hippo:configuration/hippo:domains/everywhere/readonly:
-      jcr:primaryType: hipposys:authrole
       hipposys:role: readonly
-      hipposys:users: [configuser]
+      hipposys:users:
+      - configuser
+      jcr:primaryType: hipposys:authrole

--- a/repository-data/application/src/main/resources/hcm-config/security/group-liveusers.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/security/group-liveusers.yaml
@@ -1,7 +1,9 @@
+---
 definitions:
   config:
     /hippo:configuration/hippo:groups/liveusers:
-      jcr:primaryType: hipposys:group
-      hipposys:members: [liveuser]
+      hipposys:members:
+      - liveuser
       hipposys:securityprovider: internal
       hipposys:system: true
+      jcr:primaryType: hipposys:group

--- a/repository-data/application/src/main/resources/hcm-config/security/group-previewusers.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/security/group-previewusers.yaml
@@ -1,7 +1,9 @@
+---
 definitions:
   config:
     /hippo:configuration/hippo:groups/previewusers:
-      jcr:primaryType: hipposys:group
-      hipposys:members: [previewuser]
+      hipposys:members:
+      - previewuser
       hipposys:securityprovider: internal
       hipposys:system: true
+      jcr:primaryType: hipposys:group

--- a/repository-data/application/src/main/resources/hcm-config/security/group-sitewriters.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/security/group-sitewriters.yaml
@@ -1,7 +1,9 @@
+---
 definitions:
   config:
     /hippo:configuration/hippo:groups/sitewriters:
-      jcr:primaryType: hipposys:group
-      hipposys:members: [sitewriter]
+      hipposys:members:
+      - sitewriter
       hipposys:securityprovider: internal
       hipposys:system: true
+      jcr:primaryType: hipposys:group

--- a/repository-data/application/src/main/resources/hcm-config/security/user-author.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/security/user-author.yaml
@@ -1,7 +1,8 @@
+---
 definitions:
   config:
     /hippo:configuration/hippo:users/author:
-      jcr:primaryType: hipposys:user
       hipposys:active: true
       hipposys:password: author
       hipposys:securityprovider: internal
+      jcr:primaryType: hipposys:user

--- a/repository-data/application/src/main/resources/hcm-config/security/user-configuser.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/security/user-configuser.yaml
@@ -1,8 +1,9 @@
+---
 definitions:
   config:
     /hippo:configuration/hippo:users/configuser:
-      jcr:primaryType: hipposys:user
       hipposys:active: true
       hipposys:passkey: jvm://
       hipposys:securityprovider: internal
       hipposys:system: true
+      jcr:primaryType: hipposys:user

--- a/repository-data/application/src/main/resources/hcm-config/security/user-editor.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/security/user-editor.yaml
@@ -1,7 +1,8 @@
+---
 definitions:
   config:
     /hippo:configuration/hippo:users/editor:
-      jcr:primaryType: hipposys:user
       hipposys:active: true
       hipposys:password: editor
       hipposys:securityprovider: internal
+      jcr:primaryType: hipposys:user

--- a/repository-data/application/src/main/resources/hcm-config/security/user-liveuser.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/security/user-liveuser.yaml
@@ -1,8 +1,9 @@
+---
 definitions:
   config:
     /hippo:configuration/hippo:users/liveuser:
-      jcr:primaryType: hipposys:user
       hipposys:active: true
       hipposys:passkey: jvm://
       hipposys:securityprovider: internal
       hipposys:system: true
+      jcr:primaryType: hipposys:user

--- a/repository-data/application/src/main/resources/hcm-config/security/user-previewuser.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/security/user-previewuser.yaml
@@ -1,8 +1,9 @@
+---
 definitions:
   config:
     /hippo:configuration/hippo:users/previewuser:
-      jcr:primaryType: hipposys:user
       hipposys:active: true
       hipposys:passkey: jvm://
       hipposys:securityprovider: internal
       hipposys:system: true
+      jcr:primaryType: hipposys:user

--- a/repository-data/application/src/main/resources/hcm-config/security/user-sitewriter.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/security/user-sitewriter.yaml
@@ -1,8 +1,9 @@
+---
 definitions:
   config:
     /hippo:configuration/hippo:users/sitewriter:
-      jcr:primaryType: hipposys:user
       hipposys:active: true
       hipposys:passkey: jvm://
       hipposys:securityprovider: internal
       hipposys:system: true
+      jcr:primaryType: hipposys:user

--- a/repository-data/application/src/main/resources/hcm-config/security/webfiles.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/security/webfiles.yaml
@@ -1,17 +1,22 @@
+---
 definitions:
   config:
     /hippo:configuration/hippo:domains/webfiles:
-      jcr:primaryType: hipposys:domain
       /readonly:
-        jcr:primaryType: hipposys:authrole
-        hipposys:groups: [liveusers, previewusers, sitewriters, webmaster]
+        hipposys:groups:
+        - liveusers
+        - previewusers
+        - sitewriters
+        - webmaster
         hipposys:role: readonly
+        jcr:primaryType: hipposys:authrole
       /webfiles-domain:
-        jcr:primaryType: hipposys:domainrule
         /read-webfiles-and-descendants:
-          jcr:primaryType: hipposys:facetrule
           hipposys:equals: true
           hipposys:facet: jcr:path
           hipposys:filter: false
           hipposys:type: Reference
           hipposys:value: /webfiles
+          jcr:primaryType: hipposys:facetrule
+        jcr:primaryType: hipposys:domainrule
+      jcr:primaryType: hipposys:domain

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration.yaml
@@ -1,7 +1,10 @@
 ---
-
 /content/documents/administration:
-  jcr:primaryType: hippostd:folder
-  jcr:mixinTypes: ['hippo:named', 'mix:versionable']
   hippo:name: Administration
-  hippostd:foldertype: [new-document, new-folder]
+  hippostd:foldertype:
+  - new-document
+  - new-folder
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/document-types.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/document-types.yaml
@@ -1,49 +1,80 @@
 ---
-
 /content/documents/administration/document-types:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
-  hippo:name: document types
   /document-types[1]:
-    jcr:primaryType: resourcebundle:resourcebundle
-    jcr:mixinTypes: ['mix:referenceable']
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-13T15:45:35.124Z
     hippostdpubwf:lastModificationDate: 2017-11-13T15:45:45.078Z
     hippostdpubwf:lastModifiedBy: admin
-    resourcebundle:descriptions: ['', '', '']
-    resourcebundle:id: document-types
-    resourcebundle:keys: ['publicationsystem:series', 'publicationsystem:dataset',
-      'publicationsystem:publication']
-    resourcebundle:messages: [Series, Data Set, Statistical Publication]
-  /document-types[2]:
+    jcr:mixinTypes:
+    - mix:referenceable
     jcr:primaryType: resourcebundle:resourcebundle
-    jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    resourcebundle:descriptions:
+    - ''
+    - ''
+    - ''
+    resourcebundle:id: document-types
+    resourcebundle:keys:
+    - publicationsystem:series
+    - publicationsystem:dataset
+    - publicationsystem:publication
+    resourcebundle:messages:
+    - Series
+    - Data Set
+    - Statistical Publication
+  /document-types[2]:
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-13T15:45:35.124Z
     hippostdpubwf:lastModificationDate: 2017-11-13T15:46:41.341Z
     hippostdpubwf:lastModifiedBy: admin
-    resourcebundle:descriptions: ['', '', '']
-    resourcebundle:id: document-types
-    resourcebundle:keys: ['publicationsystem:series', 'publicationsystem:dataset',
-      'publicationsystem:publication']
-    resourcebundle:messages: [Series, Data Set, Statistical Publication]
-  /document-types[3]:
+    jcr:mixinTypes:
+    - mix:referenceable
+    - mix:versionable
     jcr:primaryType: resourcebundle:resourcebundle
-    jcr:mixinTypes: ['mix:referenceable']
-    hippo:availability: [live]
+    resourcebundle:descriptions:
+    - ''
+    - ''
+    - ''
+    resourcebundle:id: document-types
+    resourcebundle:keys:
+    - publicationsystem:series
+    - publicationsystem:dataset
+    - publicationsystem:publication
+    resourcebundle:messages:
+    - Series
+    - Data Set
+    - Statistical Publication
+  /document-types[3]:
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-13T15:45:35.124Z
     hippostdpubwf:lastModificationDate: 2017-11-13T15:46:41.341Z
     hippostdpubwf:lastModifiedBy: admin
     hippostdpubwf:publicationDate: 2017-11-13T15:46:44.074Z
-    resourcebundle:descriptions: ['', '', '']
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: resourcebundle:resourcebundle
+    resourcebundle:descriptions:
+    - ''
+    - ''
+    - ''
     resourcebundle:id: document-types
-    resourcebundle:keys: ['publicationsystem:series', 'publicationsystem:dataset',
-      'publicationsystem:publication']
-    resourcebundle:messages: [Series, Data Set, Statistical Publication]
+    resourcebundle:keys:
+    - publicationsystem:series
+    - publicationsystem:dataset
+    - publicationsystem:publication
+    resourcebundle:messages:
+    - Series
+    - Data Set
+    - Statistical Publication
+  hippo:name: document types
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/month-names.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/month-names.yaml
@@ -1,52 +1,161 @@
 ---
-
 /content/documents/administration/month-names:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
-  hippo:name: month names
   /month-names[1]:
-    jcr:primaryType: resourcebundle:resourcebundle
-    jcr:mixinTypes: ['mix:referenceable']
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-01T21:05:32.191Z
     hippostdpubwf:lastModificationDate: 2017-11-01T21:05:32.192Z
     hippostdpubwf:lastModifiedBy: admin
-    resourcebundle:descriptions: ['', '', '', '', '', '', '', '', '', '', '', '']
-    resourcebundle:id: month-names
-    resourcebundle:keys: ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10',
-      '11']
-    resourcebundle:messages: [January, February, March, April, May, June, July,
-      August, September, October, November, December]
-  /month-names[2]:
+    jcr:mixinTypes:
+    - mix:referenceable
     jcr:primaryType: resourcebundle:resourcebundle
-    jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    resourcebundle:descriptions:
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    resourcebundle:id: month-names
+    resourcebundle:keys:
+    - '0'
+    - '1'
+    - '2'
+    - '3'
+    - '4'
+    - '5'
+    - '6'
+    - '7'
+    - '8'
+    - '9'
+    - '10'
+    - '11'
+    resourcebundle:messages:
+    - January
+    - February
+    - March
+    - April
+    - May
+    - June
+    - July
+    - August
+    - September
+    - October
+    - November
+    - December
+  /month-names[2]:
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-01T21:05:32.191Z
     hippostdpubwf:lastModificationDate: 2017-11-01T21:11:26.132Z
     hippostdpubwf:lastModifiedBy: admin
-    resourcebundle:descriptions: ['', '', '', '', '', '', '', '', '', '', '', '']
-    resourcebundle:id: month-names
-    resourcebundle:keys: ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10',
-      '11']
-    resourcebundle:messages: [January, February, March, April, May, June, July,
-      August, September, October, November, December]
-  /month-names[3]:
+    jcr:mixinTypes:
+    - mix:referenceable
+    - mix:versionable
     jcr:primaryType: resourcebundle:resourcebundle
-    jcr:mixinTypes: ['mix:referenceable']
-    hippo:availability: [live]
+    resourcebundle:descriptions:
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    resourcebundle:id: month-names
+    resourcebundle:keys:
+    - '0'
+    - '1'
+    - '2'
+    - '3'
+    - '4'
+    - '5'
+    - '6'
+    - '7'
+    - '8'
+    - '9'
+    - '10'
+    - '11'
+    resourcebundle:messages:
+    - January
+    - February
+    - March
+    - April
+    - May
+    - June
+    - July
+    - August
+    - September
+    - October
+    - November
+    - December
+  /month-names[3]:
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-01T21:05:32.191Z
     hippostdpubwf:lastModificationDate: 2017-11-01T21:11:26.132Z
     hippostdpubwf:lastModifiedBy: admin
     hippostdpubwf:publicationDate: 2017-11-01T21:11:35.762Z
-    resourcebundle:descriptions: ['', '', '', '', '', '', '', '', '', '', '', '']
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: resourcebundle:resourcebundle
+    resourcebundle:descriptions:
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
     resourcebundle:id: month-names
-    resourcebundle:keys: ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10',
-      '11']
-    resourcebundle:messages: [January, February, March, April, May, June, July,
-      August, September, October, November, December]
+    resourcebundle:keys:
+    - '0'
+    - '1'
+    - '2'
+    - '3'
+    - '4'
+    - '5'
+    - '6'
+    - '7'
+    - '8'
+    - '9'
+    - '10'
+    - '11'
+    resourcebundle:messages:
+    - January
+    - February
+    - March
+    - April
+    - May
+    - June
+    - July
+    - August
+    - September
+    - October
+    - November
+    - December
+  hippo:name: month names
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/publication-system.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/publication-system.yaml
@@ -1,6 +1,10 @@
 ---
 /content/documents/administration/publication-system:
-  jcr:primaryType: hippostd:folder
-  jcr:mixinTypes: ['hippo:named', 'mix:versionable']
   hippo:name: Publication System
-  hippostd:foldertype: [new-document, new-folder]
+  hippostd:foldertype:
+  - new-document
+  - new-folder
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/publication-system/headers.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/publication-system/headers.yaml
@@ -1,46 +1,80 @@
 ---
-
 /content/documents/administration/publication-system/headers:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
-  hippo:name: Headers
   /headers[1]:
-    jcr:primaryType: resourcebundle:resourcebundle
-    jcr:mixinTypes: ['mix:referenceable']
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-26T16:49:40.466+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-26T16:52:08.767+01:00
+    hippostdpubwf:creationDate: 2017-10-26T15:49:40.466Z
+    hippostdpubwf:lastModificationDate: 2017-10-26T15:52:08.767Z
     hippostdpubwf:lastModifiedBy: admin
-    resourcebundle:descriptions: ['']
-    resourcebundle:id: publicationsystem.headers
-    resourcebundle:keys: [headers.summary, headers.key-facts, headers.resources, headers.related-links]
-    resourcebundle:messages: [Summary, Key Facts, Resources, Related Links]
-  /headers[2]:
+    jcr:mixinTypes:
+    - mix:referenceable
     jcr:primaryType: resourcebundle:resourcebundle
-    jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    resourcebundle:descriptions:
+    - ''
+    resourcebundle:id: publicationsystem.headers
+    resourcebundle:keys:
+    - headers.summary
+    - headers.key-facts
+    - headers.resources
+    - headers.related-links
+    resourcebundle:messages:
+    - Summary
+    - Key Facts
+    - Resources
+    - Related Links
+  /headers[2]:
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-26T16:49:40.466+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-26T16:50:42.342+01:00
+    hippostdpubwf:creationDate: 2017-10-26T15:49:40.466Z
+    hippostdpubwf:lastModificationDate: 2017-10-26T15:50:42.342Z
     hippostdpubwf:lastModifiedBy: admin
-    resourcebundle:descriptions: ['']
-    resourcebundle:id: publicationsystem.headers
-    resourcebundle:keys: [headers.summary, headers.key-facts, headers.resources, headers.related-links]
-    resourcebundle:messages: [Summary, Key Facts, Resources, Related Links]
-  /headers[3]:
+    jcr:mixinTypes:
+    - mix:referenceable
+    - mix:versionable
     jcr:primaryType: resourcebundle:resourcebundle
-    jcr:mixinTypes: ['mix:referenceable']
-    hippo:availability: [live]
+    resourcebundle:descriptions:
+    - ''
+    resourcebundle:id: publicationsystem.headers
+    resourcebundle:keys:
+    - headers.summary
+    - headers.key-facts
+    - headers.resources
+    - headers.related-links
+    resourcebundle:messages:
+    - Summary
+    - Key Facts
+    - Resources
+    - Related Links
+  /headers[3]:
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-26T16:49:40.466+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-26T16:50:42.342+01:00
+    hippostdpubwf:creationDate: 2017-10-26T15:49:40.466Z
+    hippostdpubwf:lastModificationDate: 2017-10-26T15:50:42.342Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2017-10-26T16:50:46.950+01:00
-    resourcebundle:descriptions: ['']
+    hippostdpubwf:publicationDate: 2017-10-26T15:50:46.950Z
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: resourcebundle:resourcebundle
+    resourcebundle:descriptions:
+    - ''
     resourcebundle:id: publicationsystem.headers
-    resourcebundle:keys: [headers.summary, headers.key-facts, headers.resources, headers.related-links]
-    resourcebundle:messages: [Summary, Key Facts, Resources, Related Links]
+    resourcebundle:keys:
+    - headers.summary
+    - headers.key-facts
+    - headers.resources
+    - headers.related-links
+    resourcebundle:messages:
+    - Summary
+    - Key Facts
+    - Resources
+    - Related Links
+  hippo:name: Headers
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website.yaml
@@ -1,14 +1,14 @@
+---
 /content/documents/corporate-website:
-  jcr:primaryType: hippostd:folder
-  # DO NOT CHANGE. This is used in the facet configuration
-  jcr:uuid: 12345678-1234-1234-1234-123456789abc
-  jcr:mixinTypes:
-    - mix:versionable
-    - hippo:named
-    - hippotranslation:translated
   hippo:name: Corporate Website
   hippostd:foldertype:
-    - new-translated-folder
-    - new-document
+  - new-translated-folder
+  - new-document
   hippotranslation:id: 00000000-0000-0000-0000-000000000000
   hippotranslation:locale: en
+  jcr:mixinTypes:
+  - mix:versionable
+  - hippo:named
+  - hippotranslation:translated
+  jcr:primaryType: hippostd:folder
+  jcr:uuid: 12345678-1234-1234-1234-123456789abc

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/facet.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/facet.yaml
@@ -1,29 +1,27 @@
 ---
-
 /content/documents/corporate-website/facet:
-  jcr:primaryType: hippofacnav:facetnavigation
-  # this is hardcoded in the corporate-website folder node
   hippo:docbase: 12345678-1234-1234-1234-123456789abc
   hippofacnav:facetnodenames:
-    - DOCUMENT TYPE
-    - CATEGORY
-    - INFORMATION TYPE
-    - GEOGRAPHICAL COVERAGE
-    - GEOGRAPHICAL GRANULARITY
-    - 'YEAR${sortby:''facetvalue'', sortorder:''descending''}'
-    - 'MONTH${after:''YEAR'', sortby:''facetvalue'', sortorder:''descending'',hide:''YEAR''}'
-    - TIMEFRAME
+  - DOCUMENT TYPE
+  - CATEGORY
+  - INFORMATION TYPE
+  - GEOGRAPHICAL COVERAGE
+  - GEOGRAPHICAL GRANULARITY
+  - YEAR${sortby:'facetvalue', sortorder:'descending'}
+  - MONTH${after:'YEAR', sortby:'facetvalue', sortorder:'descending',hide:'YEAR'}
+  - TIMEFRAME
   hippofacnav:facets:
-    - 'jcr:primaryType'
-    - 'hippotaxonomy:keys'
-    - 'publicationsystem:InformationType'
-    - 'publicationsystem:GeographicCoverage'
-    - 'publicationsystem:Granularity'
-    - 'publicationsystem:NominalDate$year'
-    - 'publicationsystem:NominalDate$month'
-    - 'publicationsystem:NominalDate$[{name:''today'', resolution:''day'', begin:0, end:1},
-        {name:''yesterday'', resolution:''day'', begin:-1, end:0},{name:''this week'',
-        resolution:''week'', begin:0, end:1},{name:''this month'', resolution:''month'',
-        begin:0, end:1},{name:''this year'', resolution:''year'', begin:0, end:1},
-        {name:''before this year'', resolution:''year'', end:0}]'
+  - jcr:primaryType
+  - hippotaxonomy:keys
+  - publicationsystem:InformationType
+  - publicationsystem:GeographicCoverage
+  - publicationsystem:Granularity
+  - publicationsystem:NominalDate$year
+  - publicationsystem:NominalDate$month
+  - publicationsystem:NominalDate$[{name:'today', resolution:'day', begin:0, end:1},
+    {name:'yesterday', resolution:'day', begin:-1, end:0},{name:'this week', resolution:'week',
+    begin:0, end:1},{name:'this month', resolution:'month', begin:0, end:1},{name:'this
+    year', resolution:'year', begin:0, end:1}, {name:'before this year', resolution:'year',
+    end:0}]
   hippofacnav:limit: 100
+  jcr:primaryType: hippofacnav:facetnavigation

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/publication-system.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/publication-system.yaml
@@ -1,7 +1,13 @@
+---
 /content/documents/corporate-website/publication-system:
-  jcr:primaryType: hippostd:folder
-  jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']
   hippo:name: Publication System
-  hippostd:foldertype: [new-translated-folder, new-document]
+  hippostd:foldertype:
+  - new-translated-folder
+  - new-document
   hippotranslation:id: 00000000-0000-0000-0000-000000000000
   hippotranslation:locale: en
+  jcr:mixinTypes:
+  - hippo:named
+  - hippotranslation:translated
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/application/src/main/resources/hcm-content/content/gallery/publicationsystem.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/gallery/publicationsystem.yaml
@@ -1,7 +1,11 @@
+---
 /content/gallery/publicationsystem:
-  jcr:primaryType: hippogallery:stdImageGallery
-  jcr:mixinTypes: ['mix:referenceable', 'hippo:named']
-  hippostd:foldertype: [new-image-folder]
-  hippostd:gallerytype: ['hippogallery:imageset']
   hippo:name: NHS Digital Publication System
-
+  hippostd:foldertype:
+  - new-image-folder
+  hippostd:gallerytype:
+  - hippogallery:imageset
+  jcr:mixinTypes:
+  - mix:referenceable
+  - hippo:named
+  jcr:primaryType: hippogallery:stdImageGallery

--- a/repository-data/application/src/main/resources/hcm-content/hst/configurations/publicationsystem/channelinfo.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/hst/configurations/publicationsystem/channelinfo.yaml
@@ -1,2 +1,3 @@
+---
 /hst:hst/hst:configurations/publicationsystem/hst:workspace/hst:channel/hst:channelinfo:
   jcr:primaryType: hst:channelinfo

--- a/repository-data/application/src/main/resources/hcm-module.yaml
+++ b/repository-data/application/src/main/resources/hcm-module.yaml
@@ -1,9 +1,8 @@
+---
 group:
-  name: publicationsystem
   after: hippo-cms
-
-project: publicationsystem
-
+  name: publicationsystem
 module:
-  name: publication-system-repository-data-application
   after: publication-system-repository-data-webfiles
+  name: publication-system-repository-data-application
+project: publicationsystem

--- a/repository-data/development/pom.xml
+++ b/repository-data/development/pom.xml
@@ -37,6 +37,29 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmaven</groupId>
+                <artifactId>groovy-maven-plugin</artifactId>
+                <version>2.0</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>execute</goal>
+                        </goals>
+                        <configuration>
+                            <source>${project.basedir}/src/main/script/YamlFormatter.groovy</source>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.yaml</groupId>
+                        <artifactId>snakeyaml</artifactId>
+                        <version>1.19</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 

--- a/repository-data/development/src/main/resources/hcm-config/content/taxonomies/publication_taxonomy.yaml
+++ b/repository-data/development/src/main/resources/hcm-config/content/taxonomies/publication_taxonomy.yaml
@@ -1,968 +1,967 @@
 ---
-
 definitions:
   config:
     /content/taxonomies/publication_taxonomy:
       /publication_taxonomy[1]:
         /conditions:
-          jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: conditions
-          /hippotaxonomy:categoryinfos:
-            jcr:primaryType: hippotaxonomy:categoryinfos
-            /en:
-              jcr:primaryType: hippotaxonomy:categoryinfo
-              hippotaxonomy:name: Conditions
           /accidents-and-injuries:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: accidents-and-injuries
-            /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
-              /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
-                hippotaxonomy:name: Accidents and injuries
             /breaks-and-fractures:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: breaks-and-fractures
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Breaks and fractures
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: breaks-and-fractures
+              jcr:primaryType: hippotaxonomy:category
             /falls:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: falls
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Falls
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: falls
+              jcr:primaryType: hippotaxonomy:category
+            /hippotaxonomy:categoryinfos:
+              /en:
+                hippotaxonomy:name: Accidents and injuries
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
             /land-transport-accidents:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: land-transport-accidents
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Land transport accidents
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: land-transport-accidents
+              jcr:primaryType: hippotaxonomy:category
             /major-accidents:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: major-accidents
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Major accidents
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: major-accidents
+              jcr:primaryType: hippotaxonomy:category
             /mortality-from-accidents:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: mortality-from-accidents
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Mortality from accidents
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: mortality-from-accidents
+              jcr:primaryType: hippotaxonomy:category
+            hippotaxonomy:key: accidents-and-injuries
+            jcr:primaryType: hippotaxonomy:category
           /cancer:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: cancer
-            /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
-              /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
-                hippotaxonomy:name: Cancer
             /all-cancers:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: all-cancers
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: All cancers
-            /breast-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: breast-cancer
-              /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
-                /en:
                   jcr:primaryType: hippotaxonomy:categoryinfo
-                  hippotaxonomy:name: Breast cancer
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: all-cancers
+              jcr:primaryType: hippotaxonomy:category
             /bowel-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: bowel-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Bowel cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: bowel-cancer
+              jcr:primaryType: hippotaxonomy:category
+            /breast-cancer:
+              /hippotaxonomy:categoryinfos:
+                /en:
+                  hippotaxonomy:name: Breast cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: breast-cancer
+              jcr:primaryType: hippotaxonomy:category
             /cervical-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: cervical-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Cervical cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: cervical-cancer
+              jcr:primaryType: hippotaxonomy:category
             /colon-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: colon-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Colon cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: colon-cancer
+              jcr:primaryType: hippotaxonomy:category
             /colorectal-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: colorectal-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Colorectal cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: colorectal-cancer
+              jcr:primaryType: hippotaxonomy:category
             /head-and-neck-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: head-and-neck-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Head and neck cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: head-and-neck-cancer
+              jcr:primaryType: hippotaxonomy:category
+            /hippotaxonomy:categoryinfos:
+              /en:
+                hippotaxonomy:name: Cancer
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
             /hodgkinâ€™s-disease:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: hodgkinâ€™s-disease
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Hodgkinâ€™s disease
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: hodgkinâ€™s-disease
+              jcr:primaryType: hippotaxonomy:category
             /leukaemia:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: leukaemia
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Leukaemia
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: leukaemia
+              jcr:primaryType: hippotaxonomy:category
             /lung-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: lung-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Lung cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: lung-cancer
+              jcr:primaryType: hippotaxonomy:category
             /malignant-melanoma:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: malignant-melanoma
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Malignant melanoma
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: malignant-melanoma
+              jcr:primaryType: hippotaxonomy:category
             /oesophago-gastric-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: oesophago-gastric-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Oesophago-gastric cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: oesophago-gastric-cancer
+              jcr:primaryType: hippotaxonomy:category
             /prostate-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: prostate-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Prostate cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: prostate-cancer
+              jcr:primaryType: hippotaxonomy:category
             /skin-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: skin-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Skin cancer
-            /stomach-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: stomach-cancer
-              /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
-                /en:
                   jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: skin-cancer
+              jcr:primaryType: hippotaxonomy:category
+            /stomach-cancer:
+              /hippotaxonomy:categoryinfos:
+                /en:
                   hippotaxonomy:name: Stomach cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: stomach-cancer
+              jcr:primaryType: hippotaxonomy:category
+            hippotaxonomy:key: cancer
+            jcr:primaryType: hippotaxonomy:category
           /central-nervous-system-diseases-and-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: central-nervous-system-diseases-and-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Central nervous system diseases and disorders
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: central-nervous-system-diseases-and-disorders
+            jcr:primaryType: hippotaxonomy:category
           /circulatory-system-diseases:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: circulatory-system-diseases
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Circulatory system diseases
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: circulatory-system-diseases
+            jcr:primaryType: hippotaxonomy:category
           /dental-health:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: dental-health
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Dental health
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: dental-health
+            jcr:primaryType: hippotaxonomy:category
           /digestive-system-diseases-and-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: digestive-system-diseases-and-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Digestive system diseases and disorders
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: digestive-system-diseases-and-disorders
+            jcr:primaryType: hippotaxonomy:category
           /endocrine,-nutritional-and-metabolic-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: endocrine,-nutritional-and-metabolic-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Endocrine, nutritional and metabolic disorders
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: endocrine,-nutritional-and-metabolic-disorders
+            jcr:primaryType: hippotaxonomy:category
           /genitourinary-system-diseases-and-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: genitourinary-system-diseases-and-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Genitourinary system diseases and disorders
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: genitourinary-system-diseases-and-disorders
+            jcr:primaryType: hippotaxonomy:category
+          /hippotaxonomy:categoryinfos:
+            /en:
+              hippotaxonomy:name: Conditions
+              jcr:primaryType: hippotaxonomy:categoryinfo
+            jcr:primaryType: hippotaxonomy:categoryinfos
           /immune-system-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: immune-system-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Immune system disorders
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: immune-system-disorders
+            jcr:primaryType: hippotaxonomy:category
           /infectious-diseases:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: infectious-diseases
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Infectious diseases
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: infectious-diseases
+            jcr:primaryType: hippotaxonomy:category
           /maternal,-infant-and-child-health:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: maternal,-infant-and-child-health
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Maternal, infant and child health
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: maternal,-infant-and-child-health
+            jcr:primaryType: hippotaxonomy:category
           /mental-and-behavioural-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: mental-and-behavioural-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Mental and behavioural disorders
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: mental-and-behavioural-disorders
+            jcr:primaryType: hippotaxonomy:category
           /respiratory-system-diseases-and-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: respiratory-system-diseases-and-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Respiratory system diseases and disorders
-          /sensory-impairment:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: sensory-impairment
-            /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
-              /en:
                 jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: respiratory-system-diseases-and-disorders
+            jcr:primaryType: hippotaxonomy:category
+          /sensory-impairment:
+            /hippotaxonomy:categoryinfos:
+              /en:
                 hippotaxonomy:name: Sensory impairment
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: sensory-impairment
+            jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: conditions
+          jcr:primaryType: hippotaxonomy:category
         /outcomes-and-quality-indicators:
-          jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: outcomes-and-quality-indicators
           /hippotaxonomy:categoryinfos:
-            jcr:primaryType: hippotaxonomy:categoryinfos
             /en:
-              jcr:primaryType: hippotaxonomy:categoryinfo
               hippotaxonomy:name: Outcomes and quality indicators
+              jcr:primaryType: hippotaxonomy:categoryinfo
+            jcr:primaryType: hippotaxonomy:categoryinfos
+          hippotaxonomy:key: outcomes-and-quality-indicators
+          jcr:primaryType: hippotaxonomy:category
         /people,-patients-and-geography:
-          jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: people,-patients-and-geography
           /hippotaxonomy:categoryinfos:
-            jcr:primaryType: hippotaxonomy:categoryinfos
             /en:
-              jcr:primaryType: hippotaxonomy:categoryinfo
               hippotaxonomy:name: People, patients and geography
+              jcr:primaryType: hippotaxonomy:categoryinfo
+            jcr:primaryType: hippotaxonomy:categoryinfos
+          hippotaxonomy:key: people,-patients-and-geography
+          jcr:primaryType: hippotaxonomy:category
         /sevices:
-          jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: sevices
           /hippotaxonomy:categoryinfos:
-            jcr:primaryType: hippotaxonomy:categoryinfos
             /en:
-              jcr:primaryType: hippotaxonomy:categoryinfo
               hippotaxonomy:name: Sevices
+              jcr:primaryType: hippotaxonomy:categoryinfo
+            jcr:primaryType: hippotaxonomy:categoryinfos
+          hippotaxonomy:key: sevices
+          jcr:primaryType: hippotaxonomy:category
         /social-care:
-          jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: social-care
           /hippotaxonomy:categoryinfos:
-            jcr:primaryType: hippotaxonomy:categoryinfos
             /en:
-              jcr:primaryType: hippotaxonomy:categoryinfo
               hippotaxonomy:name: Social care
-        /workforce:
-          jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: workforce
-          /hippotaxonomy:categoryinfos:
-            jcr:primaryType: hippotaxonomy:categoryinfos
-            /en:
               jcr:primaryType: hippotaxonomy:categoryinfo
+            jcr:primaryType: hippotaxonomy:categoryinfos
+          hippotaxonomy:key: social-care
+          jcr:primaryType: hippotaxonomy:category
+        /workforce:
+          /hippotaxonomy:categoryinfos:
+            /en:
               hippotaxonomy:name: Workforce
+              jcr:primaryType: hippotaxonomy:categoryinfo
+            jcr:primaryType: hippotaxonomy:categoryinfos
+          hippotaxonomy:key: workforce
+          jcr:primaryType: hippotaxonomy:category
       /publication_taxonomy[2]:
         /conditions:
-          jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: conditions
-          /hippotaxonomy:categoryinfos:
-            jcr:primaryType: hippotaxonomy:categoryinfos
-            /en:
-              jcr:primaryType: hippotaxonomy:categoryinfo
-              hippotaxonomy:name: Conditions
           /accidents-and-injuries:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: accidents-and-injuries
-            /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
-              /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
-                hippotaxonomy:name: Accidents and injuries
             /breaks-and-fractures:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: breaks-and-fractures
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Breaks and fractures
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: breaks-and-fractures
+              jcr:primaryType: hippotaxonomy:category
             /falls:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: falls
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Falls
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: falls
+              jcr:primaryType: hippotaxonomy:category
+            /hippotaxonomy:categoryinfos:
+              /en:
+                hippotaxonomy:name: Accidents and injuries
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
             /land-transport-accidents:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: land-transport-accidents
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Land transport accidents
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: land-transport-accidents
+              jcr:primaryType: hippotaxonomy:category
             /major-accidents:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: major-accidents
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Major accidents
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: major-accidents
+              jcr:primaryType: hippotaxonomy:category
             /mortality-from-accidents:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: mortality-from-accidents
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Mortality from accidents
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: mortality-from-accidents
+              jcr:primaryType: hippotaxonomy:category
+            hippotaxonomy:key: accidents-and-injuries
+            jcr:primaryType: hippotaxonomy:category
           /cancer:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: cancer
-            /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
-              /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
-                hippotaxonomy:name: Cancer
             /all-cancers:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: all-cancers
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: All cancers
-            /breast-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: breast-cancer
-              /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
-                /en:
                   jcr:primaryType: hippotaxonomy:categoryinfo
-                  hippotaxonomy:name: Breast cancer
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: all-cancers
+              jcr:primaryType: hippotaxonomy:category
             /bowel-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: bowel-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Bowel cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: bowel-cancer
+              jcr:primaryType: hippotaxonomy:category
+            /breast-cancer:
+              /hippotaxonomy:categoryinfos:
+                /en:
+                  hippotaxonomy:name: Breast cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: breast-cancer
+              jcr:primaryType: hippotaxonomy:category
             /cervical-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: cervical-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Cervical cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: cervical-cancer
+              jcr:primaryType: hippotaxonomy:category
             /colon-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: colon-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Colon cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: colon-cancer
+              jcr:primaryType: hippotaxonomy:category
             /colorectal-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: colorectal-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Colorectal cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: colorectal-cancer
+              jcr:primaryType: hippotaxonomy:category
             /head-and-neck-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: head-and-neck-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Head and neck cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: head-and-neck-cancer
+              jcr:primaryType: hippotaxonomy:category
+            /hippotaxonomy:categoryinfos:
+              /en:
+                hippotaxonomy:name: Cancer
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
             /hodgkinâ€™s-disease:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: hodgkinâ€™s-disease
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Hodgkinâ€™s disease
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: hodgkinâ€™s-disease
+              jcr:primaryType: hippotaxonomy:category
             /leukaemia:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: leukaemia
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Leukaemia
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: leukaemia
+              jcr:primaryType: hippotaxonomy:category
             /lung-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: lung-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Lung cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: lung-cancer
+              jcr:primaryType: hippotaxonomy:category
             /malignant-melanoma:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: malignant-melanoma
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Malignant melanoma
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: malignant-melanoma
+              jcr:primaryType: hippotaxonomy:category
             /oesophago-gastric-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: oesophago-gastric-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Oesophago-gastric cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: oesophago-gastric-cancer
+              jcr:primaryType: hippotaxonomy:category
             /prostate-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: prostate-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Prostate cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: prostate-cancer
+              jcr:primaryType: hippotaxonomy:category
             /skin-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: skin-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Skin cancer
-            /stomach-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: stomach-cancer
-              /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
-                /en:
                   jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: skin-cancer
+              jcr:primaryType: hippotaxonomy:category
+            /stomach-cancer:
+              /hippotaxonomy:categoryinfos:
+                /en:
                   hippotaxonomy:name: Stomach cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: stomach-cancer
+              jcr:primaryType: hippotaxonomy:category
+            hippotaxonomy:key: cancer
+            jcr:primaryType: hippotaxonomy:category
           /central-nervous-system-diseases-and-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: central-nervous-system-diseases-and-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Central nervous system diseases and disorders
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: central-nervous-system-diseases-and-disorders
+            jcr:primaryType: hippotaxonomy:category
           /circulatory-system-diseases:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: circulatory-system-diseases
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Circulatory system diseases
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: circulatory-system-diseases
+            jcr:primaryType: hippotaxonomy:category
           /dental-health:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: dental-health
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Dental health
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: dental-health
+            jcr:primaryType: hippotaxonomy:category
           /digestive-system-diseases-and-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: digestive-system-diseases-and-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Digestive system diseases and disorders
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: digestive-system-diseases-and-disorders
+            jcr:primaryType: hippotaxonomy:category
           /endocrine,-nutritional-and-metabolic-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: endocrine,-nutritional-and-metabolic-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Endocrine, nutritional and metabolic disorders
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: endocrine,-nutritional-and-metabolic-disorders
+            jcr:primaryType: hippotaxonomy:category
           /genitourinary-system-diseases-and-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: genitourinary-system-diseases-and-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Genitourinary system diseases and disorders
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: genitourinary-system-diseases-and-disorders
+            jcr:primaryType: hippotaxonomy:category
+          /hippotaxonomy:categoryinfos:
+            /en:
+              hippotaxonomy:name: Conditions
+              jcr:primaryType: hippotaxonomy:categoryinfo
+            jcr:primaryType: hippotaxonomy:categoryinfos
           /immune-system-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: immune-system-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Immune system disorders
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: immune-system-disorders
+            jcr:primaryType: hippotaxonomy:category
           /infectious-diseases:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: infectious-diseases
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Infectious diseases
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: infectious-diseases
+            jcr:primaryType: hippotaxonomy:category
           /maternal,-infant-and-child-health:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: maternal,-infant-and-child-health
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Maternal, infant and child health
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: maternal,-infant-and-child-health
+            jcr:primaryType: hippotaxonomy:category
           /mental-and-behavioural-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: mental-and-behavioural-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Mental and behavioural disorders
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: mental-and-behavioural-disorders
+            jcr:primaryType: hippotaxonomy:category
           /respiratory-system-diseases-and-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: respiratory-system-diseases-and-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Respiratory system diseases and disorders
-          /sensory-impairment:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: sensory-impairment
-            /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
-              /en:
                 jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: respiratory-system-diseases-and-disorders
+            jcr:primaryType: hippotaxonomy:category
+          /sensory-impairment:
+            /hippotaxonomy:categoryinfos:
+              /en:
                 hippotaxonomy:name: Sensory impairment
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: sensory-impairment
+            jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: conditions
+          jcr:primaryType: hippotaxonomy:category
         /outcomes-and-quality-indicators:
-          jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: outcomes-and-quality-indicators
           /hippotaxonomy:categoryinfos:
-            jcr:primaryType: hippotaxonomy:categoryinfos
             /en:
-              jcr:primaryType: hippotaxonomy:categoryinfo
               hippotaxonomy:name: Outcomes and quality indicators
+              jcr:primaryType: hippotaxonomy:categoryinfo
+            jcr:primaryType: hippotaxonomy:categoryinfos
+          hippotaxonomy:key: outcomes-and-quality-indicators
+          jcr:primaryType: hippotaxonomy:category
         /people,-patients-and-geography:
-          jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: people,-patients-and-geography
           /hippotaxonomy:categoryinfos:
-            jcr:primaryType: hippotaxonomy:categoryinfos
             /en:
-              jcr:primaryType: hippotaxonomy:categoryinfo
               hippotaxonomy:name: People, patients and geography
+              jcr:primaryType: hippotaxonomy:categoryinfo
+            jcr:primaryType: hippotaxonomy:categoryinfos
+          hippotaxonomy:key: people,-patients-and-geography
+          jcr:primaryType: hippotaxonomy:category
         /sevices:
-          jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: sevices
           /hippotaxonomy:categoryinfos:
-            jcr:primaryType: hippotaxonomy:categoryinfos
             /en:
-              jcr:primaryType: hippotaxonomy:categoryinfo
               hippotaxonomy:name: Sevices
+              jcr:primaryType: hippotaxonomy:categoryinfo
+            jcr:primaryType: hippotaxonomy:categoryinfos
+          hippotaxonomy:key: sevices
+          jcr:primaryType: hippotaxonomy:category
         /social-care:
-          jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: social-care
           /hippotaxonomy:categoryinfos:
-            jcr:primaryType: hippotaxonomy:categoryinfos
             /en:
-              jcr:primaryType: hippotaxonomy:categoryinfo
               hippotaxonomy:name: Social care
-        /workforce:
-          jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: workforce
-          /hippotaxonomy:categoryinfos:
-            jcr:primaryType: hippotaxonomy:categoryinfos
-            /en:
               jcr:primaryType: hippotaxonomy:categoryinfo
+            jcr:primaryType: hippotaxonomy:categoryinfos
+          hippotaxonomy:key: social-care
+          jcr:primaryType: hippotaxonomy:category
+        /workforce:
+          /hippotaxonomy:categoryinfos:
+            /en:
               hippotaxonomy:name: Workforce
+              jcr:primaryType: hippotaxonomy:categoryinfo
+            jcr:primaryType: hippotaxonomy:categoryinfos
+          hippotaxonomy:key: workforce
+          jcr:primaryType: hippotaxonomy:category
       /publication_taxonomy[3]:
         /conditions:
-          jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: conditions
-          /hippotaxonomy:categoryinfos:
-            jcr:primaryType: hippotaxonomy:categoryinfos
-            /en:
-              jcr:primaryType: hippotaxonomy:categoryinfo
-              hippotaxonomy:name: Conditions
           /accidents-and-injuries:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: accidents-and-injuries
-            /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
-              /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
-                hippotaxonomy:name: Accidents and injuries
             /breaks-and-fractures:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: breaks-and-fractures
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Breaks and fractures
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: breaks-and-fractures
+              jcr:primaryType: hippotaxonomy:category
             /falls:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: falls
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Falls
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: falls
+              jcr:primaryType: hippotaxonomy:category
+            /hippotaxonomy:categoryinfos:
+              /en:
+                hippotaxonomy:name: Accidents and injuries
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
             /land-transport-accidents:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: land-transport-accidents
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Land transport accidents
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: land-transport-accidents
+              jcr:primaryType: hippotaxonomy:category
             /major-accidents:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: major-accidents
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Major accidents
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: major-accidents
+              jcr:primaryType: hippotaxonomy:category
             /mortality-from-accidents:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: mortality-from-accidents
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Mortality from accidents
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: mortality-from-accidents
+              jcr:primaryType: hippotaxonomy:category
+            hippotaxonomy:key: accidents-and-injuries
+            jcr:primaryType: hippotaxonomy:category
           /cancer:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: cancer
-            /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
-              /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
-                hippotaxonomy:name: Cancer
             /all-cancers:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: all-cancers
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: All cancers
-            /breast-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: breast-cancer
-              /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
-                /en:
                   jcr:primaryType: hippotaxonomy:categoryinfo
-                  hippotaxonomy:name: Breast cancer
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: all-cancers
+              jcr:primaryType: hippotaxonomy:category
             /bowel-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: bowel-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Bowel cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: bowel-cancer
+              jcr:primaryType: hippotaxonomy:category
+            /breast-cancer:
+              /hippotaxonomy:categoryinfos:
+                /en:
+                  hippotaxonomy:name: Breast cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: breast-cancer
+              jcr:primaryType: hippotaxonomy:category
             /cervical-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: cervical-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Cervical cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: cervical-cancer
+              jcr:primaryType: hippotaxonomy:category
             /colon-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: colon-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Colon cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: colon-cancer
+              jcr:primaryType: hippotaxonomy:category
             /colorectal-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: colorectal-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Colorectal cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: colorectal-cancer
+              jcr:primaryType: hippotaxonomy:category
             /head-and-neck-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: head-and-neck-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Head and neck cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: head-and-neck-cancer
+              jcr:primaryType: hippotaxonomy:category
+            /hippotaxonomy:categoryinfos:
+              /en:
+                hippotaxonomy:name: Cancer
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
             /hodgkinâ€™s-disease:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: hodgkinâ€™s-disease
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Hodgkinâ€™s disease
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: hodgkinâ€™s-disease
+              jcr:primaryType: hippotaxonomy:category
             /leukaemia:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: leukaemia
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Leukaemia
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: leukaemia
+              jcr:primaryType: hippotaxonomy:category
             /lung-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: lung-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Lung cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: lung-cancer
+              jcr:primaryType: hippotaxonomy:category
             /malignant-melanoma:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: malignant-melanoma
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Malignant melanoma
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: malignant-melanoma
+              jcr:primaryType: hippotaxonomy:category
             /oesophago-gastric-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: oesophago-gastric-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Oesophago-gastric cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: oesophago-gastric-cancer
+              jcr:primaryType: hippotaxonomy:category
             /prostate-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: prostate-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Prostate cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: prostate-cancer
+              jcr:primaryType: hippotaxonomy:category
             /skin-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: skin-cancer
               /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
                 /en:
-                  jcr:primaryType: hippotaxonomy:categoryinfo
                   hippotaxonomy:name: Skin cancer
-            /stomach-cancer:
-              jcr:primaryType: hippotaxonomy:category
-              hippotaxonomy:key: stomach-cancer
-              /hippotaxonomy:categoryinfos:
-                jcr:primaryType: hippotaxonomy:categoryinfos
-                /en:
                   jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: skin-cancer
+              jcr:primaryType: hippotaxonomy:category
+            /stomach-cancer:
+              /hippotaxonomy:categoryinfos:
+                /en:
                   hippotaxonomy:name: Stomach cancer
+                  jcr:primaryType: hippotaxonomy:categoryinfo
+                jcr:primaryType: hippotaxonomy:categoryinfos
+              hippotaxonomy:key: stomach-cancer
+              jcr:primaryType: hippotaxonomy:category
+            hippotaxonomy:key: cancer
+            jcr:primaryType: hippotaxonomy:category
           /central-nervous-system-diseases-and-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: central-nervous-system-diseases-and-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Central nervous system diseases and disorders
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: central-nervous-system-diseases-and-disorders
+            jcr:primaryType: hippotaxonomy:category
           /circulatory-system-diseases:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: circulatory-system-diseases
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Circulatory system diseases
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: circulatory-system-diseases
+            jcr:primaryType: hippotaxonomy:category
           /dental-health:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: dental-health
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Dental health
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: dental-health
+            jcr:primaryType: hippotaxonomy:category
           /digestive-system-diseases-and-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: digestive-system-diseases-and-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Digestive system diseases and disorders
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: digestive-system-diseases-and-disorders
+            jcr:primaryType: hippotaxonomy:category
           /endocrine,-nutritional-and-metabolic-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: endocrine,-nutritional-and-metabolic-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Endocrine, nutritional and metabolic disorders
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: endocrine,-nutritional-and-metabolic-disorders
+            jcr:primaryType: hippotaxonomy:category
           /genitourinary-system-diseases-and-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: genitourinary-system-diseases-and-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Genitourinary system diseases and disorders
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: genitourinary-system-diseases-and-disorders
+            jcr:primaryType: hippotaxonomy:category
+          /hippotaxonomy:categoryinfos:
+            /en:
+              hippotaxonomy:name: Conditions
+              jcr:primaryType: hippotaxonomy:categoryinfo
+            jcr:primaryType: hippotaxonomy:categoryinfos
           /immune-system-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: immune-system-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Immune system disorders
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: immune-system-disorders
+            jcr:primaryType: hippotaxonomy:category
           /infectious-diseases:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: infectious-diseases
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Infectious diseases
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: infectious-diseases
+            jcr:primaryType: hippotaxonomy:category
           /maternal,-infant-and-child-health:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: maternal,-infant-and-child-health
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Maternal, infant and child health
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: maternal,-infant-and-child-health
+            jcr:primaryType: hippotaxonomy:category
           /mental-and-behavioural-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: mental-and-behavioural-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Mental and behavioural disorders
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: mental-and-behavioural-disorders
+            jcr:primaryType: hippotaxonomy:category
           /respiratory-system-diseases-and-disorders:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: respiratory-system-diseases-and-disorders
             /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
               /en:
-                jcr:primaryType: hippotaxonomy:categoryinfo
                 hippotaxonomy:name: Respiratory system diseases and disorders
-          /sensory-impairment:
-            jcr:primaryType: hippotaxonomy:category
-            hippotaxonomy:key: sensory-impairment
-            /hippotaxonomy:categoryinfos:
-              jcr:primaryType: hippotaxonomy:categoryinfos
-              /en:
                 jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: respiratory-system-diseases-and-disorders
+            jcr:primaryType: hippotaxonomy:category
+          /sensory-impairment:
+            /hippotaxonomy:categoryinfos:
+              /en:
                 hippotaxonomy:name: Sensory impairment
+                jcr:primaryType: hippotaxonomy:categoryinfo
+              jcr:primaryType: hippotaxonomy:categoryinfos
+            hippotaxonomy:key: sensory-impairment
+            jcr:primaryType: hippotaxonomy:category
+          hippotaxonomy:key: conditions
+          jcr:primaryType: hippotaxonomy:category
         /outcomes-and-quality-indicators:
-          jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: outcomes-and-quality-indicators
           /hippotaxonomy:categoryinfos:
-            jcr:primaryType: hippotaxonomy:categoryinfos
             /en:
-              jcr:primaryType: hippotaxonomy:categoryinfo
               hippotaxonomy:name: Outcomes and quality indicators
+              jcr:primaryType: hippotaxonomy:categoryinfo
+            jcr:primaryType: hippotaxonomy:categoryinfos
+          hippotaxonomy:key: outcomes-and-quality-indicators
+          jcr:primaryType: hippotaxonomy:category
         /people,-patients-and-geography:
-          jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: people,-patients-and-geography
           /hippotaxonomy:categoryinfos:
-            jcr:primaryType: hippotaxonomy:categoryinfos
             /en:
-              jcr:primaryType: hippotaxonomy:categoryinfo
               hippotaxonomy:name: People, patients and geography
+              jcr:primaryType: hippotaxonomy:categoryinfo
+            jcr:primaryType: hippotaxonomy:categoryinfos
+          hippotaxonomy:key: people,-patients-and-geography
+          jcr:primaryType: hippotaxonomy:category
         /sevices:
-          jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: sevices
           /hippotaxonomy:categoryinfos:
-            jcr:primaryType: hippotaxonomy:categoryinfos
             /en:
-              jcr:primaryType: hippotaxonomy:categoryinfo
               hippotaxonomy:name: Sevices
+              jcr:primaryType: hippotaxonomy:categoryinfo
+            jcr:primaryType: hippotaxonomy:categoryinfos
+          hippotaxonomy:key: sevices
+          jcr:primaryType: hippotaxonomy:category
         /social-care:
-          jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: social-care
           /hippotaxonomy:categoryinfos:
-            jcr:primaryType: hippotaxonomy:categoryinfos
             /en:
-              jcr:primaryType: hippotaxonomy:categoryinfo
               hippotaxonomy:name: Social care
-        /workforce:
-          jcr:primaryType: hippotaxonomy:category
-          hippotaxonomy:key: workforce
-          /hippotaxonomy:categoryinfos:
-            jcr:primaryType: hippotaxonomy:categoryinfos
-            /en:
               jcr:primaryType: hippotaxonomy:categoryinfo
+            jcr:primaryType: hippotaxonomy:categoryinfos
+          hippotaxonomy:key: social-care
+          jcr:primaryType: hippotaxonomy:category
+        /workforce:
+          /hippotaxonomy:categoryinfos:
+            /en:
               hippotaxonomy:name: Workforce
+              jcr:primaryType: hippotaxonomy:categoryinfo
+            jcr:primaryType: hippotaxonomy:categoryinfos
+          hippotaxonomy:key: workforce
+          jcr:primaryType: hippotaxonomy:category

--- a/repository-data/development/src/main/resources/hcm-config/hst/hosts.yaml
+++ b/repository-data/development/src/main/resources/hcm-config/hst/hosts.yaml
@@ -1,8 +1,6 @@
 ---
-
 definitions:
   config:
     /hst:hst/hst:hosts:
       .meta:residual-child-node-category: content
-      # enable console diagnostics
       hst:diagnosticsenabled: true

--- a/repository-data/development/src/main/resources/hcm-config/main.yaml
+++ b/repository-data/development/src/main/resources/hcm-config/main.yaml
@@ -1,8 +1,10 @@
+---
 definitions:
   config:
     /hippo:configuration/hippo:modules/autoexport/hippo:moduleconfig:
+      autoexport:enabled: true
       autoexport:modules:
         operation: add
         type: string
-        value: [repository-data/development]
-      autoexport:enabled: true
+        value:
+        - repository-data/development

--- a/repository-data/development/src/main/resources/hcm-config/main.yaml
+++ b/repository-data/development/src/main/resources/hcm-config/main.yaml
@@ -5,4 +5,4 @@ definitions:
         operation: add
         type: string
         value: [repository-data/development]
-      autoexport:enabled: false
+      autoexport:enabled: true

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests.yaml
@@ -1,9 +1,13 @@
 ---
-
 /content/documents/corporate-website/publication-system/acceptance-tests:
   hippo:name: Acceptance Tests
-  hippostd:foldertype: [new-translated-folder, new-document]
+  hippostd:foldertype:
+  - new-translated-folder
+  - new-document
   hippotranslation:id: 00000000-0000-0000-0000-000000000000
   hippotranslation:locale: en
-  jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']
+  jcr:mixinTypes:
+  - hippo:named
+  - hippotranslation:translated
+  - mix:versionable
   jcr:primaryType: hippostd:folder

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-rich.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-rich.yaml
@@ -1,9 +1,13 @@
 ---
-
 /content/documents/corporate-website/publication-system/acceptance-tests/publication-rich:
-  jcr:primaryType: hippostd:folder
-  jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']
   hippo:name: Publication With Rich Content
-  hippostd:foldertype: [new-translated-folder, new-document]
+  hippostd:foldertype:
+  - new-translated-folder
+  - new-document
   hippotranslation:id: 00000000-0000-0000-0000-000000000000
   hippotranslation:locale: en
+  jcr:mixinTypes:
+  - hippo:named
+  - hippotranslation:translated
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-rich/content.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-rich/content.yaml
@@ -1,11 +1,6 @@
 ---
-
 /content/documents/corporate-website/publication-system/acceptance-tests/publication-rich/content:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['mix:referenceable']
   /content[1]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
@@ -14,33 +9,37 @@
     hippostdpubwf:lastModifiedBy: admin
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    publicationsystem:AdministrativeSources: Mauris pretium orci ac gravida
-      accumsan. Cras mattis massa a vulputate semper. Quisque in pharetra sem.
-      Curabitur dapibus odio in risus consectetur, placerat laoreet nunc vulputate.
-      Suspendisse vitae ipsum ligula. Donec sed risus vel eros posuere varius id et
-      urna.
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
+    publicationsystem:AdministrativeSources: Mauris pretium orci ac gravida accumsan.
+      Cras mattis massa a vulputate semper. Quisque in pharetra sem. Curabitur dapibus
+      odio in risus consectetur, placerat laoreet nunc vulputate. Suspendisse vitae
+      ipsum ligula. Donec sed risus vel eros posuere varius id et urna.
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [NHS Trusts]
-    publicationsystem:InformationType: [Experimental statistics]
-    publicationsystem:KeyFacts: Cras eget elementum erat. Aliquam ornare urna ut
-      ligula euismod auctor. Sed non dolor sit amet neque sodales eleifend in id
-      nisi. Nunc semper purus non justo tempor placerat. Phasellus a blandit eros.
-      Vivamus accumsan, diam in tempus sollicitudin, tortor enim gravida ligula,
-      lobortis imperdiet lectus metus vel turpis.
-    publicationsystem:NominalDate: 2016-10-10T01:00:00+01:00
-    publicationsystem:Summary: Etiam vitae tincidunt lectus. Nulla posuere
-      ultricies mollis. Mauris in ullamcorper sapien. Quisque eros quam,
-      condimentum non nisl vel, condimentum vestibulum turpis. Aenean sodales leo
-      in mauris pellentesque, nec auctor sapien facilisis. Ut accumsan orci ac
-      metus lobortis, vel facilisis nisl iaculis.
-    publicationsystem:Title: publication with rich content
+    publicationsystem:Granularity:
+    - NHS Trusts
+    publicationsystem:InformationType:
+    - Experimental statistics
+    publicationsystem:KeyFacts: Cras eget elementum erat. Aliquam ornare urna ut ligula
+      euismod auctor. Sed non dolor sit amet neque sodales eleifend in id nisi. Nunc
+      semper purus non justo tempor placerat. Phasellus a blandit eros. Vivamus accumsan,
+      diam in tempus sollicitudin, tortor enim gravida ligula, lobortis imperdiet
+      lectus metus vel turpis.
+    publicationsystem:NominalDate: 2016-10-10T00:00:00Z
     publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Etiam vitae tincidunt lectus. Nulla posuere ultricies
+      mollis. Mauris in ullamcorper sapien. Quisque eros quam, condimentum non nisl
+      vel, condimentum vestibulum turpis. Aenean sodales leo in mauris pellentesque,
+      nec auctor sapien facilisis. Ut accumsan orci ac metus lobortis, vel facilisis
+      nisl iaculis.
+    publicationsystem:Title: publication with rich content
   /content[2]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2016-11-03T13:35:36.812Z
@@ -48,33 +47,38 @@
     hippostdpubwf:lastModifiedBy: admin
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    publicationsystem:AdministrativeSources: Mauris pretium orci ac gravida
-      accumsan. Cras mattis massa a vulputate semper. Quisque in pharetra sem.
-      Curabitur dapibus odio in risus consectetur, placerat laoreet nunc vulputate.
-      Suspendisse vitae ipsum ligula. Donec sed risus vel eros posuere varius id et
-      urna.
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:publication
+    publicationsystem:AdministrativeSources: Mauris pretium orci ac gravida accumsan.
+      Cras mattis massa a vulputate semper. Quisque in pharetra sem. Curabitur dapibus
+      odio in risus consectetur, placerat laoreet nunc vulputate. Suspendisse vitae
+      ipsum ligula. Donec sed risus vel eros posuere varius id et urna.
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [NHS Trusts]
-    publicationsystem:InformationType: [Experimental statistics]
-    publicationsystem:KeyFacts: Cras eget elementum erat. Aliquam ornare urna ut
-      ligula euismod auctor. Sed non dolor sit amet neque sodales eleifend in id
-      nisi. Nunc semper purus non justo tempor placerat. Phasellus a blandit eros.
-      Vivamus accumsan, diam in tempus sollicitudin, tortor enim gravida ligula,
-      lobortis imperdiet lectus metus vel turpis.
-    publicationsystem:NominalDate: 2016-10-10T01:00:00+01:00
-    publicationsystem:Summary: Etiam vitae tincidunt lectus. Nulla posuere
-      ultricies mollis. Mauris in ullamcorper sapien. Quisque eros quam,
-      condimentum non nisl vel, condimentum vestibulum turpis. Aenean sodales leo
-      in mauris pellentesque, nec auctor sapien facilisis. Ut accumsan orci ac
-      metus lobortis, vel facilisis nisl iaculis.
-    publicationsystem:Title: publication with rich content
+    publicationsystem:Granularity:
+    - NHS Trusts
+    publicationsystem:InformationType:
+    - Experimental statistics
+    publicationsystem:KeyFacts: Cras eget elementum erat. Aliquam ornare urna ut ligula
+      euismod auctor. Sed non dolor sit amet neque sodales eleifend in id nisi. Nunc
+      semper purus non justo tempor placerat. Phasellus a blandit eros. Vivamus accumsan,
+      diam in tempus sollicitudin, tortor enim gravida ligula, lobortis imperdiet
+      lectus metus vel turpis.
+    publicationsystem:NominalDate: 2016-10-10T00:00:00Z
     publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Etiam vitae tincidunt lectus. Nulla posuere ultricies
+      mollis. Mauris in ullamcorper sapien. Quisque eros quam, condimentum non nisl
+      vel, condimentum vestibulum turpis. Aenean sodales leo in mauris pellentesque,
+      nec auctor sapien facilisis. Ut accumsan orci ac metus lobortis, vel facilisis
+      nisl iaculis.
+    publicationsystem:Title: publication with rich content
   /content[3]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2016-11-03T13:35:36.812Z
@@ -83,26 +87,34 @@
     hippostdpubwf:publicationDate: 2016-11-03T13:41:09.207Z
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    publicationsystem:AdministrativeSources: Mauris pretium orci ac gravida
-      accumsan. Cras mattis massa a vulputate semper. Quisque in pharetra sem.
-      Curabitur dapibus odio in risus consectetur, placerat laoreet nunc vulputate.
-      Suspendisse vitae ipsum ligula. Donec sed risus vel eros posuere varius id et
-      urna.
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
+    publicationsystem:AdministrativeSources: Mauris pretium orci ac gravida accumsan.
+      Cras mattis massa a vulputate semper. Quisque in pharetra sem. Curabitur dapibus
+      odio in risus consectetur, placerat laoreet nunc vulputate. Suspendisse vitae
+      ipsum ligula. Donec sed risus vel eros posuere varius id et urna.
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [NHS Trusts]
-    publicationsystem:InformationType: [Experimental statistics]
-    publicationsystem:KeyFacts: Cras eget elementum erat. Aliquam ornare urna ut
-      ligula euismod auctor. Sed non dolor sit amet neque sodales eleifend in id
-      nisi. Nunc semper purus non justo tempor placerat. Phasellus a blandit eros.
-      Vivamus accumsan, diam in tempus sollicitudin, tortor enim gravida ligula,
-      lobortis imperdiet lectus metus vel turpis.
-    publicationsystem:NominalDate: 2016-10-10T01:00:00+01:00
-    publicationsystem:Summary: Etiam vitae tincidunt lectus. Nulla posuere
-      ultricies mollis. Mauris in ullamcorper sapien. Quisque eros quam,
-      condimentum non nisl vel, condimentum vestibulum turpis. Aenean sodales leo
-      in mauris pellentesque, nec auctor sapien facilisis. Ut accumsan orci ac
-      metus lobortis, vel facilisis nisl iaculis.
-    publicationsystem:Title: publication with rich content
+    publicationsystem:Granularity:
+    - NHS Trusts
+    publicationsystem:InformationType:
+    - Experimental statistics
+    publicationsystem:KeyFacts: Cras eget elementum erat. Aliquam ornare urna ut ligula
+      euismod auctor. Sed non dolor sit amet neque sodales eleifend in id nisi. Nunc
+      semper purus non justo tempor placerat. Phasellus a blandit eros. Vivamus accumsan,
+      diam in tempus sollicitudin, tortor enim gravida ligula, lobortis imperdiet
+      lectus metus vel turpis.
+    publicationsystem:NominalDate: 2016-10-10T00:00:00Z
     publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Etiam vitae tincidunt lectus. Nulla posuere ultricies
+      mollis. Mauris in ullamcorper sapien. Quisque eros quam, condimentum non nisl
+      vel, condimentum vestibulum turpis. Aenean sodales leo in mauris pellentesque,
+      nec auctor sapien facilisis. Ut accumsan orci ac metus lobortis, vel facilisis
+      nisl iaculis.
+    publicationsystem:Title: publication with rich content
+  jcr:mixinTypes:
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets.yaml
@@ -1,9 +1,13 @@
 ---
-
 /content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets:
-  jcr:primaryType: hippostd:folder
-  jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']
   hippo:name: Publication With Datasets
-  hippostd:foldertype: [new-translated-folder, new-document]
+  hippostd:foldertype:
+  - new-translated-folder
+  - new-document
   hippotranslation:id: 00000000-0000-0000-0000-000000000000
   hippotranslation:locale: en
+  jcr:mixinTypes:
+  - hippo:named
+  - hippotranslation:translated
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/content.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/content.yaml
@@ -1,165 +1,186 @@
 ---
-
 /content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/content:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['mix:referenceable']
   /content[1]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
+    /publicationsystem:RelatedLinks:
+      jcr:primaryType: publicationsystem:relatedlink
+      publicationsystem:linkText: Test google.com link
+      publicationsystem:linkUrl: http://google.com
+    /publicationsystem:ResourceLinks:
+      jcr:primaryType: publicationsystem:relatedlink
+      publicationsystem:linkText: Related resource link
+      publicationsystem:linkUrl: http://google.com
+    /publicationsystem:attachments:
+      hippo:filename: attachment.pdf
+      hippo:text:
+        resource: attachment.pdf
+        type: binary
+      jcr:data:
+        resource: attachment.pdf
+        type: binary
+      jcr:encoding: UTF-8
+      jcr:lastModified: 2017-11-09T21:42:39.618Z
+      jcr:mimeType: application/pdf
+      jcr:primaryType: hippo:resource
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-03T13:35:36.812Z
     hippostdpubwf:lastModificationDate: 2017-11-03T13:35:36.813Z
     hippostdpubwf:lastModifiedBy: admin
-    hippotaxonomy:keys: ['people,-patients-and-geography']
+    hippotaxonomy:keys:
+    - people,-patients-and-geography
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2018-02-01T00:00:00Z
     publicationsystem:CoverageStart: 2017-11-01T00:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [NHS Trusts, GP practices]
-    publicationsystem:InformationType: [Experimental statistics]
-    publicationsystem:KeyFacts: Morbi egestas nisi at arcu pulvinar ultrices.
-      Sed et nunc risus. In hac habitasse platea dictumst. Proin ultrices, velit
-      vitae mollis aliquet, ligula ipsum tincidunt ante, nec imperdiet sapien
-      neque a nibh. In porta suscipit mauris. Suspendisse sit amet vestibulum
-      neque, at aliquet nibh. Aenean sed ante quam.
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
+    publicationsystem:Granularity:
+    - NHS Trusts
+    - GP practices
+    publicationsystem:InformationType:
+    - Experimental statistics
+    publicationsystem:KeyFacts: Morbi egestas nisi at arcu pulvinar ultrices. Sed
+      et nunc risus. In hac habitasse platea dictumst. Proin ultrices, velit vitae
+      mollis aliquet, ligula ipsum tincidunt ante, nec imperdiet sapien neque a nibh.
+      In porta suscipit mauris. Suspendisse sit amet vestibulum neque, at aliquet
+      nibh. Aenean sed ante quam.
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Lorem ipsum dolor sit amet, consectetur adipiscing
       elit. Duis convallis non massa vel dictum. In vel ex sapien. Donec sit amet
-      leo lobortis, tempor ex ut, luctus eros. In in eleifend orci, nec suscipit
-      nisi. Maecenas sed velit condimentum, lobortis tortor id, ultricies metus.
-      Integer odio ante, congue pulvinar ultrices nec, mollis vitae dolor. Curabitur
-      euismod erat elit, quis facilisis neque eleifend id. Maecenas convallis
-      vel mi nec bibendum. Donec ut erat dictum, molestie dolor non, aliquet nibh.
+      leo lobortis, tempor ex ut, luctus eros. In in eleifend orci, nec suscipit nisi.
+      Maecenas sed velit condimentum, lobortis tortor id, ultricies metus. Integer
+      odio ante, congue pulvinar ultrices nec, mollis vitae dolor. Curabitur euismod
+      erat elit, quis facilisis neque eleifend id. Maecenas convallis vel mi nec bibendum.
+      Donec ut erat dictum, molestie dolor non, aliquet nibh.
     publicationsystem:Title: publication with datasets
+  /content[2]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: Test google.com link
       publicationsystem:linkUrl: http://google.com
-    /publicationsystem:attachments:
-      jcr:primaryType: hippo:resource
-      hippo:filename: attachment.pdf
-      hippo:text:
-        type: binary
-        resource: attachment.pdf
-      jcr:data:
-        type: binary
-        resource: attachment.pdf
-      jcr:encoding: UTF-8
-      jcr:lastModified: 2017-11-09T21:42:39.618Z
-      jcr:mimeType: application/pdf
     /publicationsystem:ResourceLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: Related resource link
       publicationsystem:linkUrl: http://google.com
-  /content[2]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    /publicationsystem:attachments:
+      hippo:filename: attachment.pdf
+      hippo:text:
+        resource: attachment.pdf
+        type: binary
+      jcr:data:
+        resource: attachment.pdf
+        type: binary
+      jcr:encoding: UTF-8
+      jcr:lastModified: 2017-11-09T21:42:39.618Z
+      jcr:mimeType: application/pdf
+      jcr:primaryType: hippo:resource
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-03T13:35:36.812Z
     hippostdpubwf:lastModificationDate: 2017-11-03T13:37:39.777Z
     hippostdpubwf:lastModifiedBy: admin
-    hippotaxonomy:keys: ['people,-patients-and-geography']
+    hippotaxonomy:keys:
+    - people,-patients-and-geography
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2018-02-01T00:00:00Z
     publicationsystem:CoverageStart: 2017-11-01T00:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [NHS Trusts, GP practices]
-    publicationsystem:InformationType: [Experimental statistics]
-    publicationsystem:KeyFacts: Morbi egestas nisi at arcu pulvinar ultrices.
-      Sed et nunc risus. In hac habitasse platea dictumst. Proin ultrices, velit
-      vitae mollis aliquet, ligula ipsum tincidunt ante, nec imperdiet sapien
-      neque a nibh. In porta suscipit mauris. Suspendisse sit amet vestibulum
-      neque, at aliquet nibh. Aenean sed ante quam.
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
+    publicationsystem:Granularity:
+    - NHS Trusts
+    - GP practices
+    publicationsystem:InformationType:
+    - Experimental statistics
+    publicationsystem:KeyFacts: Morbi egestas nisi at arcu pulvinar ultrices. Sed
+      et nunc risus. In hac habitasse platea dictumst. Proin ultrices, velit vitae
+      mollis aliquet, ligula ipsum tincidunt ante, nec imperdiet sapien neque a nibh.
+      In porta suscipit mauris. Suspendisse sit amet vestibulum neque, at aliquet
+      nibh. Aenean sed ante quam.
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Lorem ipsum dolor sit amet, consectetur adipiscing
       elit. Duis convallis non massa vel dictum. In vel ex sapien. Donec sit amet
-      leo lobortis, tempor ex ut, luctus eros. In in eleifend orci, nec suscipit
-      nisi. Maecenas sed velit condimentum, lobortis tortor id, ultricies metus.
-      Integer odio ante, congue pulvinar ultrices nec, mollis vitae dolor. Curabitur
-      euismod erat elit, quis facilisis neque eleifend id. Maecenas convallis
-      vel mi nec bibendum. Donec ut erat dictum, molestie dolor non, aliquet nibh.
+      leo lobortis, tempor ex ut, luctus eros. In in eleifend orci, nec suscipit nisi.
+      Maecenas sed velit condimentum, lobortis tortor id, ultricies metus. Integer
+      odio ante, congue pulvinar ultrices nec, mollis vitae dolor. Curabitur euismod
+      erat elit, quis facilisis neque eleifend id. Maecenas convallis vel mi nec bibendum.
+      Donec ut erat dictum, molestie dolor non, aliquet nibh.
     publicationsystem:Title: publication with datasets
+  /content[3]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: Test google.com link
       publicationsystem:linkUrl: http://google.com
-    /publicationsystem:attachments:
-      jcr:primaryType: hippo:resource
-      hippo:filename: attachment.pdf
-      hippo:text:
-        type: binary
-        resource: attachment.pdf
-      jcr:data:
-        type: binary
-        resource: attachment.pdf
-      jcr:encoding: UTF-8
-      jcr:lastModified: 2017-11-09T21:42:39.618Z
-      jcr:mimeType: application/pdf
     /publicationsystem:ResourceLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: Related resource link
       publicationsystem:linkUrl: http://google.com
-  /content[3]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    /publicationsystem:attachments:
+      hippo:filename: attachment.pdf
+      hippo:text:
+        resource: attachment.pdf
+        type: binary
+      jcr:data:
+        resource: attachment.pdf
+        type: binary
+      jcr:encoding: UTF-8
+      jcr:lastModified: 2017-11-09T21:42:39.618Z
+      jcr:mimeType: application/pdf
+      jcr:primaryType: hippo:resource
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-03T13:35:36.812Z
     hippostdpubwf:lastModificationDate: 2017-11-03T13:37:39.777Z
     hippostdpubwf:lastModifiedBy: admin
-    hippotaxonomy:keys: ['people,-patients-and-geography']
     hippostdpubwf:publicationDate: 2017-11-03T13:41:09.207Z
+    hippotaxonomy:keys:
+    - people,-patients-and-geography
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 2018-02-01T00:00:00Z
     publicationsystem:CoverageStart: 2017-11-01T00:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [NHS Trusts, GP practices]
-    publicationsystem:InformationType: [Experimental statistics]
-    publicationsystem:KeyFacts: Morbi egestas nisi at arcu pulvinar ultrices.
-      Sed et nunc risus. In hac habitasse platea dictumst. Proin ultrices, velit
-      vitae mollis aliquet, ligula ipsum tincidunt ante, nec imperdiet sapien
-      neque a nibh. In porta suscipit mauris. Suspendisse sit amet vestibulum
-      neque, at aliquet nibh. Aenean sed ante quam.
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
+    publicationsystem:Granularity:
+    - NHS Trusts
+    - GP practices
+    publicationsystem:InformationType:
+    - Experimental statistics
+    publicationsystem:KeyFacts: Morbi egestas nisi at arcu pulvinar ultrices. Sed
+      et nunc risus. In hac habitasse platea dictumst. Proin ultrices, velit vitae
+      mollis aliquet, ligula ipsum tincidunt ante, nec imperdiet sapien neque a nibh.
+      In porta suscipit mauris. Suspendisse sit amet vestibulum neque, at aliquet
+      nibh. Aenean sed ante quam.
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Lorem ipsum dolor sit amet, consectetur adipiscing
       elit. Duis convallis non massa vel dictum. In vel ex sapien. Donec sit amet
-      leo lobortis, tempor ex ut, luctus eros. In in eleifend orci, nec suscipit
-      nisi. Maecenas sed velit condimentum, lobortis tortor id, ultricies metus.
-      Integer odio ante, congue pulvinar ultrices nec, mollis vitae dolor. Curabitur
-      euismod erat elit, quis facilisis neque eleifend id. Maecenas convallis
-      vel mi nec bibendum. Donec ut erat dictum, molestie dolor non, aliquet nibh.
+      leo lobortis, tempor ex ut, luctus eros. In in eleifend orci, nec suscipit nisi.
+      Maecenas sed velit condimentum, lobortis tortor id, ultricies metus. Integer
+      odio ante, congue pulvinar ultrices nec, mollis vitae dolor. Curabitur euismod
+      erat elit, quis facilisis neque eleifend id. Maecenas convallis vel mi nec bibendum.
+      Donec ut erat dictum, molestie dolor non, aliquet nibh.
     publicationsystem:Title: publication with datasets
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: Test google.com link
-      publicationsystem:linkUrl: http://google.com
-    /publicationsystem:attachments:
-      jcr:primaryType: hippo:resource
-      hippo:filename: attachment.pdf
-      hippo:text:
-        type: binary
-        resource: attachment.pdf
-      jcr:data:
-        type: binary
-        resource: attachment.pdf
-      jcr:encoding: UTF-8
-      jcr:lastModified: 2017-11-09T21:42:39.618Z
-      jcr:mimeType: application/pdf
-    /publicationsystem:ResourceLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: Related resource link
-      publicationsystem:linkUrl: http://google.com
+  jcr:mixinTypes:
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/datasets-subfolder.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/datasets-subfolder.yaml
@@ -1,9 +1,13 @@
 ---
-
 /content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/datasets-subfolder:
-  jcr:primaryType: hippostd:folder
-  jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']
   hippo:name: Datasets Subfolder (Optional)
-  hippostd:foldertype: [new-translated-folder, new-document]
+  hippostd:foldertype:
+  - new-translated-folder
+  - new-document
   hippotranslation:id: 00000000-0000-0000-0000-000000000000
   hippotranslation:locale: en
+  jcr:mixinTypes:
+  - hippo:named
+  - hippotranslation:translated
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/datasets-subfolder/publication-with-datasets-dataset.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/datasets-subfolder/publication-with-datasets-dataset.yaml
@@ -1,13 +1,20 @@
 ---
-
-/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/datasets-subfolder/publication-with-datasets-dataset:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
-  hippo:name: publication-with-datasets Dataset
-  /publication-with-datasets-dataset[1]:
-    jcr:primaryType: publicationsystem:dataset
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:versionable']
-    hippo:availability: [preview]
+? /content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/datasets-subfolder/publication-with-datasets-dataset
+: /publication-with-datasets-dataset[1]:
+    /publicationsystem:Files:
+      hippo:filename: attachment.pdf
+      hippo:text:
+        resource: attachment.pdf
+        type: binary
+      jcr:data:
+        resource: attachment.pdf
+        type: binary
+      jcr:encoding: UTF-8
+      jcr:lastModified: 2017-11-09T21:42:39.618Z
+      jcr:mimeType: application/pdf
+      jcr:primaryType: hippo:resource
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-03T13:38:20.323Z
@@ -15,12 +22,18 @@
     hippostdpubwf:lastModifiedBy: admin
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    publicationsystem:CoverageEnd: 2017-07-01T01:00:00+01:00
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:dataset
+    publicationsystem:CoverageEnd: 2017-07-01T00:00:00Z
     publicationsystem:CoverageStart: 2016-02-01T00:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [NHS Trusts]
+    publicationsystem:Granularity:
+    - NHS Trusts
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
+    publicationsystem:PubliclyAccessible: true
     publicationsystem:Purpose: Vivamus et tortor ut ex placerat congue vitae nec velit.
       Donec imperdiet vestibulum lorem non viverra. Etiam sit amet venenatis purus.
     publicationsystem:Summary: Mauris ex est, dapibus in dictum ut, elementum sit
@@ -28,22 +41,19 @@
       accumsan. Nunc fringilla interdum nunc vitae tempus. Sed vitae ullamcorper velit.
       Maecenas convallis interdum magna, et finibus libero suscipit in.
     publicationsystem:Title: publication-with-datasets Dataset
-    publicationsystem:PubliclyAccessible: true
+  /publication-with-datasets-dataset[2]:
     /publicationsystem:Files:
-      jcr:primaryType: hippo:resource
       hippo:filename: attachment.pdf
       hippo:text:
-        type: binary
         resource: attachment.pdf
+        type: binary
       jcr:data:
-        type: binary
         resource: attachment.pdf
+        type: binary
       jcr:encoding: UTF-8
       jcr:lastModified: 2017-11-09T21:42:39.618Z
       jcr:mimeType: application/pdf
-  /publication-with-datasets-dataset[2]:
-    jcr:primaryType: publicationsystem:dataset
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
+      jcr:primaryType: hippo:resource
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
@@ -52,12 +62,18 @@
     hippostdpubwf:lastModifiedBy: admin
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    publicationsystem:CoverageEnd: 2017-07-01T01:00:00+01:00
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:dataset
+    publicationsystem:CoverageEnd: 2017-07-01T00:00:00Z
     publicationsystem:CoverageStart: 2016-02-01T00:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [NHS Trusts]
+    publicationsystem:Granularity:
+    - NHS Trusts
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
+    publicationsystem:PubliclyAccessible: true
     publicationsystem:Purpose: Vivamus et tortor ut ex placerat congue vitae nec velit.
       Donec imperdiet vestibulum lorem non viverra. Etiam sit amet venenatis purus.
     publicationsystem:Summary: Mauris ex est, dapibus in dictum ut, elementum sit
@@ -65,23 +81,21 @@
       accumsan. Nunc fringilla interdum nunc vitae tempus. Sed vitae ullamcorper velit.
       Maecenas convallis interdum magna, et finibus libero suscipit in.
     publicationsystem:Title: publication-with-datasets Dataset
-    publicationsystem:PubliclyAccessible: true
+  /publication-with-datasets-dataset[3]:
     /publicationsystem:Files:
-      jcr:primaryType: hippo:resource
       hippo:filename: attachment.pdf
       hippo:text:
-        type: binary
         resource: attachment.pdf
+        type: binary
       jcr:data:
-        type: binary
         resource: attachment.pdf
+        type: binary
       jcr:encoding: UTF-8
       jcr:lastModified: 2017-11-09T21:42:39.618Z
       jcr:mimeType: application/pdf
-  /publication-with-datasets-dataset[3]:
-    jcr:primaryType: publicationsystem:dataset
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+      jcr:primaryType: hippo:resource
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-03T13:38:20.323Z
@@ -90,12 +104,18 @@
     hippostdpubwf:publicationDate: 2017-11-09T21:42:50.263Z
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    publicationsystem:CoverageEnd: 2017-07-01T01:00:00+01:00
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:dataset
+    publicationsystem:CoverageEnd: 2017-07-01T00:00:00Z
     publicationsystem:CoverageStart: 2016-02-01T00:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [NHS Trusts]
+    publicationsystem:Granularity:
+    - NHS Trusts
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
+    publicationsystem:PubliclyAccessible: true
     publicationsystem:Purpose: Vivamus et tortor ut ex placerat congue vitae nec velit.
       Donec imperdiet vestibulum lorem non viverra. Etiam sit amet venenatis purus.
     publicationsystem:Summary: Mauris ex est, dapibus in dictum ut, elementum sit
@@ -103,16 +123,8 @@
       accumsan. Nunc fringilla interdum nunc vitae tempus. Sed vitae ullamcorper velit.
       Maecenas convallis interdum magna, et finibus libero suscipit in.
     publicationsystem:Title: publication-with-datasets Dataset
-    publicationsystem:PubliclyAccessible: true
-    /publicationsystem:Files:
-      jcr:primaryType: hippo:resource
-      hippo:filename: attachment.pdf
-      hippo:text:
-        type: binary
-        resource: attachment.pdf
-      jcr:data:
-        type: binary
-        resource: attachment.pdf
-      jcr:encoding: UTF-8
-      jcr:lastModified: 2017-11-09T21:42:39.618Z
-      jcr:mimeType: application/pdf
+  hippo:name: publication-with-datasets Dataset
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/etiam-placerat-arcu-dataset.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/etiam-placerat-arcu-dataset.yaml
@@ -1,12 +1,6 @@
 ---
-
-/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/etiam-placerat-arcu-dataset:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
-  hippo:name: Etiam Placerat Arcu Dataset
-  /etiam-placerat-arcu-dataset[1]:
-    jcr:primaryType: publicationsystem:dataset
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
+? /content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/etiam-placerat-arcu-dataset
+: /etiam-placerat-arcu-dataset[1]:
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
@@ -15,23 +9,27 @@
     hippostdpubwf:lastModifiedBy: admin
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:dataset
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [GP practices]
+    publicationsystem:Granularity:
+    - GP practices
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
-    publicationsystem:Purpose: Curabitur euismod erat elit, quis facilisis neque
-      eleifend id. Maecenas convallis vel mi nec bibendum.
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
+    publicationsystem:Purpose: Curabitur euismod erat elit, quis facilisis neque eleifend
+      id. Maecenas convallis vel mi nec bibendum.
     publicationsystem:Summary: Sed et nunc risus. In hac habitasse platea dictumst.
-      Proin ultrices, velit vitae mollis aliquet, ligula ipsum tincidunt ante,
-      nec imperdiet sapien neque a nibh. In porta suscipit mauris. Suspendisse
-      sit amet vestibulum neque, at aliquet nibh. Aenean sed ante quam.
+      Proin ultrices, velit vitae mollis aliquet, ligula ipsum tincidunt ante, nec
+      imperdiet sapien neque a nibh. In porta suscipit mauris. Suspendisse sit amet
+      vestibulum neque, at aliquet nibh. Aenean sed ante quam.
     publicationsystem:Title: Etiam Placerat Arcu Dataset
   /etiam-placerat-arcu-dataset[2]:
-    jcr:primaryType: publicationsystem:dataset
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-03T13:38:20.323Z
@@ -39,23 +37,28 @@
     hippostdpubwf:lastModifiedBy: admin
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:dataset
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [GP practices]
+    publicationsystem:Granularity:
+    - GP practices
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
-    publicationsystem:Purpose: Curabitur euismod erat elit, quis facilisis neque
-      eleifend id. Maecenas convallis vel mi nec bibendum.
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
+    publicationsystem:Purpose: Curabitur euismod erat elit, quis facilisis neque eleifend
+      id. Maecenas convallis vel mi nec bibendum.
     publicationsystem:Summary: Sed et nunc risus. In hac habitasse platea dictumst.
-      Proin ultrices, velit vitae mollis aliquet, ligula ipsum tincidunt ante,
-      nec imperdiet sapien neque a nibh. In porta suscipit mauris. Suspendisse
-      sit amet vestibulum neque, at aliquet nibh. Aenean sed ante quam.
+      Proin ultrices, velit vitae mollis aliquet, ligula ipsum tincidunt ante, nec
+      imperdiet sapien neque a nibh. In porta suscipit mauris. Suspendisse sit amet
+      vestibulum neque, at aliquet nibh. Aenean sed ante quam.
     publicationsystem:Title: Etiam Placerat Arcu Dataset
   /etiam-placerat-arcu-dataset[3]:
-    jcr:primaryType: publicationsystem:dataset
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-03T13:38:20.323Z
@@ -64,16 +67,26 @@
     hippostdpubwf:publicationDate: 2017-11-03T13:47:00.597Z
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:dataset
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [GP practices]
+    publicationsystem:Granularity:
+    - GP practices
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
-    publicationsystem:Purpose: Curabitur euismod erat elit, quis facilisis neque
-      eleifend id. Maecenas convallis vel mi nec bibendum.
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
+    publicationsystem:Purpose: Curabitur euismod erat elit, quis facilisis neque eleifend
+      id. Maecenas convallis vel mi nec bibendum.
     publicationsystem:Summary: Sed et nunc risus. In hac habitasse platea dictumst.
-      Proin ultrices, velit vitae mollis aliquet, ligula ipsum tincidunt ante,
-      nec imperdiet sapien neque a nibh. In porta suscipit mauris. Suspendisse
-      sit amet vestibulum neque, at aliquet nibh. Aenean sed ante quam.
+      Proin ultrices, velit vitae mollis aliquet, ligula ipsum tincidunt ante, nec
+      imperdiet sapien neque a nibh. In porta suscipit mauris. Suspendisse sit amet
+      vestibulum neque, at aliquet nibh. Aenean sed ante quam.
     publicationsystem:Title: Etiam Placerat Arcu Dataset
+  hippo:name: Etiam Placerat Arcu Dataset
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets.yaml
@@ -1,9 +1,13 @@
 ---
-
 /content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets:
-  jcr:primaryType: hippostd:folder
-  jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']
   hippo:name: Series With Publication With Datasets
-  hippostd:foldertype: [new-translated-folder, new-document]
+  hippostd:foldertype:
+  - new-translated-folder
+  - new-document
   hippotranslation:id: 00000000-0000-0000-0000-000000000000
   hippotranslation:locale: en
+  jcr:mixinTypes:
+  - hippo:named
+  - hippotranslation:translated
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/content.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/content.yaml
@@ -1,60 +1,63 @@
 ---
-
 /content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/content:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['mix:referenceable']
   /content[1]:
-    jcr:primaryType: publicationsystem:series
-    jcr:mixinTypes: ['mix:referenceable']
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T14:58:50.358+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T14:58:50.358+01:00
+    hippostdpubwf:creationDate: 2017-10-16T13:58:50.358Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T13:58:50.358Z
     hippostdpubwf:lastModifiedBy: admin
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    publicationsystem:Title: series-with-publication-with-datasets
-    publicationsystem:Summary: Integer suscipit pulvinar lacus non porta. Aenean
-      ut tempus ex. Proin eget tortor sollicitudin, pellentesque dolor eget,
-      aliquam quam. Nullam euismod accumsan nibh at lobortis. Nam non eleifend
-      mauris. Aliquam tempor nec odio non aliquam. Suspendisse in ex sit amet
-      lectus vehicula varius pharetra eget elit. Quisque at iaculis arcu, eget
-      ornare arcu.
-  /content[2]:
+    jcr:mixinTypes:
+    - mix:referenceable
     jcr:primaryType: publicationsystem:series
-    jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    publicationsystem:Summary: Integer suscipit pulvinar lacus non porta. Aenean ut
+      tempus ex. Proin eget tortor sollicitudin, pellentesque dolor eget, aliquam
+      quam. Nullam euismod accumsan nibh at lobortis. Nam non eleifend mauris. Aliquam
+      tempor nec odio non aliquam. Suspendisse in ex sit amet lectus vehicula varius
+      pharetra eget elit. Quisque at iaculis arcu, eget ornare arcu.
+    publicationsystem:Title: series-with-publication-with-datasets
+  /content[2]:
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T14:58:50.358+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T14:59:20.720+01:00
+    hippostdpubwf:creationDate: 2017-10-16T13:58:50.358Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T13:59:20.720Z
     hippostdpubwf:lastModifiedBy: admin
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    publicationsystem:Title: series-with-publication-with-datasets
-    publicationsystem:Summary: Integer suscipit pulvinar lacus non porta. Aenean
-      ut tempus ex. Proin eget tortor sollicitudin, pellentesque dolor eget,
-      aliquam quam. Nullam euismod accumsan nibh at lobortis. Nam non eleifend
-      mauris. Aliquam tempor nec odio non aliquam. Suspendisse in ex sit amet
-      lectus vehicula varius pharetra eget elit. Quisque at iaculis arcu, eget
-      ornare arcu.
-  /content[3]:
+    jcr:mixinTypes:
+    - mix:referenceable
+    - mix:versionable
     jcr:primaryType: publicationsystem:series
-    jcr:mixinTypes: ['mix:referenceable']
-    hippo:availability: [live]
+    publicationsystem:Summary: Integer suscipit pulvinar lacus non porta. Aenean ut
+      tempus ex. Proin eget tortor sollicitudin, pellentesque dolor eget, aliquam
+      quam. Nullam euismod accumsan nibh at lobortis. Nam non eleifend mauris. Aliquam
+      tempor nec odio non aliquam. Suspendisse in ex sit amet lectus vehicula varius
+      pharetra eget elit. Quisque at iaculis arcu, eget ornare arcu.
+    publicationsystem:Title: series-with-publication-with-datasets
+  /content[3]:
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T14:58:50.358+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T14:59:20.720+01:00
+    hippostdpubwf:creationDate: 2017-10-16T13:58:50.358Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T13:59:20.720Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2017-10-16T14:59:41.695+01:00
+    hippostdpubwf:publicationDate: 2017-10-16T13:59:41.695Z
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:series
+    publicationsystem:Summary: Integer suscipit pulvinar lacus non porta. Aenean ut
+      tempus ex. Proin eget tortor sollicitudin, pellentesque dolor eget, aliquam
+      quam. Nullam euismod accumsan nibh at lobortis. Nam non eleifend mauris. Aliquam
+      tempor nec odio non aliquam. Suspendisse in ex sit amet lectus vehicula varius
+      pharetra eget elit. Quisque at iaculis arcu, eget ornare arcu.
     publicationsystem:Title: series-with-publication-with-datasets
-    publicationsystem:Summary: Integer suscipit pulvinar lacus non porta. Aenean
-      ut tempus ex. Proin eget tortor sollicitudin, pellentesque dolor eget,
-      aliquam quam. Nullam euismod accumsan nibh at lobortis. Nam non eleifend
-      mauris. Aliquam tempor nec odio non aliquam. Suspendisse in ex sit amet
-      lectus vehicula varius pharetra eget elit. Quisque at iaculis arcu, eget
-      ornare arcu.
+  jcr:mixinTypes:
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets.yaml
@@ -1,9 +1,13 @@
 ---
-
-/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets:
-  jcr:primaryType: hippostd:folder
-  jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']
-  hippo:name: Series Publication With Datasets
-  hippostd:foldertype: [new-translated-folder, new-document]
+? /content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets
+: hippo:name: Series Publication With Datasets
+  hippostd:foldertype:
+  - new-translated-folder
+  - new-document
   hippotranslation:id: 00000000-0000-0000-0000-000000000000
   hippotranslation:locale: en
+  jcr:mixinTypes:
+  - hippo:named
+  - hippotranslation:translated
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/content.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/content.yaml
@@ -1,11 +1,6 @@
 ---
-
-/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/content:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['mix:referenceable']
-  /content[1]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
+? /content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/content
+: /content[1]:
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
@@ -14,29 +9,35 @@
     hippostdpubwf:lastModifiedBy: admin
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [NHS Trusts, GP practices]
-    publicationsystem:InformationType: [Experimental statistics]
-    publicationsystem:KeyFacts: Morbi egestas nisi at arcu pulvinar ultrices.
-      Sed et nunc risus. In hac habitasse platea dictumst. Proin ultrices, velit
-      vitae mollis aliquet, ligula ipsum tincidunt ante, nec imperdiet sapien
-      neque a nibh. In porta suscipit mauris. Suspendisse sit amet vestibulum
-      neque, at aliquet nibh. Aenean sed ante quam.
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
-    publicationsystem:Summary: Maecenas pharetra, magna ut pulvinar mattis, augue
-      nisi pharetra dolor, eget commodo lacus arcu vitae ligula. Pellentesque
-      condimentum tortor eu condimentum porta. Sed sit amet consectetur ipsum.
-      Integer imperdiet gravida augue in tincidunt. Donec luctus, massa sit amet
-      porttitor cursus, ante enim fringilla felis, nec elementum eros leo eu mauris.
-    publicationsystem:Title: series publication with datasets
+    publicationsystem:Granularity:
+    - NHS Trusts
+    - GP practices
+    publicationsystem:InformationType:
+    - Experimental statistics
+    publicationsystem:KeyFacts: Morbi egestas nisi at arcu pulvinar ultrices. Sed
+      et nunc risus. In hac habitasse platea dictumst. Proin ultrices, velit vitae
+      mollis aliquet, ligula ipsum tincidunt ante, nec imperdiet sapien neque a nibh.
+      In porta suscipit mauris. Suspendisse sit amet vestibulum neque, at aliquet
+      nibh. Aenean sed ante quam.
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
     publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Maecenas pharetra, magna ut pulvinar mattis, augue
+      nisi pharetra dolor, eget commodo lacus arcu vitae ligula. Pellentesque condimentum
+      tortor eu condimentum porta. Sed sit amet consectetur ipsum. Integer imperdiet
+      gravida augue in tincidunt. Donec luctus, massa sit amet porttitor cursus, ante
+      enim fringilla felis, nec elementum eros leo eu mauris.
+    publicationsystem:Title: series publication with datasets
   /content[2]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-03T13:35:36.812Z
@@ -44,29 +45,36 @@
     hippostdpubwf:lastModifiedBy: admin
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [NHS Trusts, GP practices]
-    publicationsystem:InformationType: [Experimental statistics]
-    publicationsystem:KeyFacts: Morbi egestas nisi at arcu pulvinar ultrices.
-      Sed et nunc risus. In hac habitasse platea dictumst. Proin ultrices, velit
-      vitae mollis aliquet, ligula ipsum tincidunt ante, nec imperdiet sapien
-      neque a nibh. In porta suscipit mauris. Suspendisse sit amet vestibulum
-      neque, at aliquet nibh. Aenean sed ante quam.
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
-    publicationsystem:Summary: Maecenas pharetra, magna ut pulvinar mattis, augue
-      nisi pharetra dolor, eget commodo lacus arcu vitae ligula. Pellentesque
-      condimentum tortor eu condimentum porta. Sed sit amet consectetur ipsum.
-      Integer imperdiet gravida augue in tincidunt. Donec luctus, massa sit amet
-      porttitor cursus, ante enim fringilla felis, nec elementum eros leo eu mauris.
-    publicationsystem:Title: series publication with datasets
+    publicationsystem:Granularity:
+    - NHS Trusts
+    - GP practices
+    publicationsystem:InformationType:
+    - Experimental statistics
+    publicationsystem:KeyFacts: Morbi egestas nisi at arcu pulvinar ultrices. Sed
+      et nunc risus. In hac habitasse platea dictumst. Proin ultrices, velit vitae
+      mollis aliquet, ligula ipsum tincidunt ante, nec imperdiet sapien neque a nibh.
+      In porta suscipit mauris. Suspendisse sit amet vestibulum neque, at aliquet
+      nibh. Aenean sed ante quam.
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
     publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Maecenas pharetra, magna ut pulvinar mattis, augue
+      nisi pharetra dolor, eget commodo lacus arcu vitae ligula. Pellentesque condimentum
+      tortor eu condimentum porta. Sed sit amet consectetur ipsum. Integer imperdiet
+      gravida augue in tincidunt. Donec luctus, massa sit amet porttitor cursus, ante
+      enim fringilla felis, nec elementum eros leo eu mauris.
+    publicationsystem:Title: series publication with datasets
   /content[3]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-03T13:35:36.812Z
@@ -75,22 +83,32 @@
     hippostdpubwf:publicationDate: 2017-11-03T13:41:09.207Z
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [NHS Trusts, GP practices]
-    publicationsystem:InformationType: [Experimental statistics]
-    publicationsystem:KeyFacts: Morbi egestas nisi at arcu pulvinar ultrices.
-      Sed et nunc risus. In hac habitasse platea dictumst. Proin ultrices, velit
-      vitae mollis aliquet, ligula ipsum tincidunt ante, nec imperdiet sapien
-      neque a nibh. In porta suscipit mauris. Suspendisse sit amet vestibulum
-      neque, at aliquet nibh. Aenean sed ante quam.
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
-    publicationsystem:Summary: Maecenas pharetra, magna ut pulvinar mattis, augue
-      nisi pharetra dolor, eget commodo lacus arcu vitae ligula. Pellentesque
-      condimentum tortor eu condimentum porta. Sed sit amet consectetur ipsum.
-      Integer imperdiet gravida augue in tincidunt. Donec luctus, massa sit amet
-      porttitor cursus, ante enim fringilla felis, nec elementum eros leo eu mauris.
-    publicationsystem:Title: series publication with datasets
+    publicationsystem:Granularity:
+    - NHS Trusts
+    - GP practices
+    publicationsystem:InformationType:
+    - Experimental statistics
+    publicationsystem:KeyFacts: Morbi egestas nisi at arcu pulvinar ultrices. Sed
+      et nunc risus. In hac habitasse platea dictumst. Proin ultrices, velit vitae
+      mollis aliquet, ligula ipsum tincidunt ante, nec imperdiet sapien neque a nibh.
+      In porta suscipit mauris. Suspendisse sit amet vestibulum neque, at aliquet
+      nibh. Aenean sed ante quam.
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
     publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Maecenas pharetra, magna ut pulvinar mattis, augue
+      nisi pharetra dolor, eget commodo lacus arcu vitae ligula. Pellentesque condimentum
+      tortor eu condimentum porta. Sed sit amet consectetur ipsum. Integer imperdiet
+      gravida augue in tincidunt. Donec luctus, massa sit amet porttitor cursus, ante
+      enim fringilla felis, nec elementum eros leo eu mauris.
+    publicationsystem:Title: series publication with datasets
+  jcr:mixinTypes:
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/series-publication-with-datasets-dataset.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/series-publication-with-datasets-dataset.yaml
@@ -1,12 +1,8 @@
 ---
-
-/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/series-publication-with-datasets-dataset:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['mix:referenceable']
-  /series-publication-with-datasets-dataset[1]:
-    jcr:primaryType: publicationsystem:dataset
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:versionable']
-    hippo:availability: [preview]
+? /content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/series-publication-with-datasets-dataset
+: /series-publication-with-datasets-dataset[1]:
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-03T13:38:20.323Z
@@ -14,12 +10,17 @@
     hippostdpubwf:lastModifiedBy: admin
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:dataset
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: Great Britain
-    publicationsystem:Granularity: [NHS Health Boards]
+    publicationsystem:Granularity:
+    - NHS Health Boards
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
     publicationsystem:Purpose: Morbi ipsum mauris, tincidunt sed dictum quis, dictum
       id magna. In vitae ante placerat, molestie est vel, aliquet lectus. Vivamus
       luctus id enim eu porttitor.
@@ -32,8 +33,6 @@
       augue convallis, scelerisque diam venenatis, maximus elit.
     publicationsystem:Title: series-publication-with-datasets Dataset
   /series-publication-with-datasets-dataset[2]:
-    jcr:primaryType: publicationsystem:dataset
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
@@ -42,12 +41,17 @@
     hippostdpubwf:lastModifiedBy: admin
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:dataset
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: Great Britain
-    publicationsystem:Granularity: [NHS Health Boards]
+    publicationsystem:Granularity:
+    - NHS Health Boards
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
     publicationsystem:Purpose: Morbi ipsum mauris, tincidunt sed dictum quis, dictum
       id magna. In vitae ante placerat, molestie est vel, aliquet lectus. Vivamus
       luctus id enim eu porttitor.
@@ -60,9 +64,8 @@
       augue convallis, scelerisque diam venenatis, maximus elit.
     publicationsystem:Title: series-publication-with-datasets Dataset
   /series-publication-with-datasets-dataset[3]:
-    jcr:primaryType: publicationsystem:dataset
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-03T13:38:20.323Z
@@ -71,12 +74,17 @@
     hippostdpubwf:publicationDate: 2017-11-03T13:48:35.552Z
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:dataset
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: Great Britain
-    publicationsystem:Granularity: [NHS Health Boards]
+    publicationsystem:Granularity:
+    - NHS Health Boards
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
     publicationsystem:Purpose: Morbi ipsum mauris, tincidunt sed dictum quis, dictum
       id magna. In vitae ante placerat, molestie est vel, aliquet lectus. Vivamus
       luctus id enim eu porttitor.
@@ -88,3 +96,6 @@
       habitasse platea dictumst. Aliquam dapibus eu purus sit amet aliquam. Cras non
       augue convallis, scelerisque diam venenatis, maximus elit.
     publicationsystem:Title: series-publication-with-datasets Dataset
+  jcr:mixinTypes:
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/upcoming-publication.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/upcoming-publication.yaml
@@ -1,9 +1,13 @@
 ---
-
 /content/documents/corporate-website/publication-system/acceptance-tests/upcoming-publication:
-  jcr:primaryType: hippostd:folder
-  jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']
   hippo:name: Upcoming Publication
-  hippostd:foldertype: [new-translated-folder, new-document]
+  hippostd:foldertype:
+  - new-translated-folder
+  - new-document
   hippotranslation:id: 00000000-0000-0000-0000-000000000000
   hippotranslation:locale: en
+  jcr:mixinTypes:
+  - hippo:named
+  - hippotranslation:translated
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/upcoming-publication/content.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/upcoming-publication/content.yaml
@@ -1,11 +1,6 @@
 ---
-
 /content/documents/corporate-website/publication-system/acceptance-tests/upcoming-publication/content:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['mix:referenceable']
   /content[1]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
@@ -14,31 +9,37 @@
     hippostdpubwf:lastModifiedBy: admin
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [NHS Trusts, GP practices]
-    publicationsystem:InformationType: [Experimental statistics]
-    publicationsystem:KeyFacts: Morbi egestas nisi at arcu pulvinar ultrices.
-      Sed et nunc risus. In hac habitasse platea dictumst. Proin ultrices, velit
-      vitae mollis aliquet, ligula ipsum tincidunt ante, nec imperdiet sapien
-      neque a nibh. In porta suscipit mauris. Suspendisse sit amet vestibulum
-      neque, at aliquet nibh. Aenean sed ante quam.
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
+    publicationsystem:Granularity:
+    - NHS Trusts
+    - GP practices
+    publicationsystem:InformationType:
+    - Experimental statistics
+    publicationsystem:KeyFacts: Morbi egestas nisi at arcu pulvinar ultrices. Sed
+      et nunc risus. In hac habitasse platea dictumst. Proin ultrices, velit vitae
+      mollis aliquet, ligula ipsum tincidunt ante, nec imperdiet sapien neque a nibh.
+      In porta suscipit mauris. Suspendisse sit amet vestibulum neque, at aliquet
+      nibh. Aenean sed ante quam.
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
+    publicationsystem:PubliclyAccessible: false
     publicationsystem:Summary: Lorem ipsum dolor sit amet, consectetur adipiscing
       elit. Duis convallis non massa vel dictum. In vel ex sapien. Donec sit amet
-      leo lobortis, tempor ex ut, luctus eros. In in eleifend orci, nec suscipit
-      nisi. Maecenas sed velit condimentum, lobortis tortor id, ultricies metus.
-      Integer odio ante, congue pulvinar ultrices nec, mollis vitae dolor. Curabitur
-      euismod erat elit, quis facilisis neque eleifend id. Maecenas convallis
-      vel mi nec bibendum. Donec ut erat dictum, molestie dolor non, aliquet nibh.
+      leo lobortis, tempor ex ut, luctus eros. In in eleifend orci, nec suscipit nisi.
+      Maecenas sed velit condimentum, lobortis tortor id, ultricies metus. Integer
+      odio ante, congue pulvinar ultrices nec, mollis vitae dolor. Curabitur euismod
+      erat elit, quis facilisis neque eleifend id. Maecenas convallis vel mi nec bibendum.
+      Donec ut erat dictum, molestie dolor non, aliquet nibh.
     publicationsystem:Title: Upcoming Publication
-    publicationsystem:PubliclyAccessible: false
   /content[2]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-03T13:35:36.812Z
@@ -46,31 +47,38 @@
     hippostdpubwf:lastModifiedBy: admin
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [NHS Trusts, GP practices]
-    publicationsystem:InformationType: [Experimental statistics]
-    publicationsystem:KeyFacts: Morbi egestas nisi at arcu pulvinar ultrices.
-      Sed et nunc risus. In hac habitasse platea dictumst. Proin ultrices, velit
-      vitae mollis aliquet, ligula ipsum tincidunt ante, nec imperdiet sapien
-      neque a nibh. In porta suscipit mauris. Suspendisse sit amet vestibulum
-      neque, at aliquet nibh. Aenean sed ante quam.
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
+    publicationsystem:Granularity:
+    - NHS Trusts
+    - GP practices
+    publicationsystem:InformationType:
+    - Experimental statistics
+    publicationsystem:KeyFacts: Morbi egestas nisi at arcu pulvinar ultrices. Sed
+      et nunc risus. In hac habitasse platea dictumst. Proin ultrices, velit vitae
+      mollis aliquet, ligula ipsum tincidunt ante, nec imperdiet sapien neque a nibh.
+      In porta suscipit mauris. Suspendisse sit amet vestibulum neque, at aliquet
+      nibh. Aenean sed ante quam.
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
+    publicationsystem:PubliclyAccessible: false
     publicationsystem:Summary: Lorem ipsum dolor sit amet, consectetur adipiscing
       elit. Duis convallis non massa vel dictum. In vel ex sapien. Donec sit amet
-      leo lobortis, tempor ex ut, luctus eros. In in eleifend orci, nec suscipit
-      nisi. Maecenas sed velit condimentum, lobortis tortor id, ultricies metus.
-      Integer odio ante, congue pulvinar ultrices nec, mollis vitae dolor. Curabitur
-      euismod erat elit, quis facilisis neque eleifend id. Maecenas convallis
-      vel mi nec bibendum. Donec ut erat dictum, molestie dolor non, aliquet nibh.
+      leo lobortis, tempor ex ut, luctus eros. In in eleifend orci, nec suscipit nisi.
+      Maecenas sed velit condimentum, lobortis tortor id, ultricies metus. Integer
+      odio ante, congue pulvinar ultrices nec, mollis vitae dolor. Curabitur euismod
+      erat elit, quis facilisis neque eleifend id. Maecenas convallis vel mi nec bibendum.
+      Donec ut erat dictum, molestie dolor non, aliquet nibh.
     publicationsystem:Title: Upcoming Publication
-    publicationsystem:PubliclyAccessible: false
   /content[3]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-03T13:35:36.812Z
@@ -79,24 +87,34 @@
     hippostdpubwf:publicationDate: 2017-11-03T13:41:09.207Z
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [NHS Trusts, GP practices]
-    publicationsystem:InformationType: [Experimental statistics]
-    publicationsystem:KeyFacts: Morbi egestas nisi at arcu pulvinar ultrices.
-      Sed et nunc risus. In hac habitasse platea dictumst. Proin ultrices, velit
-      vitae mollis aliquet, ligula ipsum tincidunt ante, nec imperdiet sapien
-      neque a nibh. In porta suscipit mauris. Suspendisse sit amet vestibulum
-      neque, at aliquet nibh. Aenean sed ante quam.
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
+    publicationsystem:Granularity:
+    - NHS Trusts
+    - GP practices
+    publicationsystem:InformationType:
+    - Experimental statistics
+    publicationsystem:KeyFacts: Morbi egestas nisi at arcu pulvinar ultrices. Sed
+      et nunc risus. In hac habitasse platea dictumst. Proin ultrices, velit vitae
+      mollis aliquet, ligula ipsum tincidunt ante, nec imperdiet sapien neque a nibh.
+      In porta suscipit mauris. Suspendisse sit amet vestibulum neque, at aliquet
+      nibh. Aenean sed ante quam.
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
+    publicationsystem:PubliclyAccessible: false
     publicationsystem:Summary: Lorem ipsum dolor sit amet, consectetur adipiscing
       elit. Duis convallis non massa vel dictum. In vel ex sapien. Donec sit amet
-      leo lobortis, tempor ex ut, luctus eros. In in eleifend orci, nec suscipit
-      nisi. Maecenas sed velit condimentum, lobortis tortor id, ultricies metus.
-      Integer odio ante, congue pulvinar ultrices nec, mollis vitae dolor. Curabitur
-      euismod erat elit, quis facilisis neque eleifend id. Maecenas convallis
-      vel mi nec bibendum. Donec ut erat dictum, molestie dolor non, aliquet nibh.
+      leo lobortis, tempor ex ut, luctus eros. In in eleifend orci, nec suscipit nisi.
+      Maecenas sed velit condimentum, lobortis tortor id, ultricies metus. Integer
+      odio ante, congue pulvinar ultrices nec, mollis vitae dolor. Curabitur euismod
+      erat elit, quis facilisis neque eleifend id. Maecenas convallis vel mi nec bibendum.
+      Donec ut erat dictum, molestie dolor non, aliquet nibh.
     publicationsystem:Title: Upcoming Publication
-    publicationsystem:PubliclyAccessible: false
+  jcr:mixinTypes:
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/upcoming-publication/upcoming-dataset.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/upcoming-publication/upcoming-dataset.yaml
@@ -1,12 +1,6 @@
 ---
-
 /content/documents/corporate-website/publication-system/acceptance-tests/upcoming-publication/upcoming-dataset:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
-  hippo:name: Upcoming Dataset
   /upcoming-dataset[1]:
-    jcr:primaryType: publicationsystem:dataset
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
@@ -15,23 +9,27 @@
     hippostdpubwf:lastModifiedBy: admin
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:dataset
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [GP practices]
+    publicationsystem:Granularity:
+    - GP practices
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
-    publicationsystem:Purpose: Curabitur euismod erat elit, quis facilisis neque
-      eleifend id. Maecenas convallis vel mi nec bibendum.
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
+    publicationsystem:Purpose: Curabitur euismod erat elit, quis facilisis neque eleifend
+      id. Maecenas convallis vel mi nec bibendum.
     publicationsystem:Summary: Sed et nunc risus. In hac habitasse platea dictumst.
-      Proin ultrices, velit vitae mollis aliquet, ligula ipsum tincidunt ante,
-      nec imperdiet sapien neque a nibh. In porta suscipit mauris. Suspendisse
-      sit amet vestibulum neque, at aliquet nibh. Aenean sed ante quam.
+      Proin ultrices, velit vitae mollis aliquet, ligula ipsum tincidunt ante, nec
+      imperdiet sapien neque a nibh. In porta suscipit mauris. Suspendisse sit amet
+      vestibulum neque, at aliquet nibh. Aenean sed ante quam.
     publicationsystem:Title: Upcoming Dataset
   /upcoming-dataset[2]:
-    jcr:primaryType: publicationsystem:dataset
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-03T13:38:20.323Z
@@ -39,23 +37,28 @@
     hippostdpubwf:lastModifiedBy: admin
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:dataset
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [GP practices]
+    publicationsystem:Granularity:
+    - GP practices
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
-    publicationsystem:Purpose: Curabitur euismod erat elit, quis facilisis neque
-      eleifend id. Maecenas convallis vel mi nec bibendum.
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
+    publicationsystem:Purpose: Curabitur euismod erat elit, quis facilisis neque eleifend
+      id. Maecenas convallis vel mi nec bibendum.
     publicationsystem:Summary: Sed et nunc risus. In hac habitasse platea dictumst.
-      Proin ultrices, velit vitae mollis aliquet, ligula ipsum tincidunt ante,
-      nec imperdiet sapien neque a nibh. In porta suscipit mauris. Suspendisse
-      sit amet vestibulum neque, at aliquet nibh. Aenean sed ante quam.
+      Proin ultrices, velit vitae mollis aliquet, ligula ipsum tincidunt ante, nec
+      imperdiet sapien neque a nibh. In porta suscipit mauris. Suspendisse sit amet
+      vestibulum neque, at aliquet nibh. Aenean sed ante quam.
     publicationsystem:Title: Upcoming Dataset
   /upcoming-dataset[3]:
-    jcr:primaryType: publicationsystem:dataset
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-03T13:38:20.323Z
@@ -64,16 +67,26 @@
     hippostdpubwf:publicationDate: 2017-11-03T13:47:00.597Z
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:dataset
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:Granularity: [GP practices]
+    publicationsystem:Granularity:
+    - GP practices
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
-    publicationsystem:NominalDate: 2017-10-10T01:00:00+01:00
-    publicationsystem:Purpose: Curabitur euismod erat elit, quis facilisis neque
-      eleifend id. Maecenas convallis vel mi nec bibendum.
+    publicationsystem:NominalDate: 2017-10-10T00:00:00Z
+    publicationsystem:Purpose: Curabitur euismod erat elit, quis facilisis neque eleifend
+      id. Maecenas convallis vel mi nec bibendum.
     publicationsystem:Summary: Sed et nunc risus. In hac habitasse platea dictumst.
-      Proin ultrices, velit vitae mollis aliquet, ligula ipsum tincidunt ante,
-      nec imperdiet sapien neque a nibh. In porta suscipit mauris. Suspendisse
-      sit amet vestibulum neque, at aliquet nibh. Aenean sed ante quam.
+      Proin ultrices, velit vitae mollis aliquet, ligula ipsum tincidunt ante, nec
+      imperdiet sapien neque a nibh. In porta suscipit mauris. Suspendisse sit amet
+      vestibulum neque, at aliquet nibh. Aenean sed ante quam.
     publicationsystem:Title: Upcoming Dataset
+  hippo:name: Upcoming Dataset
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content.yaml
@@ -1,9 +1,13 @@
 ---
-
 /content/documents/corporate-website/publication-system/lorem-ipsum-content:
-  jcr:primaryType: hippostd:folder
-  jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']
   hippo:name: Lorem Ipsum Content
-  hippostd:foldertype: [new-translated-folder, new-document]
+  hippostd:foldertype:
+  - new-translated-folder
+  - new-document
   hippotranslation:id: 00000000-0000-0000-0000-000000000000
   hippotranslation:locale: en
+  jcr:mixinTypes:
+  - hippo:named
+  - hippotranslation:translated
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/fusce-viverra-dolor.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/fusce-viverra-dolor.yaml
@@ -1,111 +1,123 @@
 ---
-
 /content/documents/corporate-website/publication-system/lorem-ipsum-content/fusce-viverra-dolor:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['mix:referenceable']
   /fusce-viverra-dolor[1]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
+    /publicationsystem:RelatedLinks:
+      jcr:primaryType: publicationsystem:relatedlink
+      publicationsystem:linkText: ''
+      publicationsystem:linkUrl: ''
+      publicationsystem:link_text: ''
+      publicationsystem:link_url: ''
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - falls
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: Ipsum dolor sit amet, consectetur adipiscing elit.
       Mauris mattis sodales felis, vitae ultricies turpis porttitor in. Integer sit
       amet efficitur urna.
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc
-      pellentesque, lobortis orci eu, placerat nibh. Nulla est mauris, vehicula
-      nec ornare a, lacinia vel odio. Sed et accumsan mi, quis finibus orci. Integer
-      eget tortor mauris. Cras fermentum sodales urna, ac vulputate odio lobortis
-      eget. Etiam id erat blandit, feugiat orci non, pharetra est. Sed interdum
-      a leo facilisis aliquam. Curabitur justo nisi, mattis vel neque placerat,
-      imperdiet ultrices tortor.
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc pellentesque,
+      lobortis orci eu, placerat nibh. Nulla est mauris, vehicula nec ornare a, lacinia
+      vel odio. Sed et accumsan mi, quis finibus orci. Integer eget tortor mauris.
+      Cras fermentum sodales urna, ac vulputate odio lobortis eget. Etiam id erat
+      blandit, feugiat orci non, pharetra est. Sed interdum a leo facilisis aliquam.
+      Curabitur justo nisi, mattis vel neque placerat, imperdiet ultrices tortor.
     publicationsystem:Title: Fusce viverra dolor
+  /fusce-viverra-dolor[2]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: ''
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /fusce-viverra-dolor[2]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - falls
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: Ipsum dolor sit amet, consectetur adipiscing elit.
       Mauris mattis sodales felis, vitae ultricies turpis porttitor in. Integer sit
       amet efficitur urna.
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc
-      pellentesque, lobortis orci eu, placerat nibh. Nulla est mauris, vehicula
-      nec ornare a, lacinia vel odio. Sed et accumsan mi, quis finibus orci. Integer
-      eget tortor mauris. Cras fermentum sodales urna, ac vulputate odio lobortis
-      eget. Etiam id erat blandit, feugiat orci non, pharetra est. Sed interdum
-      a leo facilisis aliquam. Curabitur justo nisi, mattis vel neque placerat,
-      imperdiet ultrices tortor.
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc pellentesque,
+      lobortis orci eu, placerat nibh. Nulla est mauris, vehicula nec ornare a, lacinia
+      vel odio. Sed et accumsan mi, quis finibus orci. Integer eget tortor mauris.
+      Cras fermentum sodales urna, ac vulputate odio lobortis eget. Etiam id erat
+      blandit, feugiat orci non, pharetra est. Sed interdum a leo facilisis aliquam.
+      Curabitur justo nisi, mattis vel neque placerat, imperdiet ultrices tortor.
     publicationsystem:Title: Fusce viverra dolor
+  /fusce-viverra-dolor[3]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: ''
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /fusce-viverra-dolor[3]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:publicationDate: 2017-10-16T14:00:00Z
+    hippotaxonomy:keys:
+    - falls
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: Ipsum dolor sit amet, consectetur adipiscing elit.
       Mauris mattis sodales felis, vitae ultricies turpis porttitor in. Integer sit
       amet efficitur urna.
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc
-      pellentesque, lobortis orci eu, placerat nibh. Nulla est mauris, vehicula
-      nec ornare a, lacinia vel odio. Sed et accumsan mi, quis finibus orci. Integer
-      eget tortor mauris. Cras fermentum sodales urna, ac vulputate odio lobortis
-      eget. Etiam id erat blandit, feugiat orci non, pharetra est. Sed interdum
-      a leo facilisis aliquam. Curabitur justo nisi, mattis vel neque placerat,
-      imperdiet ultrices tortor.
-    publicationsystem:Title: Fusce viverra dolor
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
     publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc pellentesque,
+      lobortis orci eu, placerat nibh. Nulla est mauris, vehicula nec ornare a, lacinia
+      vel odio. Sed et accumsan mi, quis finibus orci. Integer eget tortor mauris.
+      Cras fermentum sodales urna, ac vulputate odio lobortis eget. Etiam id erat
+      blandit, feugiat orci non, pharetra est. Sed interdum a leo facilisis aliquam.
+      Curabitur justo nisi, mattis vel neque placerat, imperdiet ultrices tortor.
+    publicationsystem:Title: Fusce viverra dolor
+  jcr:mixinTypes:
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/lorem-ipsum.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/lorem-ipsum.yaml
@@ -1,105 +1,117 @@
 ---
-
 /content/documents/corporate-website/publication-system/lorem-ipsum-content/lorem-ipsum:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['mix:referenceable']
   /lorem-ipsum[1]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
+    /publicationsystem:RelatedLinks:
+      jcr:primaryType: publicationsystem:relatedlink
+      publicationsystem:linkText: ''
+      publicationsystem:linkUrl: ''
+      publicationsystem:link_text: ''
+      publicationsystem:link_url: ''
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - infectious-diseases
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [infectious-diseases]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc
-      pellentesque, lobortis orci eu, placerat lorem. Nulla est mauris, vehicula
-      nec ornare a, lacinia vel odio. Sed et accumsan mi, quis finibus orci. Integer
-      eget tortor mauris. Cras fermentum sodales urna, ac vulputate odio lobortis
-      eget. Etiam id erat blandit, feugiat orci non, pharetra est. Sed interdum
-      a leo facilisis aliquam. Curabitur justo nisi, mattis vel neque placerat,
-      imperdiet ultrices tortor.
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc pellentesque,
+      lobortis orci eu, placerat lorem. Nulla est mauris, vehicula nec ornare a, lacinia
+      vel odio. Sed et accumsan mi, quis finibus orci. Integer eget tortor mauris.
+      Cras fermentum sodales urna, ac vulputate odio lobortis eget. Etiam id erat
+      blandit, feugiat orci non, pharetra est. Sed interdum a leo facilisis aliquam.
+      Curabitur justo nisi, mattis vel neque placerat, imperdiet ultrices tortor.
     publicationsystem:Title: Lorem ipsum dolor sit amet.
+  /lorem-ipsum[2]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: ''
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /lorem-ipsum[2]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - infectious-diseases
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [infectious-diseases]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc
-      pellentesque, lobortis orci eu, placerat lorem. Nulla est mauris, vehicula
-      nec ornare a, lacinia vel odio. Sed et accumsan mi, quis finibus orci. Integer
-      eget tortor mauris. Cras fermentum sodales urna, ac vulputate odio lobortis
-      eget. Etiam id erat blandit, feugiat orci non, pharetra est. Sed interdum
-      a leo facilisis aliquam. Curabitur justo nisi, mattis vel neque placerat,
-      imperdiet ultrices tortor.
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc pellentesque,
+      lobortis orci eu, placerat lorem. Nulla est mauris, vehicula nec ornare a, lacinia
+      vel odio. Sed et accumsan mi, quis finibus orci. Integer eget tortor mauris.
+      Cras fermentum sodales urna, ac vulputate odio lobortis eget. Etiam id erat
+      blandit, feugiat orci non, pharetra est. Sed interdum a leo facilisis aliquam.
+      Curabitur justo nisi, mattis vel neque placerat, imperdiet ultrices tortor.
     publicationsystem:Title: Lorem ipsum dolor sit amet.
+  /lorem-ipsum[3]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: ''
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /lorem-ipsum[3]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:publicationDate: 2017-10-16T14:00:00Z
+    hippotaxonomy:keys:
+    - infectious-diseases
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [infectious-diseases]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc
-      pellentesque, lobortis orci eu, placerat lorem. Nulla est mauris, vehicula
-      nec ornare a, lacinia vel odio. Sed et accumsan mi, quis finibus orci. Integer
-      eget tortor mauris. Cras fermentum sodales urna, ac vulputate odio lobortis
-      eget. Etiam id erat blandit, feugiat orci non, pharetra est. Sed interdum
-      a leo facilisis aliquam. Curabitur justo nisi, mattis vel neque placerat,
-      imperdiet ultrices tortor.
-    publicationsystem:Title: Lorem ipsum dolor sit amet.
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
     publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc pellentesque,
+      lobortis orci eu, placerat lorem. Nulla est mauris, vehicula nec ornare a, lacinia
+      vel odio. Sed et accumsan mi, quis finibus orci. Integer eget tortor mauris.
+      Cras fermentum sodales urna, ac vulputate odio lobortis eget. Etiam id erat
+      blandit, feugiat orci non, pharetra est. Sed interdum a leo facilisis aliquam.
+      Curabitur justo nisi, mattis vel neque placerat, imperdiet ultrices tortor.
+    publicationsystem:Title: Lorem ipsum dolor sit amet.
+  jcr:mixinTypes:
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-tempor-euismod-vehicula.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-tempor-euismod-vehicula.yaml
@@ -1,108 +1,123 @@
 ---
-
 /content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-tempor-euismod-vehicula:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['mix:referenceable']
   /morbi-tempor-euismod-vehicula[1]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
+    /publicationsystem:RelatedLinks:
+      jcr:primaryType: publicationsystem:relatedlink
+      publicationsystem:linkText: ''
+      publicationsystem:linkUrl: ''
+      publicationsystem:link_text: ''
+      publicationsystem:link_url: ''
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Duis vel ultricies ante. Vestibulum nec commodo
-      justo. Donec et tellus justo. Nunc id lobortis odio. Morbi quis lectus
-      scelerisque, efficitur augue a, aliquet velit. Duis ac malesuada tortor. Duis
-      mollis lorem consectetur ipsum convallis sollicitudin. Lorem ipsum dolor sit
-      amet, consectetur adipiscing elit. Donec varius eget purus nec finibus. Cras
-      a urna vestibulum, blandit nisl sit amet, auctor augue. Ut euismod eros quis
-      lacus ullamcorper, ut mollis nunc vehicula. Ut maximus, arcu nec mollis
-      ultricies, libero tortor porta ante, id iaculis nisl est ac velit.
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Duis vel ultricies ante. Vestibulum nec commodo justo.
+      Donec et tellus justo. Nunc id lobortis odio. Morbi quis lectus scelerisque,
+      efficitur augue a, aliquet velit. Duis ac malesuada tortor. Duis mollis lorem
+      consectetur ipsum convallis sollicitudin. Lorem ipsum dolor sit amet, consectetur
+      adipiscing elit. Donec varius eget purus nec finibus. Cras a urna vestibulum,
+      blandit nisl sit amet, auctor augue. Ut euismod eros quis lacus ullamcorper,
+      ut mollis nunc vehicula. Ut maximus, arcu nec mollis ultricies, libero tortor
+      porta ante, id iaculis nisl est ac velit.
     publicationsystem:Title: Morbi tempor euismod vehicula
+  /morbi-tempor-euismod-vehicula[2]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: ''
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /morbi-tempor-euismod-vehicula[2]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Duis vel ultricies ante. Vestibulum nec commodo
-      justo. Donec et tellus justo. Nunc id lobortis odio. Morbi quis lectus
-      scelerisque, efficitur augue a, aliquet velit. Duis ac malesuada tortor. Duis
-      mollis lorem consectetur ipsum convallis sollicitudin. Lorem ipsum dolor sit
-      amet, consectetur adipiscing elit. Donec varius eget purus nec finibus. Cras
-      a urna vestibulum, blandit nisl sit amet, auctor augue. Ut euismod eros quis
-      lacus ullamcorper, ut mollis nunc vehicula. Ut maximus, arcu nec mollis
-      ultricies, libero tortor porta ante, id iaculis nisl est ac velit.
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Duis vel ultricies ante. Vestibulum nec commodo justo.
+      Donec et tellus justo. Nunc id lobortis odio. Morbi quis lectus scelerisque,
+      efficitur augue a, aliquet velit. Duis ac malesuada tortor. Duis mollis lorem
+      consectetur ipsum convallis sollicitudin. Lorem ipsum dolor sit amet, consectetur
+      adipiscing elit. Donec varius eget purus nec finibus. Cras a urna vestibulum,
+      blandit nisl sit amet, auctor augue. Ut euismod eros quis lacus ullamcorper,
+      ut mollis nunc vehicula. Ut maximus, arcu nec mollis ultricies, libero tortor
+      porta ante, id iaculis nisl est ac velit.
     publicationsystem:Title: Morbi tempor euismod vehicula
+  /morbi-tempor-euismod-vehicula[3]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: ''
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /morbi-tempor-euismod-vehicula[3]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:publicationDate: 2017-10-16T14:00:00Z
+    hippotaxonomy:keys:
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Duis vel ultricies ante. Vestibulum nec commodo
-      justo. Donec et tellus justo. Nunc id lobortis odio. Morbi quis lectus
-      scelerisque, efficitur augue a, aliquet velit. Duis ac malesuada tortor. Duis
-      mollis lorem consectetur ipsum convallis sollicitudin. Lorem ipsum dolor sit
-      amet, consectetur adipiscing elit. Donec varius eget purus nec finibus. Cras
-      a urna vestibulum, blandit nisl sit amet, auctor augue. Ut euismod eros quis
-      lacus ullamcorper, ut mollis nunc vehicula. Ut maximus, arcu nec mollis
-      ultricies, libero tortor porta ante, id iaculis nisl est ac velit.
-    publicationsystem:Title: Morbi tempor euismod vehicula
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
     publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Duis vel ultricies ante. Vestibulum nec commodo justo.
+      Donec et tellus justo. Nunc id lobortis odio. Morbi quis lectus scelerisque,
+      efficitur augue a, aliquet velit. Duis ac malesuada tortor. Duis mollis lorem
+      consectetur ipsum convallis sollicitudin. Lorem ipsum dolor sit amet, consectetur
+      adipiscing elit. Donec varius eget purus nec finibus. Cras a urna vestibulum,
+      blandit nisl sit amet, auctor augue. Ut euismod eros quis lacus ullamcorper,
+      ut mollis nunc vehicula. Ut maximus, arcu nec mollis ultricies, libero tortor
+      porta ante, id iaculis nisl est ac velit.
+    publicationsystem:Title: Morbi tempor euismod vehicula
+  jcr:mixinTypes:
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-vitae-nunc-ac-lacus-malesuada-tempus.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-vitae-nunc-ac-lacus-malesuada-tempus.yaml
@@ -1,111 +1,126 @@
 ---
-
 /content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-vitae-nunc-ac-lacus-malesuada-tempus:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['mix:referenceable']
   /morbi-vitae-nunc-ac-lacus-malesuada-tempus[1]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
+    /publicationsystem:RelatedLinks:
+      jcr:primaryType: publicationsystem:relatedlink
+      publicationsystem:linkText: ''
+      publicationsystem:linkUrl: ''
+      publicationsystem:link_text: ''
+      publicationsystem:link_url: ''
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - infectious-diseases
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [infectious-diseases, workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
-    publicationsystem:KeyFacts: Donec ultricies fringilla mauris nec varius.
-      Pellentesque ultricies et libero et venenatis. Mauris accumsan ligula sed enim
-      volutpat scelerisque.
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Etiam tempus quam sed massa ullamcorper, in
-      vestibulum ex ultrices. Duis ipsum, eros et accumsan auctor, turpis lectus
-      viverra urna, eu viverra neque sem at metus. Praesent lacinia erat facilisis,
-      blandit elit a, volutpat ipsum. Morbi egestas eleifend sem. Sed semper egestas
-      purus, ac tempor sem efficitur ac. Cras leo mauris, vestibulum eget turpis ut,
-      bibendum rhoncus neque. Aliquam erat volutpat. Aliquam erat volutpat. Nullam
-      justo mi, ipsum a ante nec, tincidunt eleifend tortor.
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
+    publicationsystem:KeyFacts: Donec ultricies fringilla mauris nec varius. Pellentesque
+      ultricies et libero et venenatis. Mauris accumsan ligula sed enim volutpat scelerisque.
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Etiam tempus quam sed massa ullamcorper, in vestibulum
+      ex ultrices. Duis ipsum, eros et accumsan auctor, turpis lectus viverra urna,
+      eu viverra neque sem at metus. Praesent lacinia erat facilisis, blandit elit
+      a, volutpat ipsum. Morbi egestas eleifend sem. Sed semper egestas purus, ac
+      tempor sem efficitur ac. Cras leo mauris, vestibulum eget turpis ut, bibendum
+      rhoncus neque. Aliquam erat volutpat. Aliquam erat volutpat. Nullam justo mi,
+      ipsum a ante nec, tincidunt eleifend tortor.
     publicationsystem:Title: Morbi vitae nunc ac lacus malesuada tempus
+  /morbi-vitae-nunc-ac-lacus-malesuada-tempus[2]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: ''
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /morbi-vitae-nunc-ac-lacus-malesuada-tempus[2]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - infectious-diseases
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [infectious-diseases, workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
-    publicationsystem:KeyFacts: Donec ultricies fringilla mauris nec varius.
-      Pellentesque ultricies et libero et venenatis. Mauris accumsan ligula sed enim
-      volutpat scelerisque.
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Etiam tempus quam sed massa ullamcorper, in
-      vestibulum ex ultrices. Duis ipsum, eros et accumsan auctor, turpis lectus
-      viverra urna, eu viverra neque sem at metus. Praesent lacinia erat facilisis,
-      blandit elit a, volutpat ipsum. Morbi egestas eleifend sem. Sed semper egestas
-      purus, ac tempor sem efficitur ac. Cras leo mauris, vestibulum eget turpis ut,
-      bibendum rhoncus neque. Aliquam erat volutpat. Aliquam erat volutpat. Nullam
-      justo mi, ipsum a ante nec, tincidunt eleifend tortor.
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
+    publicationsystem:KeyFacts: Donec ultricies fringilla mauris nec varius. Pellentesque
+      ultricies et libero et venenatis. Mauris accumsan ligula sed enim volutpat scelerisque.
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Etiam tempus quam sed massa ullamcorper, in vestibulum
+      ex ultrices. Duis ipsum, eros et accumsan auctor, turpis lectus viverra urna,
+      eu viverra neque sem at metus. Praesent lacinia erat facilisis, blandit elit
+      a, volutpat ipsum. Morbi egestas eleifend sem. Sed semper egestas purus, ac
+      tempor sem efficitur ac. Cras leo mauris, vestibulum eget turpis ut, bibendum
+      rhoncus neque. Aliquam erat volutpat. Aliquam erat volutpat. Nullam justo mi,
+      ipsum a ante nec, tincidunt eleifend tortor.
     publicationsystem:Title: Morbi vitae nunc ac lacus malesuada tempus
+  /morbi-vitae-nunc-ac-lacus-malesuada-tempus[3]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: ''
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /morbi-vitae-nunc-ac-lacus-malesuada-tempus[3]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:publicationDate: 2017-10-16T14:00:00Z
+    hippotaxonomy:keys:
+    - infectious-diseases
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [infectious-diseases, workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
-    publicationsystem:KeyFacts: Donec ultricies fringilla mauris nec varius.
-      Pellentesque ultricies et libero et venenatis. Mauris accumsan ligula sed enim
-      volutpat scelerisque.
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Etiam tempus quam sed massa ullamcorper, in
-      vestibulum ex ultrices. Duis ipsum, eros et accumsan auctor, turpis lectus
-      viverra urna, eu viverra neque sem at metus. Praesent lacinia erat facilisis,
-      blandit elit a, volutpat ipsum. Morbi egestas eleifend sem. Sed semper egestas
-      purus, ac tempor sem efficitur ac. Cras leo mauris, vestibulum eget turpis ut,
-      bibendum rhoncus neque. Aliquam erat volutpat. Aliquam erat volutpat. Nullam
-      justo mi, ipsum a ante nec, tincidunt eleifend tortor.
-    publicationsystem:Title: Morbi vitae nunc ac lacus malesuada tempus
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
+    publicationsystem:KeyFacts: Donec ultricies fringilla mauris nec varius. Pellentesque
+      ultricies et libero et venenatis. Mauris accumsan ligula sed enim volutpat scelerisque.
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
     publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Etiam tempus quam sed massa ullamcorper, in vestibulum
+      ex ultrices. Duis ipsum, eros et accumsan auctor, turpis lectus viverra urna,
+      eu viverra neque sem at metus. Praesent lacinia erat facilisis, blandit elit
+      a, volutpat ipsum. Morbi egestas eleifend sem. Sed semper egestas purus, ac
+      tempor sem efficitur ac. Cras leo mauris, vestibulum eget turpis ut, bibendum
+      rhoncus neque. Aliquam erat volutpat. Aliquam erat volutpat. Nullam justo mi,
+      ipsum a ante nec, tincidunt eleifend tortor.
+    publicationsystem:Title: Morbi vitae nunc ac lacus malesuada tempus
+  jcr:mixinTypes:
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nullam-vel-ligula-dapibus.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nullam-vel-ligula-dapibus.yaml
@@ -1,105 +1,126 @@
 ---
-
 /content/documents/corporate-website/publication-system/lorem-ipsum-content/nullam-vel-ligula-dapibus:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['mix:referenceable']
   /nullam-vel-ligula-dapibus[1]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
+    /publicationsystem:RelatedLinks:
+      jcr:primaryType: publicationsystem:relatedlink
+      publicationsystem:linkText: ''
+      publicationsystem:linkUrl: ''
+      publicationsystem:link_text: ''
+      publicationsystem:link_url: ''
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - falls
+    - infectious-diseases
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls, infectious-diseases, workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
-    publicationsystem:KeyFacts: ""
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
+    publicationsystem:KeyFacts: ''
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Vivamus eros ipsum, facilisis vitae orci sit amet,
       viverra commodo sem. Phasellus commodo turpis non ultrices feugiat. Proin non
-      metus diam. Pellentesque ipsum morbi tristique senectus et netus et
-      malesuada fames ac turpis egestas. Pellentesque habitant morbi tristique
-      senectus et ipsum et malesuada fames ac turpis egestas. Vestibulum ante ipsum
-      primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis justo
-      magna, ipsum id iaculis eget, tempor sit amet ante.
+      metus diam. Pellentesque ipsum morbi tristique senectus et netus et malesuada
+      fames ac turpis egestas. Pellentesque habitant morbi tristique senectus et ipsum
+      et malesuada fames ac turpis egestas. Vestibulum ante ipsum primis in faucibus
+      orci luctus et ultrices posuere cubilia Curae; Duis justo magna, ipsum id iaculis
+      eget, tempor sit amet ante.
     publicationsystem:Title: Nullam vel ligula dapibus
+  /nullam-vel-ligula-dapibus[2]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: ''
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /nullam-vel-ligula-dapibus[2]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - falls
+    - infectious-diseases
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls, infectious-diseases, workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
-    publicationsystem:KeyFacts: ""
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
+    publicationsystem:KeyFacts: ''
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Vivamus eros ipsum, facilisis vitae orci sit amet,
       viverra commodo sem. Phasellus commodo turpis non ultrices feugiat. Proin non
-      metus diam. Pellentesque ipsum morbi tristique senectus et netus et
-      malesuada fames ac turpis egestas. Pellentesque habitant morbi tristique
-      senectus et ipsum et malesuada fames ac turpis egestas. Vestibulum ante ipsum
-      primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis justo
-      magna, ipsum id iaculis eget, tempor sit amet ante.
+      metus diam. Pellentesque ipsum morbi tristique senectus et netus et malesuada
+      fames ac turpis egestas. Pellentesque habitant morbi tristique senectus et ipsum
+      et malesuada fames ac turpis egestas. Vestibulum ante ipsum primis in faucibus
+      orci luctus et ultrices posuere cubilia Curae; Duis justo magna, ipsum id iaculis
+      eget, tempor sit amet ante.
     publicationsystem:Title: Nullam vel ligula dapibus
+  /nullam-vel-ligula-dapibus[3]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: ''
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /nullam-vel-ligula-dapibus[3]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:publicationDate: 2017-10-16T14:00:00Z
+    hippotaxonomy:keys:
+    - falls
+    - infectious-diseases
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls, infectious-diseases, workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
-    publicationsystem:KeyFacts: ""
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
+    publicationsystem:KeyFacts: ''
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Vivamus eros ipsum, facilisis vitae orci sit amet,
       viverra commodo sem. Phasellus commodo turpis non ultrices feugiat. Proin non
-      metus diam. Pellentesque ipsum morbi tristique senectus et netus et
-      malesuada fames ac turpis egestas. Pellentesque habitant morbi tristique
-      senectus et ipsum et malesuada fames ac turpis egestas. Vestibulum ante ipsum
-      primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis justo
-      magna, ipsum id iaculis eget, tempor sit amet ante.
+      metus diam. Pellentesque ipsum morbi tristique senectus et netus et malesuada
+      fames ac turpis egestas. Pellentesque habitant morbi tristique senectus et ipsum
+      et malesuada fames ac turpis egestas. Vestibulum ante ipsum primis in faucibus
+      orci luctus et ultrices posuere cubilia Curae; Duis justo magna, ipsum id iaculis
+      eget, tempor sit amet ante.
     publicationsystem:Title: Nullam vel ligula dapibus
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
+  jcr:mixinTypes:
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nunc-tempus-ante-nec.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nunc-tempus-ante-nec.yaml
@@ -1,114 +1,132 @@
 ---
-
 /content/documents/corporate-website/publication-system/lorem-ipsum-content/nunc-tempus-ante-nec:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['mix:referenceable']
   /nunc-tempus-ante-nec[1]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
+    /publicationsystem:RelatedLinks:
+      jcr:primaryType: publicationsystem:relatedlink
+      publicationsystem:linkText: ''
+      publicationsystem:linkUrl: ''
+      publicationsystem:link_text: ''
+      publicationsystem:link_url: ''
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - falls
+    - circulatory-system-diseases
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls, circulatory-system-diseases]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
-    publicationsystem:KeyFacts: Quisque fermentum eros turpis, non laoreet lacus
-      tempus quis. Donec eget orci at massa egestas cursus. Duis at diam et eros
-      fringilla porta.
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Aenean dictum et diam sit amet egestas. Nullam
-      ultrices, lacus vel pretium bibendum, erat metus gravida quam, id elementum
-      urna sapien vel orci. Mauris ut lorem lorem. Vestibulum bibendum lorem nec
-      nibh volutpat pharetra. Nullam vitae dignissim ipsum, non varius justo. Cras
-      hendrerit lacus id urna accumsan, sit amet consequat odio viverra. Phasellus
-      et metus finibus, congue mauris egestas, hendrerit est. Donec elit mi,
-      malesuada a interdum et, pulvinar eget justo. Nam gravida justo non dui
-      sodales suscipit. Integer in turpis eros.
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
+    publicationsystem:KeyFacts: Quisque fermentum eros turpis, non laoreet lacus tempus
+      quis. Donec eget orci at massa egestas cursus. Duis at diam et eros fringilla
+      porta.
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Aenean dictum et diam sit amet egestas. Nullam ultrices,
+      lacus vel pretium bibendum, erat metus gravida quam, id elementum urna sapien
+      vel orci. Mauris ut lorem lorem. Vestibulum bibendum lorem nec nibh volutpat
+      pharetra. Nullam vitae dignissim ipsum, non varius justo. Cras hendrerit lacus
+      id urna accumsan, sit amet consequat odio viverra. Phasellus et metus finibus,
+      congue mauris egestas, hendrerit est. Donec elit mi, malesuada a interdum et,
+      pulvinar eget justo. Nam gravida justo non dui sodales suscipit. Integer in
+      turpis eros.
     publicationsystem:Title: Nunc tempus ante nec
+  /nunc-tempus-ante-nec[2]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: ''
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /nunc-tempus-ante-nec[2]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - falls
+    - circulatory-system-diseases
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls, circulatory-system-diseases]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
-    publicationsystem:KeyFacts: Quisque fermentum eros turpis, non laoreet lacus
-      tempus quis. Donec eget orci at massa egestas cursus. Duis at diam et eros
-      fringilla porta.
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Aenean dictum et diam sit amet egestas. Nullam
-      ultrices, lacus vel pretium bibendum, erat metus gravida quam, id elementum
-      urna sapien vel orci. Mauris ut lorem lorem. Vestibulum bibendum lorem nec
-      nibh volutpat pharetra. Nullam vitae dignissim ipsum, non varius justo. Cras
-      hendrerit lacus id urna accumsan, sit amet consequat odio viverra. Phasellus
-      et metus finibus, congue mauris egestas, hendrerit est. Donec elit mi,
-      malesuada a interdum et, pulvinar eget justo. Nam gravida justo non dui
-      sodales suscipit. Integer in turpis eros.
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
+    publicationsystem:KeyFacts: Quisque fermentum eros turpis, non laoreet lacus tempus
+      quis. Donec eget orci at massa egestas cursus. Duis at diam et eros fringilla
+      porta.
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Aenean dictum et diam sit amet egestas. Nullam ultrices,
+      lacus vel pretium bibendum, erat metus gravida quam, id elementum urna sapien
+      vel orci. Mauris ut lorem lorem. Vestibulum bibendum lorem nec nibh volutpat
+      pharetra. Nullam vitae dignissim ipsum, non varius justo. Cras hendrerit lacus
+      id urna accumsan, sit amet consequat odio viverra. Phasellus et metus finibus,
+      congue mauris egestas, hendrerit est. Donec elit mi, malesuada a interdum et,
+      pulvinar eget justo. Nam gravida justo non dui sodales suscipit. Integer in
+      turpis eros.
     publicationsystem:Title: Nunc tempus ante nec
+  /nunc-tempus-ante-nec[3]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: ''
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /nunc-tempus-ante-nec[3]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:publicationDate: 2017-10-16T14:00:00Z
+    hippotaxonomy:keys:
+    - falls
+    - circulatory-system-diseases
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls, circulatory-system-diseases]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
-    publicationsystem:KeyFacts: Quisque fermentum eros turpis, non laoreet lacus
-      tempus quis. Donec eget orci at massa egestas cursus. Duis at diam et eros
-      fringilla porta.
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Aenean dictum et diam sit amet egestas. Nullam
-      ultrices, lacus vel pretium bibendum, erat metus gravida quam, id elementum
-      urna sapien vel orci. Mauris ut lorem lorem. Vestibulum bibendum lorem nec
-      nibh volutpat pharetra. Nullam vitae dignissim ipsum, non varius justo. Cras
-      hendrerit lacus id urna accumsan, sit amet consequat odio viverra. Phasellus
-      et metus finibus, congue mauris egestas, hendrerit est. Donec elit mi,
-      malesuada a interdum et, pulvinar eget justo. Nam gravida justo non dui
-      sodales suscipit. Integer in turpis eros.
-    publicationsystem:Title: Nunc tempus ante nec
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
+    publicationsystem:KeyFacts: Quisque fermentum eros turpis, non laoreet lacus tempus
+      quis. Donec eget orci at massa egestas cursus. Duis at diam et eros fringilla
+      porta.
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
     publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Aenean dictum et diam sit amet egestas. Nullam ultrices,
+      lacus vel pretium bibendum, erat metus gravida quam, id elementum urna sapien
+      vel orci. Mauris ut lorem lorem. Vestibulum bibendum lorem nec nibh volutpat
+      pharetra. Nullam vitae dignissim ipsum, non varius justo. Cras hendrerit lacus
+      id urna accumsan, sit amet consequat odio viverra. Phasellus et metus finibus,
+      congue mauris egestas, hendrerit est. Donec elit mi, malesuada a interdum et,
+      pulvinar eget justo. Nam gravida justo non dui sodales suscipit. Integer in
+      turpis eros.
+    publicationsystem:Title: Nunc tempus ante nec
+  jcr:mixinTypes:
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-elementum-justo-eu-tortor.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-elementum-justo-eu-tortor.yaml
@@ -1,105 +1,120 @@
 ---
-
 /content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-elementum-justo-eu-tortor:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['mix:referenceable']
   /proin-elementum-justo-eu-tortor[1]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
+    /publicationsystem:RelatedLinks:
+      jcr:primaryType: publicationsystem:relatedlink
+      publicationsystem:linkText: ''
+      publicationsystem:linkUrl: ''
+      publicationsystem:link_text: ''
+      publicationsystem:link_url: ''
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - falls
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls, workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Suspendisse pellentesque, purus nec fermentum
-      vulputate, lorem metus interdum dolor, eget facilisis lacus ligula sed dui.
-      Praesent facilisis sollicitudin odio sit amet ullamcorper. Pellentesque
-      imperdiet neque nibh, quis vehicula risus finibus a. Aenean a sagittis lacus.
-      Fusce id metus vel eros iaculis lobortis. Vestibulum tempor dapibus turpis,
-      sit amet euismod lorem. Vivamus id orci eu sem vehicula interdum vitae vitae
-      diam.
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Suspendisse pellentesque, purus nec fermentum vulputate,
+      lorem metus interdum dolor, eget facilisis lacus ligula sed dui. Praesent facilisis
+      sollicitudin odio sit amet ullamcorper. Pellentesque imperdiet neque nibh, quis
+      vehicula risus finibus a. Aenean a sagittis lacus. Fusce id metus vel eros iaculis
+      lobortis. Vestibulum tempor dapibus turpis, sit amet euismod lorem. Vivamus
+      id orci eu sem vehicula interdum vitae vitae diam.
     publicationsystem:Title: Proin elementum justo eu tortor
+  /proin-elementum-justo-eu-tortor[2]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: ''
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /proin-elementum-justo-eu-tortor[2]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - falls
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls, workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Suspendisse pellentesque, purus nec fermentum
-      vulputate, lorem metus interdum dolor, eget facilisis lacus ligula sed dui.
-      Praesent facilisis sollicitudin odio sit amet ullamcorper. Pellentesque
-      imperdiet neque nibh, quis vehicula risus finibus a. Aenean a sagittis lacus.
-      Fusce id metus vel eros iaculis lobortis. Vestibulum tempor dapibus turpis,
-      sit amet euismod lorem. Vivamus id orci eu sem vehicula interdum vitae vitae
-      diam.
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Suspendisse pellentesque, purus nec fermentum vulputate,
+      lorem metus interdum dolor, eget facilisis lacus ligula sed dui. Praesent facilisis
+      sollicitudin odio sit amet ullamcorper. Pellentesque imperdiet neque nibh, quis
+      vehicula risus finibus a. Aenean a sagittis lacus. Fusce id metus vel eros iaculis
+      lobortis. Vestibulum tempor dapibus turpis, sit amet euismod lorem. Vivamus
+      id orci eu sem vehicula interdum vitae vitae diam.
     publicationsystem:Title: Proin elementum justo eu tortor
+  /proin-elementum-justo-eu-tortor[3]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: ''
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /proin-elementum-justo-eu-tortor[3]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:publicationDate: 2017-10-16T14:00:00Z
+    hippotaxonomy:keys:
+    - falls
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls, workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Suspendisse pellentesque, purus nec fermentum
-      vulputate, lorem metus interdum dolor, eget facilisis lacus ligula sed dui.
-      Praesent facilisis sollicitudin odio sit amet ullamcorper. Pellentesque
-      imperdiet neque nibh, quis vehicula risus finibus a. Aenean a sagittis lacus.
-      Fusce id metus vel eros iaculis lobortis. Vestibulum tempor dapibus turpis,
-      sit amet euismod lorem. Vivamus id orci eu sem vehicula interdum vitae vitae
-      diam.
-    publicationsystem:Title: Proin elementum justo eu tortor
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
     publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Suspendisse pellentesque, purus nec fermentum vulputate,
+      lorem metus interdum dolor, eget facilisis lacus ligula sed dui. Praesent facilisis
+      sollicitudin odio sit amet ullamcorper. Pellentesque imperdiet neque nibh, quis
+      vehicula risus finibus a. Aenean a sagittis lacus. Fusce id metus vel eros iaculis
+      lobortis. Vestibulum tempor dapibus turpis, sit amet euismod lorem. Vivamus
+      id orci eu sem vehicula interdum vitae vitae diam.
+    publicationsystem:Title: Proin elementum justo eu tortor
+  jcr:mixinTypes:
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-nec-justo.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-nec-justo.yaml
@@ -1,117 +1,134 @@
 ---
-
 /content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-nec-justo:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['mix:referenceable']
   /proin-nec-justo[1]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
+    /publicationsystem:RelatedLinks:
+      jcr:primaryType: publicationsystem:relatedlink
+      publicationsystem:linkText: ''
+      publicationsystem:linkUrl: ''
+      publicationsystem:link_text: ''
+      publicationsystem:link_url: ''
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - circulatory-system-diseases
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [circulatory-system-diseases, workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Nulla eu augue eros. Maecenas ultrices tempus
-      placerat. Phasellus commodo nulla in gravida pretium. Donec justo magna,
-      vehicula tristique suscipit vel, condimentum quis lectus. Nam posuere eu elit
-      vitae gravida. Nullam a volutpat dolor, sagittis iaculis urna. Fusce rhoncus
-      sagittis mauris, non rutrum eros volutpat ut. Duis non tempus ante. Duis
-      scelerisque, massa et luctus sollicitudin, quam massa convallis justo, in
-      eleifend ante nibh a mauris. Aliquam finibus pellentesque lacus, ac vulputate
-      nisi iaculis at. Integer consequat mollis ipsum, ac tincidunt diam cursus id.
-      Mauris convallis a nisl eget mattis. Vestibulum sodales nisl aliquam, cursus
-      nunc eu, tincidunt ligula. Aliquam a ligula ac elit efficitur viverra eu quis
-      libero.
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Nulla eu augue eros. Maecenas ultrices tempus placerat.
+      Phasellus commodo nulla in gravida pretium. Donec justo magna, vehicula tristique
+      suscipit vel, condimentum quis lectus. Nam posuere eu elit vitae gravida. Nullam
+      a volutpat dolor, sagittis iaculis urna. Fusce rhoncus sagittis mauris, non
+      rutrum eros volutpat ut. Duis non tempus ante. Duis scelerisque, massa et luctus
+      sollicitudin, quam massa convallis justo, in eleifend ante nibh a mauris. Aliquam
+      finibus pellentesque lacus, ac vulputate nisi iaculis at. Integer consequat
+      mollis ipsum, ac tincidunt diam cursus id. Mauris convallis a nisl eget mattis.
+      Vestibulum sodales nisl aliquam, cursus nunc eu, tincidunt ligula. Aliquam a
+      ligula ac elit efficitur viverra eu quis libero.
     publicationsystem:Title: Proin nec justo
+  /proin-nec-justo[2]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: ''
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /proin-nec-justo[2]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - falls
+    - infectious-diseases
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls, infectious-diseases, workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Nulla eu augue eros. Maecenas ultrices tempus
-      placerat. Phasellus commodo nulla in gravida pretium. Donec justo magna,
-      vehicula tristique suscipit vel, condimentum quis lectus. Nam posuere eu elit
-      vitae gravida. Nullam a volutpat dolor, sagittis iaculis urna. Fusce rhoncus
-      sagittis mauris, non rutrum eros volutpat ut. Duis non tempus ante. Duis
-      scelerisque, massa et luctus sollicitudin, quam massa convallis justo, in
-      eleifend ante nibh a mauris. Aliquam finibus pellentesque lacus, ac vulputate
-      nisi iaculis at. Integer consequat mollis ipsum, ac tincidunt diam cursus id.
-      Mauris convallis a nisl eget mattis. Vestibulum sodales nisl aliquam, cursus
-      nunc eu, tincidunt ligula. Aliquam a ligula ac elit efficitur viverra eu quis
-      libero.
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Nulla eu augue eros. Maecenas ultrices tempus placerat.
+      Phasellus commodo nulla in gravida pretium. Donec justo magna, vehicula tristique
+      suscipit vel, condimentum quis lectus. Nam posuere eu elit vitae gravida. Nullam
+      a volutpat dolor, sagittis iaculis urna. Fusce rhoncus sagittis mauris, non
+      rutrum eros volutpat ut. Duis non tempus ante. Duis scelerisque, massa et luctus
+      sollicitudin, quam massa convallis justo, in eleifend ante nibh a mauris. Aliquam
+      finibus pellentesque lacus, ac vulputate nisi iaculis at. Integer consequat
+      mollis ipsum, ac tincidunt diam cursus id. Mauris convallis a nisl eget mattis.
+      Vestibulum sodales nisl aliquam, cursus nunc eu, tincidunt ligula. Aliquam a
+      ligula ac elit efficitur viverra eu quis libero.
     publicationsystem:Title: Proin nec justo
+  /proin-nec-justo[3]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: ''
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /proin-nec-justo[3]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:publicationDate: 2017-10-16T14:00:00Z
+    hippotaxonomy:keys:
+    - falls
+    - infectious-diseases
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls, infectious-diseases, workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: Nulla eu augue eros. Maecenas ultrices tempus
-      placerat. Phasellus commodo nulla in gravida pretium. Donec justo magna,
-      vehicula tristique suscipit vel, condimentum quis lectus. Nam posuere eu elit
-      vitae gravida. Nullam a volutpat dolor, sagittis iaculis urna. Fusce rhoncus
-      sagittis mauris, non rutrum eros volutpat ut. Duis non tempus ante. Duis
-      scelerisque, massa et luctus sollicitudin, quam massa convallis justo, in
-      eleifend ante nibh a mauris. Aliquam finibus pellentesque lacus, ac vulputate
-      nisi iaculis at. Integer consequat mollis ipsum, ac tincidunt diam cursus id.
-      Mauris convallis a nisl eget mattis. Vestibulum sodales nisl aliquam, cursus
-      nunc eu, tincidunt ligula. Aliquam a ligula ac elit efficitur viverra eu quis
-      libero.
-    publicationsystem:Title: Proin nec justo
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
     publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: Nulla eu augue eros. Maecenas ultrices tempus placerat.
+      Phasellus commodo nulla in gravida pretium. Donec justo magna, vehicula tristique
+      suscipit vel, condimentum quis lectus. Nam posuere eu elit vitae gravida. Nullam
+      a volutpat dolor, sagittis iaculis urna. Fusce rhoncus sagittis mauris, non
+      rutrum eros volutpat ut. Duis non tempus ante. Duis scelerisque, massa et luctus
+      sollicitudin, quam massa convallis justo, in eleifend ante nibh a mauris. Aliquam
+      finibus pellentesque lacus, ac vulputate nisi iaculis at. Integer consequat
+      mollis ipsum, ac tincidunt diam cursus id. Mauris convallis a nisl eget mattis.
+      Vestibulum sodales nisl aliquam, cursus nunc eu, tincidunt ligula. Aliquam a
+      ligula ac elit efficitur viverra eu quis libero.
+    publicationsystem:Title: Proin nec justo
+  jcr:mixinTypes:
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/published-upcoming-publication.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/published-upcoming-publication.yaml
@@ -1,75 +1,96 @@
 ---
-
 /content/documents/corporate-website/publication-system/published-upcoming-publication:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['mix:referenceable']
   /published-upcoming-publication[1]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - falls
+    - infectious-diseases
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls, infectious-diseases, workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: Ipsum dolor sit amet, consectetur adipiscing elit.
       Mauris mattis sodales felis, vitae ultricies turpis porttitor in. Integer sit
       amet efficitur urna.
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: false
     publicationsystem:Summary: Published Upcoming Publication summary.
     publicationsystem:Title: Published Upcoming Publication
-    publicationsystem:PubliclyAccessible: false
   /published-upcoming-publication[2]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - falls
+    - infectious-diseases
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls, infectious-diseases, workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: Ipsum dolor sit amet, consectetur adipiscing elit.
       Mauris mattis sodales felis, vitae ultricies turpis porttitor in. Integer sit
       amet efficitur urna.
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: false
     publicationsystem:Summary: Published Upcoming Publication summary.
     publicationsystem:Title: Published Upcoming Publication
-    publicationsystem:PubliclyAccessible: false
   /published-upcoming-publication[3]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:publicationDate: 2017-10-16T14:00:00Z
+    hippotaxonomy:keys:
+    - falls
+    - infectious-diseases
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls, infectious-diseases, workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: Ipsum dolor sit amet, consectetur adipiscing elit.
       Mauris mattis sodales felis, vitae ultricies turpis porttitor in. Integer sit
       amet efficitur urna.
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: false
     publicationsystem:Summary: Published Upcoming Publication summary.
     publicationsystem:Title: Published Upcoming Publication
-    publicationsystem:PubliclyAccessible: false
+  jcr:mixinTypes:
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor.yaml
@@ -1,14 +1,13 @@
 ---
-
 /content/documents/corporate-website/publication-system/search-test-loremipsumdolor:
-  jcr:primaryType: hippostd:folder
-  jcr:mixinTypes:
-    - mix:versionable
-    - hippo:named
-    - hippotranslation:translated
   hippo:name: Search Test LoremIpsumDolor
   hippostd:foldertype:
-    - new-translated-folder
-    - new-document
+  - new-translated-folder
+  - new-document
   hippotranslation:id: 00000000-0000-0000-0000-000000000000
   hippotranslation:locale: en
+  jcr:mixinTypes:
+  - mix:versionable
+  - hippo:named
+  - hippotranslation:translated
+  jcr:primaryType: hippostd:folder

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/loremimsumdolor.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/loremimsumdolor.yaml
@@ -1,87 +1,108 @@
 ---
-
 /content/documents/corporate-website/publication-system/search-test-loremipsumdolor/loremipsumdolor:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['mix:referenceable']
   /loremipsumdolor[1]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
+    /publicationsystem:RelatedLinks:
+      jcr:primaryType: publicationsystem:relatedlink
+      publicationsystem:linkText: ''
+      publicationsystem:linkUrl: ''
+      publicationsystem:link_text: ''
+      publicationsystem:link_url: ''
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - falls
+    - infectious-diseases
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls, infectious-diseases, workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: ""
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: ''
     publicationsystem:Title: loremipsumdolor
+  /loremipsumdolor[2]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: ''
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
-    publicationsystem:PubliclyAccessible: true
-  /loremipsumdolor[2]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - falls
+    - infectious-diseases
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls, infectious-diseases, workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: ""
-    publicationsystem:Title: loremipsumdolor
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
     publicationsystem:PubliclyAccessible: true
+    publicationsystem:Summary: ''
+    publicationsystem:Title: loremipsumdolor
+  /loremipsumdolor[3]:
     /publicationsystem:RelatedLinks:
       jcr:primaryType: publicationsystem:relatedlink
       publicationsystem:linkText: ''
       publicationsystem:linkUrl: ''
       publicationsystem:link_text: ''
       publicationsystem:link_url: ''
-  /loremipsumdolor[3]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2017-10-16T15:00:00.000+01:00
-    hippostdpubwf:lastModificationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
+    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2017-10-16T15:00:00.000+01:00
+    hippostdpubwf:publicationDate: 2017-10-16T14:00:00Z
+    hippotaxonomy:keys:
+    - falls
+    - infectious-diseases
+    - workforce
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
     hippotranslation:locale: en
-    hippotaxonomy:keys: [falls, infectious-diseases, workforce]
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T09:00:00.000+01:00
-    publicationsystem:CoverageStart: 2017-01-01T09:00:00.000+01:00
-    publicationsystem:InformationType: [Official statistics]
+    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:InformationType:
+    - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T09:30:00.000+01:00
-    publicationsystem:Summary: ""
-    publicationsystem:Title: loremipsumdolor
+    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
     publicationsystem:PubliclyAccessible: true
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
+    publicationsystem:Summary: ''
+    publicationsystem:Title: loremipsumdolor
+  jcr:mixinTypes:
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-1.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-1.yaml
@@ -1,73 +1,92 @@
 ---
-
 /content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-1:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
-  hippo:name: search test 1
   /search-test-1[1]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-07T11:04:05.894Z
     hippostdpubwf:lastModificationDate: 2017-11-07T11:06:03.945Z
     hippostdpubwf:lastModifiedBy: admin
-    hippotaxonomy:keys: [circulatory-system-diseases, dental-health]
+    hippotaxonomy:keys:
+    - circulatory-system-diseases
+    - dental-health
     hippotranslation:id: 518f777b-111a-49f6-9594-cf9b80886605
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:InformationType: [Audit]
+    publicationsystem:InformationType:
+    - Audit
     publicationsystem:KeyFacts: And I like oranges
     publicationsystem:NominalDate: 2017-11-07T00:00:00Z
+    publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: I like apples
     publicationsystem:Title: Apple pear orange bear
-    publicationsystem:PubliclyAccessible: true
   /search-test-1[2]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-07T11:04:05.894Z
     hippostdpubwf:lastModificationDate: 2017-11-07T11:06:03.914Z
     hippostdpubwf:lastModifiedBy: admin
-    hippotaxonomy:keys: [circulatory-system-diseases, dental-health]
+    hippotaxonomy:keys:
+    - circulatory-system-diseases
+    - dental-health
     hippotranslation:id: 518f777b-111a-49f6-9594-cf9b80886605
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:InformationType: [Audit]
+    publicationsystem:InformationType:
+    - Audit
     publicationsystem:KeyFacts: And I like oranges
     publicationsystem:NominalDate: 2017-11-07T00:00:00Z
+    publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: I like apples
     publicationsystem:Title: Apple pear orange bear
-    publicationsystem:PubliclyAccessible: true
   /search-test-1[3]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-07T11:04:05.894Z
     hippostdpubwf:lastModificationDate: 2017-11-07T11:06:03.914Z
     hippostdpubwf:lastModifiedBy: admin
     hippostdpubwf:publicationDate: 2017-11-07T11:06:11.420Z
-    hippotaxonomy:keys: [circulatory-system-diseases, dental-health]
+    hippotaxonomy:keys:
+    - circulatory-system-diseases
+    - dental-health
     hippotranslation:id: 518f777b-111a-49f6-9594-cf9b80886605
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:InformationType: [Audit]
+    publicationsystem:InformationType:
+    - Audit
     publicationsystem:KeyFacts: And I like oranges
     publicationsystem:NominalDate: 2017-11-07T00:00:00Z
+    publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: I like apples
     publicationsystem:Title: Apple pear orange bear
-    publicationsystem:PubliclyAccessible: true
+  hippo:name: search test 1
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-2.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-2.yaml
@@ -1,73 +1,91 @@
 ---
-
 /content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-2:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
-  hippo:name: search test 2
   /search-test-2[1]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-07T11:04:05.894Z
     hippostdpubwf:lastModificationDate: 2017-11-07T11:06:56.610Z
     hippostdpubwf:lastModifiedBy: admin
-    hippotaxonomy:keys: [circulatory-system-diseases, dental-health]
+    hippotaxonomy:keys:
+    - circulatory-system-diseases
+    - dental-health
     hippotranslation:id: ab8570f7-9041-4fdf-a127-8b57d5bb7448
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:InformationType: [Experimental statistics]
+    publicationsystem:InformationType:
+    - Experimental statistics
     publicationsystem:KeyFacts: And I like oranges
     publicationsystem:NominalDate: 2017-11-07T00:00:00Z
+    publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: I like apples
     publicationsystem:Title: Apple orange
-    publicationsystem:PubliclyAccessible: true
   /search-test-2[2]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-07T11:04:05.894Z
     hippostdpubwf:lastModificationDate: 2017-11-07T11:06:39.482Z
     hippostdpubwf:lastModifiedBy: admin
-    hippotaxonomy:keys: [circulatory-system-diseases, dental-health]
+    hippotaxonomy:keys:
+    - circulatory-system-diseases
+    - dental-health
     hippotranslation:id: ab8570f7-9041-4fdf-a127-8b57d5bb7448
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:InformationType: [Experimental statistics]
+    publicationsystem:InformationType:
+    - Experimental statistics
     publicationsystem:KeyFacts: And I like oranges
     publicationsystem:NominalDate: 2017-11-07T00:00:00Z
+    publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: I like apples
     publicationsystem:Title: Apple orange
-    publicationsystem:PubliclyAccessible: true
   /search-test-2[3]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-07T11:04:05.894Z
     hippostdpubwf:lastModificationDate: 2017-11-07T11:06:56.610Z
     hippostdpubwf:lastModifiedBy: admin
     hippostdpubwf:publicationDate: 2017-11-07T11:07:00.081Z
-    hippotaxonomy:keys: [circulatory-system-diseases, dental-health]
+    hippotaxonomy:keys:
+    - circulatory-system-diseases
+    - dental-health
     hippotranslation:id: ab8570f7-9041-4fdf-a127-8b57d5bb7448
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:InformationType: [Experimental statistics]
+    publicationsystem:InformationType:
+    - Experimental statistics
     publicationsystem:KeyFacts: And I like oranges
     publicationsystem:NominalDate: 2017-11-07T00:00:00Z
+    publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: I like apples
     publicationsystem:Title: Apple orange
-    publicationsystem:PubliclyAccessible: true
+  hippo:name: search test 2
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-3.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-3.yaml
@@ -1,73 +1,91 @@
 ---
-
 /content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-3:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
-  hippo:name: search test 3
   /search-test-3[1]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-07T11:04:05.894Z
     hippostdpubwf:lastModificationDate: 2017-11-07T11:07:33.177Z
     hippostdpubwf:lastModifiedBy: admin
-    hippotaxonomy:keys: [circulatory-system-diseases, dental-health]
+    hippotaxonomy:keys:
+    - circulatory-system-diseases
+    - dental-health
     hippotranslation:id: 95cd9446-b4b2-41bb-86ab-a8cd8687bb7b
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:InformationType: [Experimental statistics]
+    publicationsystem:InformationType:
+    - Experimental statistics
     publicationsystem:KeyFacts: And I like pears too
     publicationsystem:NominalDate: 2017-11-08T00:00:00Z
+    publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: I like pears
     publicationsystem:Title: Apple orange pear
-    publicationsystem:PubliclyAccessible: true
   /search-test-3[2]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-07T11:04:05.894Z
     hippostdpubwf:lastModificationDate: 2017-11-07T11:07:08.370Z
     hippostdpubwf:lastModifiedBy: admin
-    hippotaxonomy:keys: [circulatory-system-diseases, dental-health]
+    hippotaxonomy:keys:
+    - circulatory-system-diseases
+    - dental-health
     hippotranslation:id: 95cd9446-b4b2-41bb-86ab-a8cd8687bb7b
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:InformationType: [Experimental statistics]
+    publicationsystem:InformationType:
+    - Experimental statistics
     publicationsystem:KeyFacts: And I like pears too
     publicationsystem:NominalDate: 2017-11-08T00:00:00Z
+    publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: I like pears
     publicationsystem:Title: Apple orange pear
-    publicationsystem:PubliclyAccessible: true
   /search-test-3[3]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-07T11:04:05.894Z
     hippostdpubwf:lastModificationDate: 2017-11-07T11:07:33.177Z
     hippostdpubwf:lastModifiedBy: admin
     hippostdpubwf:publicationDate: 2017-11-07T11:07:36.481Z
-    hippotaxonomy:keys: [circulatory-system-diseases, dental-health]
+    hippotaxonomy:keys:
+    - circulatory-system-diseases
+    - dental-health
     hippotranslation:id: 95cd9446-b4b2-41bb-86ab-a8cd8687bb7b
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England
-    publicationsystem:InformationType: [Experimental statistics]
+    publicationsystem:InformationType:
+    - Experimental statistics
     publicationsystem:KeyFacts: And I like pears too
     publicationsystem:NominalDate: 2017-11-08T00:00:00Z
+    publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: I like pears
     publicationsystem:Title: Apple orange pear
-    publicationsystem:PubliclyAccessible: true
+  hippo:name: search test 3
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-4.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-4.yaml
@@ -1,73 +1,91 @@
 ---
-
 /content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-4:
-  jcr:primaryType: hippo:handle
-  jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
-  hippo:name: search test 4
   /search-test-4[1]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:versionable']
-    hippo:availability: [preview]
+    hippo:availability:
+    - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-07T11:04:05.894Z
     hippostdpubwf:lastModificationDate: 2017-11-07T11:08:34.632Z
     hippostdpubwf:lastModifiedBy: admin
-    hippotaxonomy:keys: [circulatory-system-diseases, dental-health]
+    hippotaxonomy:keys:
+    - circulatory-system-diseases
+    - dental-health
     hippotranslation:id: 7fc8dc44-6460-410b-9dc8-4989407d6a56
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England and Northern Ireland
-    publicationsystem:InformationType: [Experimental statistics]
+    publicationsystem:InformationType:
+    - Experimental statistics
     publicationsystem:KeyFacts: And I like bears
     publicationsystem:NominalDate: 2017-11-08T00:00:00Z
+    publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: I like apples
     publicationsystem:Title: No mention of interesting terms in the title
-    publicationsystem:PubliclyAccessible: true
   /search-test-4[2]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-07T11:04:05.894Z
     hippostdpubwf:lastModificationDate: 2017-11-07T11:07:56.598Z
     hippostdpubwf:lastModifiedBy: admin
-    hippotaxonomy:keys: [circulatory-system-diseases, dental-health]
+    hippotaxonomy:keys:
+    - circulatory-system-diseases
+    - dental-health
     hippotranslation:id: 7fc8dc44-6460-410b-9dc8-4989407d6a56
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England and Northern Ireland
-    publicationsystem:InformationType: [Experimental statistics]
+    publicationsystem:InformationType:
+    - Experimental statistics
     publicationsystem:KeyFacts: And I like bears
     publicationsystem:NominalDate: 2017-11-08T00:00:00Z
+    publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: I like apples
     publicationsystem:Title: No mention of interesting terms in the title
-    publicationsystem:PubliclyAccessible: true
   /search-test-4[3]:
-    jcr:primaryType: publicationsystem:publication
-    jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-    hippo:availability: [live]
+    hippo:availability:
+    - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-11-07T11:04:05.894Z
     hippostdpubwf:lastModificationDate: 2017-11-07T11:08:34.632Z
     hippostdpubwf:lastModifiedBy: admin
     hippostdpubwf:publicationDate: 2017-11-07T11:08:36.681Z
-    hippotaxonomy:keys: [circulatory-system-diseases, dental-health]
+    hippotaxonomy:keys:
+    - circulatory-system-diseases
+    - dental-health
     hippotranslation:id: 7fc8dc44-6460-410b-9dc8-4989407d6a56
     hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage: England and Northern Ireland
-    publicationsystem:InformationType: [Experimental statistics]
+    publicationsystem:InformationType:
+    - Experimental statistics
     publicationsystem:KeyFacts: And I like bears
     publicationsystem:NominalDate: 2017-11-08T00:00:00Z
+    publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: I like apples
     publicationsystem:Title: No mention of interesting terms in the title
-    publicationsystem:PubliclyAccessible: true
+  hippo:name: search test 4
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/valid-publication-series.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/valid-publication-series.yaml
@@ -1,25 +1,367 @@
+---
 /content/documents/corporate-website/publication-system/valid-publication-series:
-  jcr:primaryType: hippostd:folder
-  jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']
-  hippo:name: valid publication series
-  hippostd:foldertype: [new-translated-folder, new-document]
-  hippotranslation:id: 00000000-0000-0000-0000-000000000000
-  hippotranslation:locale: en
-  /time-series-index:
-    jcr:primaryType: hippo:handle
-    jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
-    hippo:name: Time Series Index
-    /time-series-index[1]:
-      jcr:primaryType: publicationsystem:series
-      jcr:mixinTypes: ['mix:referenceable']
+  /2012:
+    /2012[1]:
+      /publicationsystem:RelatedLinks:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: ''
+        publicationsystem:linkUrl: ''
+        publicationsystem:link_text: ''
+        publicationsystem:link_url: ''
       hippo:availability: []
       hippostd:state: draft
       hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2017-10-16T14:58:50.358+01:00
-      hippostdpubwf:lastModificationDate: 2017-10-16T14:58:50.358+01:00
+      hippostdpubwf:creationDate: 2017-10-16T14:03:16.644Z
+      hippostdpubwf:lastModificationDate: 2017-10-16T14:03:16.644Z
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: 00000000-0000-0000-0000-000000000000
       hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+      publicationsystem:InformationType:
+      - Official statistics
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2013-01-10T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: A published publication
+      publicationsystem:Title: Lorem Ipsum Dolor 2012
+    /2012[2]:
+      /publicationsystem:RelatedLinks:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: ''
+        publicationsystem:linkUrl: ''
+        publicationsystem:link_text: ''
+        publicationsystem:link_url: ''
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2017-10-16T14:03:16.644Z
+      hippostdpubwf:lastModificationDate: 2017-10-16T14:03:52.340Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 00000000-0000-0000-0000-000000000000
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+      publicationsystem:InformationType:
+      - Official statistics
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2013-01-10T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: A published publication
+      publicationsystem:Title: Lorem Ipsum Dolor 2012
+    /2012[3]:
+      /publicationsystem:RelatedLinks:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: ''
+        publicationsystem:linkUrl: ''
+        publicationsystem:link_text: ''
+        publicationsystem:link_url: ''
+      hippo:availability:
+      - live
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2017-10-16T14:03:16.644Z
+      hippostdpubwf:lastModificationDate: 2017-10-16T14:03:52.340Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2017-10-16T14:03:59.870Z
+      hippotranslation:id: 00000000-0000-0000-0000-000000000000
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+      publicationsystem:InformationType:
+      - Official statistics
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2013-01-10T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: A published publication
+      publicationsystem:Title: Lorem Ipsum Dolor 2012
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+  /2013:
+    /2013[1]:
+      /publicationsystem:RelatedLinks:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: ''
+        publicationsystem:linkUrl: ''
+        publicationsystem:link_text: ''
+        publicationsystem:link_url: ''
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2017-10-16T14:04:13.132Z
+      hippostdpubwf:lastModificationDate: 2017-10-16T14:04:13.132Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 00000000-0000-0000-0000-000000000000
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+      publicationsystem:InformationType:
+      - Official statistics
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2014-01-10T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: A published publication 2013.
+      publicationsystem:Title: Lorem Ipsum Dolor 2013
+    /2013[2]:
+      /publicationsystem:RelatedLinks:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: ''
+        publicationsystem:linkUrl: ''
+        publicationsystem:link_text: ''
+        publicationsystem:link_url: ''
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2017-10-16T14:04:13.132Z
+      hippostdpubwf:lastModificationDate: 2017-10-16T14:05:15.456Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 00000000-0000-0000-0000-000000000000
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+      publicationsystem:InformationType:
+      - Official statistics
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2014-01-10T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: A published publication 2013.
+      publicationsystem:Title: Lorem Ipsum Dolor 2013
+    /2013[3]:
+      /publicationsystem:RelatedLinks:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: ''
+        publicationsystem:linkUrl: ''
+        publicationsystem:link_text: ''
+        publicationsystem:link_url: ''
+      hippo:availability:
+      - live
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2017-10-16T14:04:13.132Z
+      hippostdpubwf:lastModificationDate: 2017-10-16T14:05:15.456Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2017-10-16T14:05:18.987Z
+      hippotranslation:id: 00000000-0000-0000-0000-000000000000
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+      publicationsystem:InformationType:
+      - Official statistics
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2014-01-10T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: A published publication 2013.
+      publicationsystem:Title: Lorem Ipsum Dolor 2013
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+  /2014:
+    /2014[1]:
+      /publicationsystem:RelatedLinks:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: ''
+        publicationsystem:linkUrl: ''
+        publicationsystem:link_text: ''
+        publicationsystem:link_url: ''
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2017-10-16T14:05:34.800Z
+      hippostdpubwf:lastModificationDate: 2017-10-16T14:05:34.800Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 00000000-0000-0000-0000-000000000000
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+      publicationsystem:InformationType:
+      - Official statistics
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2015-01-10T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: Published 2014 stats.
+      publicationsystem:Title: Lorem Ipsum Dolor 2014
+    /2014[2]:
+      /publicationsystem:RelatedLinks:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: ''
+        publicationsystem:linkUrl: ''
+        publicationsystem:link_text: ''
+        publicationsystem:link_url: ''
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2017-10-16T14:05:34.800Z
+      hippostdpubwf:lastModificationDate: 2017-10-16T14:06:16.077Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 00000000-0000-0000-0000-000000000000
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+      publicationsystem:InformationType:
+      - Official statistics
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2015-01-10T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: Published 2014 stats.
+      publicationsystem:Title: Lorem Ipsum Dolor 2014
+    /2014[3]:
+      /publicationsystem:RelatedLinks:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: ''
+        publicationsystem:linkUrl: ''
+        publicationsystem:link_text: ''
+        publicationsystem:link_url: ''
+      hippo:availability:
+      - live
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2017-10-16T14:05:34.800Z
+      hippostdpubwf:lastModificationDate: 2017-10-16T14:06:16.077Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2017-10-16T14:07:01.115Z
+      hippotranslation:id: 00000000-0000-0000-0000-000000000000
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+      publicationsystem:InformationType:
+      - Official statistics
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2015-01-10T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: Published 2014 stats.
+      publicationsystem:Title: Lorem Ipsum Dolor 2014
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+  /2015:
+    /2015[1]:
+      /publicationsystem:RelatedLinks:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: ''
+        publicationsystem:linkUrl: ''
+        publicationsystem:link_text: ''
+        publicationsystem:link_url: ''
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2017-10-16T14:07:17.576Z
+      hippostdpubwf:lastModificationDate: 2017-10-17T12:09:35.563Z
+      hippostdpubwf:lastModifiedBy: author
+      hippotranslation:id: 00000000-0000-0000-0000-000000000000
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+      publicationsystem:InformationType:
+      - Official statistics
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2016-01-10T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: Unreleased 2015 stats.
+      publicationsystem:Title: Lorem Ipsum Dolor 2015
+    /2015[2]:
+      /publicationsystem:RelatedLinks:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: ''
+        publicationsystem:linkUrl: ''
+        publicationsystem:link_text: ''
+        publicationsystem:link_url: ''
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2017-10-16T14:07:17.576Z
+      hippostdpubwf:lastModificationDate: 2017-10-16T14:07:40.063Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 00000000-0000-0000-0000-000000000000
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+      publicationsystem:InformationType:
+      - Official statistics
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2016-01-10T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: Unreleased 2015 stats.
+      publicationsystem:Title: Lorem Ipsum Dolor 2015
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+  /time-series-index:
+    /time-series-index[1]:
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2017-10-16T13:58:50.358Z
+      hippostdpubwf:lastModificationDate: 2017-10-16T13:58:50.358Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 00000000-0000-0000-0000-000000000000
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:series
       publicationsystem:Summary: Integer suscipit pulvinar lacus non porta. Aenean
         ut tempus ex. Proin eget tortor sollicitudin, pellentesque dolor eget, aliquam
         quam. Nullam euismod accumsan nibh at lobortis. Nam non eleifend mauris. Aliquam
@@ -27,16 +369,19 @@
         pharetra eget elit. Quisque at iaculis arcu, eget ornare arcu.
       publicationsystem:Title: Time Series Lorem Ipsum Dolor
     /time-series-index[2]:
-      jcr:primaryType: publicationsystem:series
-      jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
-      hippo:availability: [preview]
+      hippo:availability:
+      - preview
       hippostd:state: unpublished
       hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2017-10-16T14:58:50.358+01:00
-      hippostdpubwf:lastModificationDate: 2017-10-16T14:59:20.720+01:00
+      hippostdpubwf:creationDate: 2017-10-16T13:58:50.358Z
+      hippostdpubwf:lastModificationDate: 2017-10-16T13:59:20.720Z
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: 00000000-0000-0000-0000-000000000000
       hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:series
       publicationsystem:Summary: Integer suscipit pulvinar lacus non porta. Aenean
         ut tempus ex. Proin eget tortor sollicitudin, pellentesque dolor eget, aliquam
         quam. Nullam euismod accumsan nibh at lobortis. Nam non eleifend mauris. Aliquam
@@ -44,321 +389,38 @@
         pharetra eget elit. Quisque at iaculis arcu, eget ornare arcu.
       publicationsystem:Title: Time Series Lorem Ipsum Dolor
     /time-series-index[3]:
-      jcr:primaryType: publicationsystem:series
-      jcr:mixinTypes: ['mix:referenceable']
-      hippo:availability: [live]
+      hippo:availability:
+      - live
       hippostd:state: published
       hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2017-10-16T14:58:50.358+01:00
-      hippostdpubwf:lastModificationDate: 2017-10-16T14:59:20.720+01:00
+      hippostdpubwf:creationDate: 2017-10-16T13:58:50.358Z
+      hippostdpubwf:lastModificationDate: 2017-10-16T13:59:20.720Z
       hippostdpubwf:lastModifiedBy: admin
-      hippostdpubwf:publicationDate: 2017-10-16T14:59:41.695+01:00
+      hippostdpubwf:publicationDate: 2017-10-16T13:59:41.695Z
       hippotranslation:id: 00000000-0000-0000-0000-000000000000
       hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:series
       publicationsystem:Summary: Integer suscipit pulvinar lacus non porta. Aenean
         ut tempus ex. Proin eget tortor sollicitudin, pellentesque dolor eget, aliquam
         quam. Nullam euismod accumsan nibh at lobortis. Nam non eleifend mauris. Aliquam
         tempor nec odio non aliquam. Suspendisse in ex sit amet lectus vehicula varius
         pharetra eget elit. Quisque at iaculis arcu, eget ornare arcu.
       publicationsystem:Title: Time Series Lorem Ipsum Dolor
-  /2012:
+    hippo:name: Time Series Index
+    jcr:mixinTypes:
+    - hippo:named
+    - mix:referenceable
     jcr:primaryType: hippo:handle
-    jcr:mixinTypes: ['mix:referenceable']
-    /2012[1]:
-      jcr:primaryType: publicationsystem:publication
-      jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-      hippo:availability: []
-      hippostd:state: draft
-      hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2017-10-16T15:03:16.644+01:00
-      hippostdpubwf:lastModificationDate: 2017-10-16T15:03:16.644+01:00
-      hippostdpubwf:lastModifiedBy: admin
-      hippotranslation:id: 00000000-0000-0000-0000-000000000000
-      hippotranslation:locale: en
-      publicationsystem:AdministrativeSources: ''
-      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
-      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:InformationType: [Official statistics]
-      publicationsystem:KeyFacts: ''
-      publicationsystem:NominalDate: 2013-01-10T01:00:00+01:00
-      publicationsystem:Summary: A published publication
-      publicationsystem:Title: Lorem Ipsum Dolor 2012
-      /publicationsystem:RelatedLinks:
-        jcr:primaryType: publicationsystem:relatedlink
-        publicationsystem:linkText: ''
-        publicationsystem:linkUrl: ''
-        publicationsystem:link_text: ''
-        publicationsystem:link_url: ''
-      publicationsystem:PubliclyAccessible: true
-    /2012[2]:
-      jcr:primaryType: publicationsystem:publication
-      jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-      hippo:availability: [preview]
-      hippostd:state: unpublished
-      hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2017-10-16T15:03:16.644+01:00
-      hippostdpubwf:lastModificationDate: 2017-10-16T15:03:52.340+01:00
-      hippostdpubwf:lastModifiedBy: admin
-      hippotranslation:id: 00000000-0000-0000-0000-000000000000
-      hippotranslation:locale: en
-      publicationsystem:AdministrativeSources: ''
-      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
-      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:InformationType: [Official statistics]
-      publicationsystem:KeyFacts: ''
-      publicationsystem:NominalDate: 2013-01-10T01:00:00+01:00
-      publicationsystem:Summary: A published publication
-      publicationsystem:Title: Lorem Ipsum Dolor 2012
-      /publicationsystem:RelatedLinks:
-        jcr:primaryType: publicationsystem:relatedlink
-        publicationsystem:linkText: ''
-        publicationsystem:linkUrl: ''
-        publicationsystem:link_text: ''
-        publicationsystem:link_url: ''
-      publicationsystem:PubliclyAccessible: true
-    /2012[3]:
-      jcr:primaryType: publicationsystem:publication
-      jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-      hippo:availability: [live]
-      hippostd:state: published
-      hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2017-10-16T15:03:16.644+01:00
-      hippostdpubwf:lastModificationDate: 2017-10-16T15:03:52.340+01:00
-      hippostdpubwf:lastModifiedBy: admin
-      hippostdpubwf:publicationDate: 2017-10-16T15:03:59.870+01:00
-      hippotranslation:id: 00000000-0000-0000-0000-000000000000
-      hippotranslation:locale: en
-      publicationsystem:AdministrativeSources: ''
-      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
-      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:InformationType: [Official statistics]
-      publicationsystem:KeyFacts: ''
-      publicationsystem:NominalDate: 2013-01-10T01:00:00+01:00
-      publicationsystem:Summary: A published publication
-      publicationsystem:Title: Lorem Ipsum Dolor 2012
-      /publicationsystem:RelatedLinks:
-        jcr:primaryType: publicationsystem:relatedlink
-        publicationsystem:linkText: ''
-        publicationsystem:linkUrl: ''
-        publicationsystem:link_text: ''
-        publicationsystem:link_url: ''
-      publicationsystem:PubliclyAccessible: true
-  /2013:
-    jcr:primaryType: hippo:handle
-    jcr:mixinTypes: ['mix:referenceable']
-    /2013[1]:
-      jcr:primaryType: publicationsystem:publication
-      jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-      hippo:availability: []
-      hippostd:state: draft
-      hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2017-10-16T15:04:13.132+01:00
-      hippostdpubwf:lastModificationDate: 2017-10-16T15:04:13.132+01:00
-      hippostdpubwf:lastModifiedBy: admin
-      hippotranslation:id: 00000000-0000-0000-0000-000000000000
-      hippotranslation:locale: en
-      publicationsystem:AdministrativeSources: ''
-      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
-      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:InformationType: [Official statistics]
-      publicationsystem:KeyFacts: ''
-      publicationsystem:NominalDate: 2014-01-10T01:00:00+01:00
-      publicationsystem:Summary: A published publication 2013.
-      publicationsystem:Title: Lorem Ipsum Dolor 2013
-      /publicationsystem:RelatedLinks:
-        jcr:primaryType: publicationsystem:relatedlink
-        publicationsystem:linkText: ''
-        publicationsystem:linkUrl: ''
-        publicationsystem:link_text: ''
-        publicationsystem:link_url: ''
-      publicationsystem:PubliclyAccessible: true
-    /2013[2]:
-      jcr:primaryType: publicationsystem:publication
-      jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-      hippo:availability: [preview]
-      hippostd:state: unpublished
-      hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2017-10-16T15:04:13.132+01:00
-      hippostdpubwf:lastModificationDate: 2017-10-16T15:05:15.456+01:00
-      hippostdpubwf:lastModifiedBy: admin
-      hippotranslation:id: 00000000-0000-0000-0000-000000000000
-      hippotranslation:locale: en
-      publicationsystem:AdministrativeSources: ''
-      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
-      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:InformationType: [Official statistics]
-      publicationsystem:KeyFacts: ''
-      publicationsystem:NominalDate: 2014-01-10T01:00:00+01:00
-      publicationsystem:Summary: A published publication 2013.
-      publicationsystem:Title: Lorem Ipsum Dolor 2013
-      /publicationsystem:RelatedLinks:
-        jcr:primaryType: publicationsystem:relatedlink
-        publicationsystem:linkText: ''
-        publicationsystem:linkUrl: ''
-        publicationsystem:link_text: ''
-        publicationsystem:link_url: ''
-      publicationsystem:PubliclyAccessible: true
-    /2013[3]:
-      jcr:primaryType: publicationsystem:publication
-      jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-      hippo:availability: [live]
-      hippostd:state: published
-      hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2017-10-16T15:04:13.132+01:00
-      hippostdpubwf:lastModificationDate: 2017-10-16T15:05:15.456+01:00
-      hippostdpubwf:lastModifiedBy: admin
-      hippostdpubwf:publicationDate: 2017-10-16T15:05:18.987+01:00
-      hippotranslation:id: 00000000-0000-0000-0000-000000000000
-      hippotranslation:locale: en
-      publicationsystem:AdministrativeSources: ''
-      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
-      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:InformationType: [Official statistics]
-      publicationsystem:KeyFacts: ''
-      publicationsystem:NominalDate: 2014-01-10T01:00:00+01:00
-      publicationsystem:Summary: A published publication 2013.
-      publicationsystem:Title: Lorem Ipsum Dolor 2013
-      /publicationsystem:RelatedLinks:
-        jcr:primaryType: publicationsystem:relatedlink
-        publicationsystem:linkText: ''
-        publicationsystem:linkUrl: ''
-        publicationsystem:link_text: ''
-        publicationsystem:link_url: ''
-      publicationsystem:PubliclyAccessible: true
-  /2014:
-    jcr:primaryType: hippo:handle
-    jcr:mixinTypes: ['mix:referenceable']
-    /2014[1]:
-      jcr:primaryType: publicationsystem:publication
-      jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-      hippo:availability: []
-      hippostd:state: draft
-      hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2017-10-16T15:05:34.800+01:00
-      hippostdpubwf:lastModificationDate: 2017-10-16T15:05:34.800+01:00
-      hippostdpubwf:lastModifiedBy: admin
-      hippotranslation:id: 00000000-0000-0000-0000-000000000000
-      hippotranslation:locale: en
-      publicationsystem:AdministrativeSources: ''
-      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
-      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:InformationType: [Official statistics]
-      publicationsystem:KeyFacts: ''
-      publicationsystem:NominalDate: 2015-01-10T01:00:00+01:00
-      publicationsystem:Summary: Published 2014 stats.
-      publicationsystem:Title: Lorem Ipsum Dolor 2014
-      /publicationsystem:RelatedLinks:
-        jcr:primaryType: publicationsystem:relatedlink
-        publicationsystem:linkText: ''
-        publicationsystem:linkUrl: ''
-        publicationsystem:link_text: ''
-        publicationsystem:link_url: ''
-      publicationsystem:PubliclyAccessible: true
-    /2014[2]:
-      jcr:primaryType: publicationsystem:publication
-      jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-      hippo:availability: [preview]
-      hippostd:state: unpublished
-      hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2017-10-16T15:05:34.800+01:00
-      hippostdpubwf:lastModificationDate: 2017-10-16T15:06:16.077+01:00
-      hippostdpubwf:lastModifiedBy: admin
-      hippotranslation:id: 00000000-0000-0000-0000-000000000000
-      hippotranslation:locale: en
-      publicationsystem:AdministrativeSources: ''
-      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
-      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:InformationType: [Official statistics]
-      publicationsystem:KeyFacts: ''
-      publicationsystem:NominalDate: 2015-01-10T01:00:00+01:00
-      publicationsystem:Summary: Published 2014 stats.
-      publicationsystem:Title: Lorem Ipsum Dolor 2014
-      /publicationsystem:RelatedLinks:
-        jcr:primaryType: publicationsystem:relatedlink
-        publicationsystem:linkText: ''
-        publicationsystem:linkUrl: ''
-        publicationsystem:link_text: ''
-        publicationsystem:link_url: ''
-      publicationsystem:PubliclyAccessible: true
-    /2014[3]:
-      jcr:primaryType: publicationsystem:publication
-      jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-      hippo:availability: [live]
-      hippostd:state: published
-      hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2017-10-16T15:05:34.800+01:00
-      hippostdpubwf:lastModificationDate: 2017-10-16T15:06:16.077+01:00
-      hippostdpubwf:lastModifiedBy: admin
-      hippostdpubwf:publicationDate: 2017-10-16T15:07:01.115+01:00
-      hippotranslation:id: 00000000-0000-0000-0000-000000000000
-      hippotranslation:locale: en
-      publicationsystem:AdministrativeSources: ''
-      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
-      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:InformationType: [Official statistics]
-      publicationsystem:KeyFacts: ''
-      publicationsystem:NominalDate: 2015-01-10T01:00:00+01:00
-      publicationsystem:Summary: Published 2014 stats.
-      publicationsystem:Title: Lorem Ipsum Dolor 2014
-      /publicationsystem:RelatedLinks:
-        jcr:primaryType: publicationsystem:relatedlink
-        publicationsystem:linkText: ''
-        publicationsystem:linkUrl: ''
-        publicationsystem:link_text: ''
-        publicationsystem:link_url: ''
-      publicationsystem:PubliclyAccessible: true
-  /2015:
-    jcr:primaryType: hippo:handle
-    jcr:mixinTypes: ['mix:referenceable']
-    /2015[1]:
-      jcr:primaryType: publicationsystem:publication
-      jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable']
-      hippo:availability: []
-      hippostd:state: draft
-      hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2017-10-16T15:07:17.576+01:00
-      hippostdpubwf:lastModificationDate: 2017-10-17T13:09:35.563+01:00
-      hippostdpubwf:lastModifiedBy: author
-      hippotranslation:id: 00000000-0000-0000-0000-000000000000
-      hippotranslation:locale: en
-      publicationsystem:AdministrativeSources: ''
-      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
-      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:InformationType: [Official statistics]
-      publicationsystem:KeyFacts: ''
-      publicationsystem:NominalDate: 2016-01-10T01:00:00+01:00
-      publicationsystem:Summary: Unreleased 2015 stats.
-      publicationsystem:Title: Lorem Ipsum Dolor 2015
-      /publicationsystem:RelatedLinks:
-        jcr:primaryType: publicationsystem:relatedlink
-        publicationsystem:linkText: ''
-        publicationsystem:linkUrl: ''
-        publicationsystem:link_text: ''
-        publicationsystem:link_url: ''
-      publicationsystem:PubliclyAccessible: true
-    /2015[2]:
-      jcr:primaryType: publicationsystem:publication
-      jcr:mixinTypes: ['hippotaxonomy:classifiable', 'mix:referenceable', 'mix:versionable']
-      hippo:availability: [preview]
-      hippostd:state: unpublished
-      hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2017-10-16T15:07:17.576+01:00
-      hippostdpubwf:lastModificationDate: 2017-10-16T15:07:40.063+01:00
-      hippostdpubwf:lastModifiedBy: admin
-      hippotranslation:id: 00000000-0000-0000-0000-000000000000
-      hippotranslation:locale: en
-      publicationsystem:AdministrativeSources: ''
-      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
-      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
-      publicationsystem:InformationType: [Official statistics]
-      publicationsystem:KeyFacts: ''
-      publicationsystem:NominalDate: 2016-01-10T01:00:00+01:00
-      publicationsystem:Summary: Unreleased 2015 stats.
-      publicationsystem:Title: Lorem Ipsum Dolor 2015
-      /publicationsystem:RelatedLinks:
-        jcr:primaryType: publicationsystem:relatedlink
-        publicationsystem:linkText: ''
-        publicationsystem:linkUrl: ''
-        publicationsystem:link_text: ''
-        publicationsystem:link_url: ''
-      publicationsystem:PubliclyAccessible: true
+  hippo:name: valid publication series
+  hippostd:foldertype:
+  - new-translated-folder
+  - new-document
+  hippotranslation:id: 00000000-0000-0000-0000-000000000000
+  hippotranslation:locale: en
+  jcr:mixinTypes:
+  - hippo:named
+  - hippotranslation:translated
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/development/src/main/resources/hcm-module.yaml
+++ b/repository-data/development/src/main/resources/hcm-module.yaml
@@ -1,7 +1,8 @@
+---
 group:
-  name: publicationsystem
   after: hippo-cms
-project: publicationsystem
+  name: publicationsystem
 module:
-  name: publication-system-repository-data-development
   after: publication-system-repository-data-application
+  name: publication-system-repository-data-development
+project: publicationsystem

--- a/repository-data/development/src/main/script/YamlFormatter.groovy
+++ b/repository-data/development/src/main/script/YamlFormatter.groovy
@@ -1,0 +1,52 @@
+import groovy.io.FileType
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.yaml.snakeyaml.DumperOptions
+import org.yaml.snakeyaml.Yaml
+
+// Options for how the file is written out
+DumperOptions options = new DumperOptions()
+options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK)
+options.setExplicitStart(true) // This puts '---' at the start of the document
+Yaml parser = new Yaml(options)
+
+Logger log = LoggerFactory.getLogger(YamlFormatter.class)
+log.info("Starting to format yaml files")
+
+// Go through all yaml files in all the repository-data subfolders and format them
+File rootDir = new File("repository-data")
+rootDir.eachFileRecurse(FileType.DIRECTORIES) { dir ->
+    dir.eachFileMatch(FileType.FILES, ~/.*.yaml/) { file ->
+        String text = file.getText()
+        LinkedHashMap map = parser.load(text)
+
+        // Don't remove the UUID for this file, it's referenced in the facet configuration
+        boolean removeUuid = !file.getName().equals("corporate-website.yaml")
+        map = format(map, removeUuid)
+
+        // Write out the formatted yaml
+        parser.dump(map, new FileWriter(file))
+    }
+}
+
+log.info("Finished formatting yaml files")
+
+LinkedHashMap format(LinkedHashMap map, boolean removeUuid) {
+    // Sort alphabetically so the order is deterministic
+    map = map.sort()
+
+    // Remove the uuid so hippo can generate one on startup
+    if (removeUuid) {
+        map.remove("jcr:uuid")
+    }
+
+    // Apply to all the sub-maps as well
+    for (String key:map.keySet()) {
+        def value = map.get(key)
+        if (value instanceof LinkedHashMap) {
+            map.put(key, format(value, removeUuid))
+        }
+    }
+
+    return map
+}

--- a/repository-data/webfiles/src/main/resources/hcm-config/main.yaml
+++ b/repository-data/webfiles/src/main/resources/hcm-config/main.yaml
@@ -1,2 +1,3 @@
+---
 definitions:
   webfilebundle: site

--- a/repository-data/webfiles/src/main/resources/hcm-module.yaml
+++ b/repository-data/webfiles/src/main/resources/hcm-module.yaml
@@ -1,8 +1,7 @@
+---
 group:
-  name: publicationsystem
   after: hippo-cms
-
-project: publicationsystem
-
+  name: publicationsystem
 module:
   name: publication-system-repository-data-webfiles
+project: publicationsystem


### PR DESCRIPTION
Note: There are 2 commits with this, the first is the functional change to add the script and the second is running the script on our YAML files to get them in the right format.

The groovy script orders the entries in the yaml files alphabetically and removes any UUIDs.
This should reduce changes when using auto-export so diffs will show only what has actually changed.
The script will run on maven verify and I've also added a command to run it manually with make from the command line.

Also performed an initial run of YAML formatter to write files in the new standard format.
In future all diffs for these files will be only the functional changes.
There are no functional changes to the YAML, the main formatting differences are:
 - Entries are sorted alphabetically
 - All files start with ---
 - All arrays are now formatted as lists
 - Long key values are wrapped and prefixed with '?' (See complex keys in YAML docs)