### PR TITLE
[RPS-160] Clinical indicator summary migration

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/DatasetPageElements.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/DatasetPageElements.java
@@ -15,8 +15,6 @@ public class DatasetPageElements implements PageElements {
             By.xpath("//*[" + getDataUiPathXpath("title") + "]"));
         put("Dataset Summary",
             By.xpath("//*[" + getDataUiPathXpath("summary") + "]"));
-        put("Dataset Purpose",
-            By.xpath("//*[" + getDataUiPathXpath("purpose") + "]"));
         put("Dataset Granularity",
             By.xpath("//*[" + getDataUiPathXpath("granularity") + "]"));
         put("Dataset Geographic Coverage",

--- a/acceptance-tests/src/test/resources/features/site/datasets.feature
+++ b/acceptance-tests/src/test/resources/features/site/datasets.feature
@@ -8,7 +8,6 @@ Scenario: Search individual data set by name
     Then I should see data set page titled "publication-with-datasets Dataset"
     And I should also see:
         | Dataset Summary               | Mauris ex est, dapibus in dictum ut, elementum sit amet ...       |
-        | Dataset Purpose               | Vivamus et tortor ut ex placerat congue vitae nec velit. ...      |
         | Dataset Granularity           | NHS Trusts                                                        |
         | Dataset Geographic Coverage   | England                                                           |
         | Dataset Date Range            | 01/02/2016 to 01/07/2017                                          |
@@ -33,7 +32,6 @@ Scenario: Find data set in publication that is part of series
     Then I should see data set page titled "series-publication-with-datasets Dataset"
     And I should also see:
         | Dataset Summary               | Sed viverra, odio nec eleifend sodales, ligula lectus varius ...  |
-        | Dataset Purpose               | Morbi ipsum mauris, tincidunt sed dictum quis, dictum id ...      |
         | Dataset Granularity           | NHS Health Boards                                                 |
         | Dataset Geographic Coverage   | Great Britain                                                     |
 

--- a/migrator/pom.xml
+++ b/migrator/pom.xml
@@ -70,6 +70,20 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.tngtech.java</groupId>
+            <artifactId>junit-dataprovider</artifactId>
+            <version>1.13.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/DataSet.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/DataSet.java
@@ -1,15 +1,45 @@
 package uk.nhs.digital.ps.migrator.model.hippo;
 
+import java.util.*;
+import java.util.regex.Pattern;
+
 public class DataSet extends HippoImportableItem {
 
     private final String title;
+    private final String summary;
 
-    public DataSet(final Folder parentFolder, final String name, final String title) {
+    public DataSet(final Folder parentFolder,
+                   final String name,
+                   final String title,
+                   final String summary) {
         super(parentFolder, name);
         this.title = title;
+        this.summary = formatSummary(summary);
+    }
+
+    /**
+     * Check that we don't have any html markup and format the paragraphs for import
+     */
+    private static String formatSummary(final String input) {
+        boolean containsMarkup = Arrays.stream(new String[]{"<.*>", "&lt;", "&gt;"})
+            .anyMatch(s -> Pattern.compile(s).matcher(input).find());
+        if (containsMarkup) {
+            throw new RuntimeException("Summary contained a bad char. Input: " + input);
+        }
+
+        // Need to have 2 new lines for paragraphs to be rendered in the cms.
+        // Also we need to double escape new lines and quotes as they need to be escaped in the json for the import
+        return input.trim()
+            .replaceAll("(\n\r?){2,}", "\\\\n\\\\n")
+            .replaceAll("\n\r?", "\\\\n")
+            .replaceAll("\"", "\\\\\"");
     }
 
     public String getTitle() {
         return title;
+    }
+
+    public String getSummary() {
+        return summary;
     }
 }

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/nesstar/PublishingPackage.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/nesstar/PublishingPackage.java
@@ -14,7 +14,8 @@ public class PublishingPackage {
 
     private XPathExpression<Element> idXpath;
     private XPathExpression<Element> titleXpath;
-
+    private XPathExpression<Element> notesXpath;
+    private XPathExpression<Element> abstractXpath;
 
     public PublishingPackage(final Element rootElement) {
         this.rootElement = rootElement;
@@ -29,6 +30,31 @@ public class PublishingPackage {
         return titleXpath.evaluateFirst(rootElement).getTextTrim();
     }
 
+    public String getNotes() {
+        return notesXpath.evaluateFirst(rootElement).getTextTrim();
+    }
+
+    public String getAbstract() {
+        // abstract is not a required tag so check for null
+        Element element = abstractXpath.evaluateFirst(rootElement);
+        return element == null ? null : element.getTextTrim();
+    }
+
+    /**
+     * The summary is the notes followed by a new paragraph with the abstract
+     */
+    public String getSummary() {
+        StringBuilder summary = new StringBuilder(getNotes());
+
+        String abstractStr = getAbstract();
+        if (abstractStr != null) {
+            summary.append("\n\n");
+            summary.append(abstractStr);
+        }
+
+        return summary.toString();
+    }
+
     @Override
     public String toString() {
         return "DataSet{" +
@@ -41,6 +67,8 @@ public class PublishingPackage {
     private void initXpath() {
         idXpath = compileXpath("stdyDscr/citation/titlStmt/IDNo");
         titleXpath = compileXpath("stdyDscr/citation/titlStmt/titl");
+        notesXpath = compileXpath("stdyDscr/citation/notes");
+        abstractXpath = compileXpath("stdyDscr/stdyInfo/abstract");
     }
 
     private XPathExpression<Element> compileXpath(final String xpath) {

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/ImportableItemsFactory.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/ImportableItemsFactory.java
@@ -38,7 +38,8 @@ public class ImportableItemsFactory {
         return new DataSet(
             parentFolder,
             exportedPublishingPackage.getTitle(),
-            exportedPublishingPackage.getTitle()
+            exportedPublishingPackage.getTitle(),
+            exportedPublishingPackage.getSummary()
         );
     }
 

--- a/migrator/src/main/resources/templates/dataset.json.ftl
+++ b/migrator/src/main/resources/templates/dataset.json.ftl
@@ -19,11 +19,6 @@
     "multiple" : false,
     "values" : [ "${dataset.title}" ]
   }, {
-    "name" : "publicationsystem:Purpose",
-    "type" : "STRING",
-    "multiple" : false,
-    "values" : [ "example dataset purpose" ]
-  }, {
     "name" : "publicationsystem:Granularity",
     "type" : "STRING",
     "multiple" : true,
@@ -52,7 +47,7 @@
     "name" : "publicationsystem:Summary",
     "type" : "STRING",
     "multiple" : false,
-    "values" : [ "example dataset summary" ]
+    "values" : [ "${dataset.summary}" ]
   }, {
     "name" : "hippotranslation:locale",
     "type" : "STRING",

--- a/migrator/src/main/resources/templates/publication.json.ftl
+++ b/migrator/src/main/resources/templates/publication.json.ftl
@@ -27,7 +27,7 @@
     "name" : "publicationsystem:Summary",
     "type" : "STRING",
     "multiple" : false,
-    "values" : [ "Some summary" ]
+    "values" : [ "Publication" ]
   }, {
     "name" : "publicationsystem:CoverageEnd",
     "type" : "DATE",

--- a/migrator/src/main/resources/templates/series.json.ftl
+++ b/migrator/src/main/resources/templates/series.json.ftl
@@ -17,7 +17,7 @@
     "name" : "publicationsystem:Summary",
     "type" : "STRING",
     "multiple" : false,
-    "values" : [ "example series summary" ]
+    "values" : [ "Series" ]
   }, {
     "name" : "jcr:path",
     "type" : "STRING",

--- a/migrator/src/test/java/uk/nhs/digital/ps/migrator/model/hippo/DataSetTest.java
+++ b/migrator/src/test/java/uk/nhs/digital/ps/migrator/model/hippo/DataSetTest.java
@@ -1,0 +1,67 @@
+package uk.nhs.digital.ps.migrator.model.hippo;
+
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(DataProviderRunner.class)
+public class DataSetTest {
+
+    @Test
+    @UseDataProvider("validSummaries")
+    public void summaryFormatTest(String[] testData) {
+        String input = testData[0];
+        String expected = testData[1];
+
+        DataSet dataSet = new DataSet(null, "", "", input);
+        assertThat(dataSet.getSummary(), is(expected));
+    }
+
+    @Test(expected = RuntimeException.class)
+    @UseDataProvider("invalidSummaries")
+    public void invalidSummaryFormatTest(String summary) {
+        new DataSet(null, "", "", summary);
+    }
+
+    @DataProvider
+    public static List<String[]> validSummaries() {
+        return Arrays.asList(
+            //           Input                                       Expected
+            // Any number of new line chars > 2 are replaced with two new lines
+            new String[]{"Summary for\n\n a data set",               "Summary for\\n\\n a data set"},
+            new String[]{"Summary for\n\r\n a data set",             "Summary for\\n\\n a data set"},
+            new String[]{"Summary for\n\n\n\r\n\n\r\n a data set",   "Summary for\\n\\n a data set"},
+            new String[]{"Summary\n\n for\n\n\r\n a\n\n data set",   "Summary\\n\\n for\\n\\n a\\n\\n data set"},
+
+            // New lines at the start and end are trimmed
+            new String[]{"\n\rSummary for\n\n a data set\n",         "Summary for\\n\\n a data set"},
+            new String[]{"\n\nSummary for a data set",               "Summary for a data set"},
+            new String[]{"Summary for a data set\n\n\n",             "Summary for a data set"},
+
+            // No double new lines so leave alone except for ecapsing special chars
+            new String[]{"Summary for a data set",                   "Summary for a data set"},
+            new String[]{"Summary for\n a \"data set\"",             "Summary for\\n a \\\"data set\\\""},
+            new String[]{"Summary for\n\r a data set",               "Summary for\\n a data set"}
+        );
+    }
+
+    @DataProvider
+    public static List<String> invalidSummaries() {
+        return Arrays.asList(
+            // If html tags are input, we get an exception
+            "<p>Summary for a data set",
+            "Summary <br>for a data set",
+            "Summary for a data <i>set</i>",
+            "Sum&gt;mary for a data set",
+            "Sum&lt;mary for\n\n a \n\r\n\rdata set"
+        );
+    }
+}

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/EximImport.groovy
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/EximImport.groovy
@@ -51,6 +51,12 @@ class EximImport extends BaseNodeUpdateVisitor {
     }
 
     boolean doUpdate(Node node) {
+        // This method is called for each node in the jcr,
+        // we obviously only want to do the import once so only do it for the root directory
+        if (!node.getPath().equals("/")) {
+            return false
+        }
+
         def contentNode
         def primaryTypeName
         def documentLocation

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/dataset.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/dataset.yaml
@@ -58,14 +58,6 @@ definitions:
             mixin: hippotaxonomy:classifiable
             plugin.class: org.hippoecm.frontend.editor.plugins.mixin.MixinLoaderPlugin
             wicket.id: ${cluster.id}.right.item
-          /Purpose:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: Purpose
-            field: Purpose
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.left.item
           /Files:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
@@ -197,14 +189,6 @@ definitions:
             hipposysedit:primary: false
             hipposysedit:type: CalendarDate
             jcr:primaryType: hipposysedit:field
-          /Purpose:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:Purpose
-            hipposysedit:primary: false
-            hipposysedit:type: Text
-            jcr:primaryType: hipposysedit:field
           /Summary:
             hipposysedit:mandatory: true
             hipposysedit:multiple: false
@@ -262,7 +246,6 @@ definitions:
           - ''
           publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
           publicationsystem:NominalDate: 0001-01-01T12:00:00Z
-          publicationsystem:Purpose: ''
           publicationsystem:Summary: ''
           publicationsystem:Title: ''
         jcr:primaryType: hipposysedit:prototypeset

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/datasets-subfolder/publication-with-datasets-dataset.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/datasets-subfolder/publication-with-datasets-dataset.yaml
@@ -34,8 +34,6 @@
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
     publicationsystem:NominalDate: 2017-10-10T00:00:00Z
     publicationsystem:PubliclyAccessible: true
-    publicationsystem:Purpose: Vivamus et tortor ut ex placerat congue vitae nec velit.
-      Donec imperdiet vestibulum lorem non viverra. Etiam sit amet venenatis purus.
     publicationsystem:Summary: "Mauris ex est, dapibus in dictum ut, elementum sit\
       \ amet odio. Proin egestas augue sit amet est vestibulum, vitae maximus ipsum\
       \ accumsan. Nunc fringilla interdum nunc vitae tempus. Sed vitae ullamcorper\
@@ -82,8 +80,6 @@
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
     publicationsystem:NominalDate: 2017-10-10T00:00:00Z
     publicationsystem:PubliclyAccessible: true
-    publicationsystem:Purpose: Vivamus et tortor ut ex placerat congue vitae nec velit.
-      Donec imperdiet vestibulum lorem non viverra. Etiam sit amet venenatis purus.
     publicationsystem:Summary: "Mauris ex est, dapibus in dictum ut, elementum sit\
       \ amet odio. Proin egestas augue sit amet est vestibulum, vitae maximus ipsum\
       \ accumsan. Nunc fringilla interdum nunc vitae tempus. Sed vitae ullamcorper\
@@ -132,8 +128,6 @@
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
     publicationsystem:NominalDate: 2017-10-10T00:00:00Z
     publicationsystem:PubliclyAccessible: true
-    publicationsystem:Purpose: Vivamus et tortor ut ex placerat congue vitae nec velit.
-      Donec imperdiet vestibulum lorem non viverra. Etiam sit amet venenatis purus.
     publicationsystem:Summary: "Mauris ex est, dapibus in dictum ut, elementum sit\
       \ amet odio. Proin egestas augue sit amet est vestibulum, vitae maximus ipsum\
       \ accumsan. Nunc fringilla interdum nunc vitae tempus. Sed vitae ullamcorper\

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/etiam-placerat-arcu-dataset.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/etiam-placerat-arcu-dataset.yaml
@@ -20,8 +20,6 @@
     - GP practices
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
     publicationsystem:NominalDate: 2017-10-10T00:00:00Z
-    publicationsystem:Purpose: Curabitur euismod erat elit, quis facilisis neque eleifend
-      id. Maecenas convallis vel mi nec bibendum.
     publicationsystem:Summary: Sed et nunc risus. In hac habitasse platea dictumst.
       Proin ultrices, velit vitae mollis aliquet, ligula ipsum tincidunt ante, nec
       imperdiet sapien neque a nibh. In porta suscipit mauris. Suspendisse sit amet
@@ -49,8 +47,6 @@
     - GP practices
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
     publicationsystem:NominalDate: 2017-10-10T00:00:00Z
-    publicationsystem:Purpose: Curabitur euismod erat elit, quis facilisis neque eleifend
-      id. Maecenas convallis vel mi nec bibendum.
     publicationsystem:Summary: Sed et nunc risus. In hac habitasse platea dictumst.
       Proin ultrices, velit vitae mollis aliquet, ligula ipsum tincidunt ante, nec
       imperdiet sapien neque a nibh. In porta suscipit mauris. Suspendisse sit amet
@@ -78,8 +74,6 @@
     - GP practices
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
     publicationsystem:NominalDate: 2017-10-10T00:00:00Z
-    publicationsystem:Purpose: Curabitur euismod erat elit, quis facilisis neque eleifend
-      id. Maecenas convallis vel mi nec bibendum.
     publicationsystem:Summary: Sed et nunc risus. In hac habitasse platea dictumst.
       Proin ultrices, velit vitae mollis aliquet, ligula ipsum tincidunt ante, nec
       imperdiet sapien neque a nibh. In porta suscipit mauris. Suspendisse sit amet

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/series-publication-with-datasets-dataset.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/series-publication-with-datasets-dataset.yaml
@@ -21,9 +21,6 @@
     - NHS Health Boards
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
     publicationsystem:NominalDate: 2017-10-10T00:00:00Z
-    publicationsystem:Purpose: Morbi ipsum mauris, tincidunt sed dictum quis, dictum
-      id magna. In vitae ante placerat, molestie est vel, aliquet lectus. Vivamus
-      luctus id enim eu porttitor.
     publicationsystem:Summary: "Sed viverra, odio nec eleifend sodales, ligula lectus\
       \ varius felis, eget auctor justo purus vitae erat. Nam at tempus dolor. Proin\
       \ neque nisi, pellentesque id cursus in, fermentum vitae purus. Vivamus feugiat\
@@ -66,9 +63,6 @@
     - NHS Health Boards
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
     publicationsystem:NominalDate: 2017-10-10T00:00:00Z
-    publicationsystem:Purpose: Morbi ipsum mauris, tincidunt sed dictum quis, dictum
-      id magna. In vitae ante placerat, molestie est vel, aliquet lectus. Vivamus
-      luctus id enim eu porttitor.
     publicationsystem:Summary: "Sed viverra, odio nec eleifend sodales, ligula lectus\
       \ varius felis, eget auctor justo purus vitae erat. Nam at tempus dolor. Proin\
       \ neque nisi, pellentesque id cursus in, fermentum vitae purus. Vivamus feugiat\
@@ -113,9 +107,6 @@
     - NHS Health Boards
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
     publicationsystem:NominalDate: 2017-10-10T00:00:00Z
-    publicationsystem:Purpose: Morbi ipsum mauris, tincidunt sed dictum quis, dictum
-      id magna. In vitae ante placerat, molestie est vel, aliquet lectus. Vivamus
-      luctus id enim eu porttitor.
     publicationsystem:Summary: "Sed viverra, odio nec eleifend sodales, ligula lectus\
       \ varius felis, eget auctor justo purus vitae erat. Nam at tempus dolor. Proin\
       \ neque nisi, pellentesque id cursus in, fermentum vitae purus. Vivamus feugiat\

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/upcoming-publication/upcoming-dataset.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/upcoming-publication/upcoming-dataset.yaml
@@ -20,8 +20,6 @@
     - GP practices
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
     publicationsystem:NominalDate: 2017-10-10T00:00:00Z
-    publicationsystem:Purpose: Curabitur euismod erat elit, quis facilisis neque eleifend
-      id. Maecenas convallis vel mi nec bibendum.
     publicationsystem:Summary: Sed et nunc risus. In hac habitasse platea dictumst.
       Proin ultrices, velit vitae mollis aliquet, ligula ipsum tincidunt ante, nec
       imperdiet sapien neque a nibh. In porta suscipit mauris. Suspendisse sit amet
@@ -49,8 +47,6 @@
     - GP practices
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
     publicationsystem:NominalDate: 2017-10-10T00:00:00Z
-    publicationsystem:Purpose: Curabitur euismod erat elit, quis facilisis neque eleifend
-      id. Maecenas convallis vel mi nec bibendum.
     publicationsystem:Summary: Sed et nunc risus. In hac habitasse platea dictumst.
       Proin ultrices, velit vitae mollis aliquet, ligula ipsum tincidunt ante, nec
       imperdiet sapien neque a nibh. In porta suscipit mauris. Suspendisse sit amet
@@ -78,8 +74,6 @@
     - GP practices
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
     publicationsystem:NominalDate: 2017-10-10T00:00:00Z
-    publicationsystem:Purpose: Curabitur euismod erat elit, quis facilisis neque eleifend
-      id. Maecenas convallis vel mi nec bibendum.
     publicationsystem:Summary: Sed et nunc risus. In hac habitasse platea dictumst.
       Proin ultrices, velit vitae mollis aliquet, ligula ipsum tincidunt ante, nec
       imperdiet sapien neque a nibh. In porta suscipit mauris. Suspendisse sit amet

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/dataset.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/dataset.ftl
@@ -54,8 +54,6 @@
         <p class="doc-summary" data-uipath="ps.dataset.summary">${element?html}</p>
         </#if>
     </#list>
-
-    <p class="doc-summary" data-uipath="ps.dataset.purpose">${dataset.purpose}</p>
 </div>
 
 <div class="content-section">

--- a/site/src/main/java/uk/nhs/digital/common/components/FacetComponent.java
+++ b/site/src/main/java/uk/nhs/digital/common/components/FacetComponent.java
@@ -7,6 +7,8 @@ import org.hippoecm.hst.core.request.HstRequestContext;
 import org.hippoecm.hst.site.HstServices;
 import org.onehippo.taxonomy.api.Taxonomy;
 import org.onehippo.taxonomy.api.TaxonomyManager;
+import uk.nhs.digital.ps.beans.HippoBeanHelper;
+
 import javax.jcr.RepositoryException;
 
 public class FacetComponent extends SearchComponent {
@@ -14,28 +16,11 @@ public class FacetComponent extends SearchComponent {
     @Override
     public void doBeforeRender(HstRequest request, HstResponse response) {
         TaxonomyManager taxonomyManager = HstServices.getComponentManager().getComponent(TaxonomyManager.class.getName());
-        Taxonomy taxonomy = taxonomyManager.getTaxonomies().getTaxonomy(getTaxonomyName(request.getRequestContext()));
+        Taxonomy taxonomy = taxonomyManager.getTaxonomies().getTaxonomy(HippoBeanHelper.getTaxonomyName());
 
         request.setAttribute("taxonomy", taxonomy);
         request.setAttribute("query", getQueryParameter(request));
         request.setAttribute("facets", getFacetNavigationBean(request));
         request.setAttribute("cparam", getComponentInfo(request)) ;
-    }
-
-    // TODO: copied from uk.nhs.digital.ps.components.PublicationComponent. Refactor?
-    private String getTaxonomyName(HstRequestContext ctx) throws HstComponentException {
-        String taxonomyName;
-
-        try {
-            taxonomyName = ctx.getSession().getNode(
-                "/hippo:namespaces/publicationsystem/publication/editor:templates/_default_/classifiable")
-                .getProperty("essentials-taxonomy-name")
-                .getString();
-        } catch (RepositoryException e) {
-            throw new HstComponentException(
-                "Exception occurred during fetching taxonomy file name.", e);
-        }
-
-        return taxonomyName;
     }
 }

--- a/site/src/main/java/uk/nhs/digital/ps/beans/Dataset.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/Dataset.java
@@ -21,11 +21,6 @@ public class Dataset extends BaseDocument {
         return new StructuredText(getProperty("publicationsystem:Summary"));
     }
 
-    @HippoEssentialsGenerated(internalName = "publicationsystem:Purpose")
-    public String getPurpose() {
-        return getProperty("publicationsystem:Purpose");
-    }
-
     @HippoEssentialsGenerated(internalName = "publicationsystem:NominalDate")
     public Calendar getNominalDate() {
         return getProperty("publicationsystem:NominalDate");

--- a/site/src/main/java/uk/nhs/digital/ps/beans/HippoBeanHelper.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/HippoBeanHelper.java
@@ -2,6 +2,10 @@ package uk.nhs.digital.ps.beans;
 
 import org.hippoecm.hst.container.RequestContextProvider;
 import org.hippoecm.hst.content.beans.standard.HippoBean;
+import org.hippoecm.hst.core.component.HstComponentException;
+import org.hippoecm.hst.core.request.HstRequestContext;
+
+import javax.jcr.RepositoryException;
 
 /**
  * Static helper for {@linkplain org.hippoecm.hst.content.beans.standard.HippoBean}
@@ -12,5 +16,22 @@ public class HippoBeanHelper {
         HippoBean siteContentBaseBean = RequestContextProvider.get().getSiteContentBaseBean();
 
         return folder.isSelf(siteContentBaseBean);
+    }
+
+    public static String getTaxonomyName() throws HstComponentException {
+        String taxonomyName;
+
+        try {
+            HstRequestContext ctx = RequestContextProvider.get();
+            taxonomyName = ctx.getSession().getNode(
+                "/hippo:namespaces/publicationsystem/publication/editor:templates/_default_/classifiable")
+                .getProperty("essentials-taxonomy-name")
+                .getString();
+        } catch (RepositoryException e) {
+            throw new HstComponentException(
+                "Exception occurred during fetching taxonomy file name.", e);
+        }
+
+        return taxonomyName;
     }
 }

--- a/site/src/main/java/uk/nhs/digital/ps/beans/Publication.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/Publication.java
@@ -1,6 +1,5 @@
 package uk.nhs.digital.ps.beans;
 
-import org.hippoecm.hst.container.RequestContextProvider;
 import org.hippoecm.hst.content.beans.query.HstQueryResult;
 import org.hippoecm.hst.content.beans.query.builder.HstQueryBuilder;
 import org.hippoecm.hst.content.beans.query.exceptions.QueryException;
@@ -9,7 +8,6 @@ import org.hippoecm.hst.content.beans.standard.HippoBeanIterator;
 import org.hippoecm.hst.content.beans.standard.HippoFolder;
 import org.hippoecm.hst.content.beans.standard.HippoResourceBean;
 import org.hippoecm.hst.core.component.HstComponentException;
-import org.hippoecm.hst.core.request.HstRequestContext;
 import org.hippoecm.hst.site.HstServices;
 import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
 import org.hippoecm.hst.content.beans.Node;
@@ -21,7 +19,6 @@ import org.slf4j.LoggerFactory;
 import uk.nhs.digital.ps.beans.structuredText.StructuredText;
 import uk.nhs.digital.ps.site.exceptions.DataRestrictionViolationException;
 
-import javax.jcr.RepositoryException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
@@ -75,7 +72,7 @@ public class Publication extends BaseDocument {
         if (getKeys() != null) {
             // Lookup Taxonomy Tree
             TaxonomyManager taxonomyManager = HstServices.getComponentManager().getComponent(TaxonomyManager.class.getName());
-            Taxonomy taxonomyTree = taxonomyManager.getTaxonomies().getTaxonomy(getTaxonomyName());
+            Taxonomy taxonomyTree = taxonomyManager.getTaxonomies().getTaxonomy(HippoBeanHelper.getTaxonomyName());
 
             for (String key : getKeys()) {
                 List<Category> ancestors = (List<Category>) taxonomyTree.getCategoryByKey(key).getAncestors();
@@ -89,23 +86,6 @@ public class Publication extends BaseDocument {
         }
 
         return taxonomyList;
-    }
-
-    private static String getTaxonomyName() throws HstComponentException {
-        String taxonomyName;
-
-        try {
-            HstRequestContext ctx = RequestContextProvider.get();
-            taxonomyName = ctx.getSession().getNode(
-                "/hippo:namespaces/publicationsystem/publication/editor:templates/_default_/classifiable")
-                .getProperty("essentials-taxonomy-name")
-                .getString();
-        } catch (RepositoryException e) {
-            throw new HstComponentException(
-                "Exception occurred during fetching taxonomy file name.", e);
-        }
-
-        return taxonomyName;
     }
 
     public Series getParentSeries() {


### PR DESCRIPTION
Added summary migration for clinical indicators.
Also removed the Purpose field from the CMS as we want the purpose to
 just be the last paragraph in the summary.
Also small bit of refactoring to remove duplicate TaxonomyName method.