### PR TITLE
[RPS-186] Cleaned up series doctype

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/series.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/series.yaml
@@ -48,7 +48,6 @@ definitions:
           hippotranslation:locale: document-type-locale
           publicationsystem:Summary: ''
           publicationsystem:Title: ''
-          publicationsystem:title: ''
       /editor:templates:
         jcr:primaryType: editor:templateset
         /_default_:


### PR DESCRIPTION
Removed 'title' that was an unused duplicate of 'Title'.