### PR TITLE
[RPS-70] Productionise coverage start and end dates

### DIFF
--- a/cms/src/main/java/uk/nhs/digital/ps/CoverageDatesValidator.java
+++ b/cms/src/main/java/uk/nhs/digital/ps/CoverageDatesValidator.java
@@ -1,0 +1,97 @@
+package uk.nhs.digital.ps;
+
+import org.apache.wicket.model.IModel;
+import org.hippoecm.frontend.editor.validator.plugins.AbstractCmsValidator;
+import org.hippoecm.frontend.model.JcrNodeModel;
+import org.hippoecm.frontend.plugin.IPluginContext;
+import org.hippoecm.frontend.plugin.config.IPluginConfig;
+import org.hippoecm.frontend.validation.IFieldValidator;
+import org.hippoecm.frontend.validation.ValidationException;
+import org.hippoecm.frontend.validation.Violation;
+
+import javax.jcr.RepositoryException;
+import java.util.Calendar;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.text.MessageFormat.format;
+
+public class CoverageDatesValidator extends AbstractCmsValidator {
+
+    private static final String SUPPORTED_FIELD_TYPE_NAME = "CalendarDate";
+    private static final String HIPPO_COVERAGE_START_PROPERTY_NAME = "publicationsystem:CoverageStart";
+    private static final String HIPPO_COVERAGE_END_PROPERTY_NAME = "publicationsystem:CoverageEnd";
+    private static final String HIPPO_NOMINAL_DATE_PROPERTY_NAME = "publicationsystem:NominalDate";
+
+    @SuppressWarnings("WeakerAccess") // Hippo CMS requires the constructor to be public
+    public CoverageDatesValidator(final IPluginContext pluginContext, final IPluginConfig pluginConfig) {
+        super(pluginContext, pluginConfig);
+    }
+
+    @Override
+    public void preValidation(IFieldValidator fieldValidator) throws ValidationException {
+
+        final String actualFieldTypeName = fieldValidator.getFieldDescriptor().getTypeDescriptor().getName();
+
+        if (!SUPPORTED_FIELD_TYPE_NAME.equals(actualFieldTypeName)) {
+            throw new ValidationException(format(
+                "Cannot validate field ''{0}'' of type ''{1}''. This validator only supports fields of type ''{2}''.",
+                fieldValidator.getFieldDescriptor().getPath(),
+                actualFieldTypeName,
+                SUPPORTED_FIELD_TYPE_NAME
+            ));
+        }
+    }
+
+    @Override
+    public Set<Violation> validate(final IFieldValidator fieldValidator,
+                                   final JcrNodeModel documentModel,
+                                   final IModel coverageDateFieldModel) throws ValidationException {
+
+        final Set<Violation> violations = new HashSet<>();
+
+        // get dates
+        final Calendar start = getDateValue(documentModel, HIPPO_COVERAGE_START_PROPERTY_NAME);
+        final Calendar end = getDateValue(documentModel, HIPPO_COVERAGE_END_PROPERTY_NAME);
+        final Calendar nominal = getDateValue(documentModel, HIPPO_NOMINAL_DATE_PROPERTY_NAME);
+
+        // coverageEnd but no coverageStart
+        if (!isHippoEmptyDate(end) && isHippoEmptyDate(start)) {
+            violations.add(fieldValidator.newValueViolation(documentModel, getTranslation("no-start-provided")));
+        }
+
+        // coverageStart but no coverageEnd
+        if (!isHippoEmptyDate(start) && isHippoEmptyDate(end)) {
+            violations.add(fieldValidator.newValueViolation(documentModel, getTranslation("no-end-provided")));
+        }
+
+        if (!isHippoEmptyDate(start) && !isHippoEmptyDate(end)) {
+
+            // coverageEnd is before coverageStart
+            if (end.before(start)) {
+                violations.add(fieldValidator.newValueViolation(documentModel, getTranslation("end-before-start")));
+            }
+
+            // coverage dates CANNOT BE AFTER nominal publication date
+            if (!isHippoEmptyDate(nominal)
+                && (start.after(nominal) || end.after(nominal))) {
+                violations.add(fieldValidator.newValueViolation(documentModel, getTranslation("dates-after-nominal")));
+            }
+        }
+
+        return violations;
+    }
+
+    private Calendar getDateValue(final JcrNodeModel documentModel, String propertyName) throws ValidationException {
+        try {
+            return documentModel.getNode().getProperty(propertyName).getDate();
+        } catch (final RepositoryException e) {
+            throw new ValidationException(format("Failed to read field ''{0}'' value", propertyName));
+        }
+    }
+
+    private boolean isHippoEmptyDate(final Calendar date) {
+        // Hippo empty dates are stored as 0001-01-01T12:00:00Z
+        return (date.get(Calendar.YEAR) == 1 && date.get(Calendar.MONTH) == 0 && date.get(Calendar.DAY_OF_MONTH) == 1);
+    }
+}

--- a/cms/src/test/java/uk/nhs/digital/ps/CoverageDatesValidatorTest.java
+++ b/cms/src/test/java/uk/nhs/digital/ps/CoverageDatesValidatorTest.java
@@ -1,0 +1,332 @@
+package uk.nhs.digital.ps;
+
+import org.apache.wicket.Page;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.util.tester.WicketTester;
+import org.hippoecm.frontend.model.JcrNodeModel;
+import org.hippoecm.frontend.plugin.IPluginContext;
+import org.hippoecm.frontend.plugin.config.IPluginConfig;
+import org.hippoecm.frontend.types.IFieldDescriptor;
+import org.hippoecm.frontend.types.ITypeDescriptor;
+import org.hippoecm.frontend.validation.IFieldValidator;
+import org.hippoecm.frontend.validation.ValidationException;
+import org.hippoecm.frontend.validation.Violation;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import java.util.*;
+
+import static java.text.MessageFormat.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class CoverageDatesValidatorTest {
+
+    private static final String SUPPORTED_FIELD_TYPE_NAME = "CalendarDate";
+    private static final String HIPPO_COVERAGE_START_PROPERTY_NAME = "publicationsystem:CoverageStart";
+    private static final String HIPPO_COVERAGE_END_PROPERTY_NAME = "publicationsystem:CoverageEnd";
+    private static final String HIPPO_NOMINAL_DATE_PROPERTY_NAME = "publicationsystem:NominalDate";
+
+    @Rule public ExpectedException expectedException = ExpectedException.none();
+
+    @Mock private IFieldValidator fieldValidator;
+    @Mock private IFieldDescriptor fieldDescriptor;
+    @Mock private ITypeDescriptor typeDescriptor;
+    @Mock private Node documentNode;
+    @Mock private JcrNodeModel documentNodeModel;
+    @Mock private JcrNodeModel fieldModel;
+    @Mock private IPluginConfig pluginConfig;
+    @Mock private IPluginContext pluginContext;
+    @Mock private IModel<String> violationMessageTranslationModel;
+
+    private CoverageDatesValidator coverageDatesValidator;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        given(pluginConfig.getName()).willReturn("SomeTestConfig");
+
+        initialiseWicketApplication();
+
+        coverageDatesValidator = new CoverageDatesValidator(
+            pluginContext,
+            pluginConfig
+        );
+    }
+
+    @Test
+    public void reportsError_whenCalledForInvalidFieldType() throws Exception {
+
+        // given
+        programMocksForPreValidationTestForHappyPath();
+        reset(typeDescriptor);
+
+        final String unsupportedFieldTypeName = newRandomString();
+        given(typeDescriptor.getName()).willReturn(unsupportedFieldTypeName);
+
+        expectedException.expect(ValidationException.class);
+        expectedException.expectMessage(format(
+            "Cannot validate field ''{0}'' of type ''{1}''. This validator only supports fields of type ''{2}''.",
+            fieldValidator.getFieldDescriptor().getPath(),
+            unsupportedFieldTypeName,
+            SUPPORTED_FIELD_TYPE_NAME
+        ));
+
+        // when
+        coverageDatesValidator.preValidation(fieldValidator);
+
+        // then
+        // expectations as specified in 'given'
+
+    }
+
+    @Test
+    public void reportsNoValidationViolations_forCorrectlyPopulatedDates() throws Exception {
+
+        // Given
+        final Property coverageStartProperty = mock(Property.class);
+        given(coverageStartProperty.getDate()).willReturn(generateHippoDateTodayAddDays(-2));
+        given(documentNode.getProperty(HIPPO_COVERAGE_START_PROPERTY_NAME)).willReturn(coverageStartProperty);
+
+        final Property coverageEndProperty = mock(Property.class);
+        given(coverageEndProperty.getDate()).willReturn(generateHippoDateTodayAddDays(-1));
+        given(documentNode.getProperty(HIPPO_COVERAGE_END_PROPERTY_NAME)).willReturn(coverageEndProperty);
+
+        final Property nominalDateProperty = mock(Property.class);
+        given(nominalDateProperty.getDate()).willReturn(generateHippoDateTodayAddDays(10));
+        given(documentNode.getProperty(HIPPO_NOMINAL_DATE_PROPERTY_NAME)).willReturn(nominalDateProperty);
+
+
+        given(documentNodeModel.getNode()).willReturn(documentNode);
+
+        // when
+        final Set<Violation> actualValidationViolations =
+            coverageDatesValidator.validate(fieldValidator, documentNodeModel, fieldModel);
+
+        // then
+        then(documentNode).should().getProperty(HIPPO_COVERAGE_START_PROPERTY_NAME);
+        then(documentNode).should().getProperty(HIPPO_COVERAGE_END_PROPERTY_NAME);
+        then(documentNode).should().getProperty(HIPPO_NOMINAL_DATE_PROPERTY_NAME);
+
+        assertThat("No violation has been reported.", actualValidationViolations, is(empty()));
+    }
+
+
+    @Test
+    public void reportsError_whenEndDateLessThanStartDate() throws Exception {
+
+        final Violation expectedViolation = new Violation(Collections.emptySet(), violationMessageTranslationModel);
+
+        // Given
+        final Property coverageStartProperty = mock(Property.class);
+        given(coverageStartProperty.getDate()).willReturn(generateHippoDateTodayAddDays(-2));
+        given(documentNode.getProperty(HIPPO_COVERAGE_START_PROPERTY_NAME)).willReturn(coverageStartProperty);
+
+        final Property coverageEndProperty = mock(Property.class);
+        given(coverageEndProperty.getDate()).willReturn(generateHippoDateTodayAddDays(-4));
+        given(documentNode.getProperty(HIPPO_COVERAGE_END_PROPERTY_NAME)).willReturn(coverageEndProperty);
+
+        final Property nominalDateProperty = mock(Property.class);
+        given(nominalDateProperty.getDate()).willReturn(generateHippoDateEmpty());
+        given(documentNode.getProperty(HIPPO_NOMINAL_DATE_PROPERTY_NAME)).willReturn(nominalDateProperty);
+
+
+        given(documentNodeModel.getNode()).willReturn(documentNode);
+
+        given(fieldValidator.newValueViolation(eq(documentNodeModel), isA(IModel.class)))
+            .willReturn(expectedViolation);
+
+        // when
+        final Set<Violation> actualValidationViolations =
+            coverageDatesValidator.validate(fieldValidator, documentNodeModel, fieldModel);
+
+        // then
+        then(documentNode).should().getProperty(HIPPO_COVERAGE_START_PROPERTY_NAME);
+        then(documentNode).should().getProperty(HIPPO_COVERAGE_END_PROPERTY_NAME);
+        then(documentNode).should().getProperty(HIPPO_NOMINAL_DATE_PROPERTY_NAME);
+
+        assertThat("Exactly one violation has been reported", actualValidationViolations, hasSize(1));
+
+        final Violation actualViolation = actualValidationViolations.iterator().next();
+        assertThat("Violation is not null", actualViolation, notNullValue());
+        assertThat("Correct violation has been reported.",actualViolation.getMessage(),
+            is(violationMessageTranslationModel));
+    }
+
+    @Test
+    public void reportsError_whenEndDateButNoStartDate() throws Exception {
+
+        final Violation expectedViolation = new Violation(Collections.emptySet(), violationMessageTranslationModel);
+
+        // Given
+        final Property coverageStartProperty = mock(Property.class);
+        given(coverageStartProperty.getDate()).willReturn(generateHippoDateEmpty());
+        given(documentNode.getProperty(HIPPO_COVERAGE_START_PROPERTY_NAME)).willReturn(coverageStartProperty);
+
+        final Property coverageEndProperty = mock(Property.class);
+        given(coverageEndProperty.getDate()).willReturn(generateHippoDateTodayAddDays(-7));
+        given(documentNode.getProperty(HIPPO_COVERAGE_END_PROPERTY_NAME)).willReturn(coverageEndProperty);
+
+        final Property nominalDateProperty = mock(Property.class);
+        given(nominalDateProperty.getDate()).willReturn(generateHippoDateEmpty());
+        given(documentNode.getProperty(HIPPO_NOMINAL_DATE_PROPERTY_NAME)).willReturn(nominalDateProperty);
+
+        given(documentNodeModel.getNode()).willReturn(documentNode);
+
+
+        given(fieldValidator.newValueViolation(eq(documentNodeModel), isA(IModel.class)))
+            .willReturn(expectedViolation);
+
+        // when
+        final Set<Violation> actualValidationViolations =
+            coverageDatesValidator.validate(fieldValidator, documentNodeModel, fieldModel);
+
+        // then
+        then(documentNode).should().getProperty(HIPPO_COVERAGE_START_PROPERTY_NAME);
+        then(documentNode).should().getProperty(HIPPO_COVERAGE_END_PROPERTY_NAME);
+        then(documentNode).should().getProperty(HIPPO_NOMINAL_DATE_PROPERTY_NAME);
+
+        assertThat("Exactly one violation has been reported", actualValidationViolations, hasSize(1));
+
+        final Violation actualViolation = actualValidationViolations.iterator().next();
+        assertThat("Violation is not null", actualViolation, notNullValue());
+        assertThat("Correct violation has been reported.",actualViolation.getMessage(),
+            is(violationMessageTranslationModel));
+    }
+
+    @Test
+    public void reportsError_whenStartDateButNoEndDate() throws Exception {
+
+        final Violation expectedViolation = new Violation(Collections.emptySet(), violationMessageTranslationModel);
+
+        // Given
+        final Property coverageStartProperty = mock(Property.class);
+        given(coverageStartProperty.getDate()).willReturn(generateHippoDateTodayAddDays(-7));
+        given(documentNode.getProperty(HIPPO_COVERAGE_START_PROPERTY_NAME)).willReturn(coverageStartProperty);
+
+        final Property coverageEndProperty = mock(Property.class);
+        given(coverageEndProperty.getDate()).willReturn(generateHippoDateEmpty());
+        given(documentNode.getProperty(HIPPO_COVERAGE_END_PROPERTY_NAME)).willReturn(coverageEndProperty);
+
+        final Property nominalDateProperty = mock(Property.class);
+        given(nominalDateProperty.getDate()).willReturn(generateHippoDateEmpty());
+        given(documentNode.getProperty(HIPPO_NOMINAL_DATE_PROPERTY_NAME)).willReturn(nominalDateProperty);
+
+
+        given(documentNodeModel.getNode()).willReturn(documentNode);
+
+        given(fieldValidator.newValueViolation(eq(documentNodeModel), isA(IModel.class)))
+            .willReturn(expectedViolation);
+
+        // when
+        final Set<Violation> actualValidationViolations =
+            coverageDatesValidator.validate(fieldValidator, documentNodeModel, fieldModel);
+
+        // then
+        then(documentNode).should().getProperty(HIPPO_COVERAGE_START_PROPERTY_NAME);
+        then(documentNode).should().getProperty(HIPPO_COVERAGE_END_PROPERTY_NAME);
+        then(documentNode).should().getProperty(HIPPO_NOMINAL_DATE_PROPERTY_NAME);
+
+        assertThat("Exactly one violation has been reported", actualValidationViolations, hasSize(1));
+
+        final Violation actualViolation = actualValidationViolations.iterator().next();
+        assertThat("Violation is not null", actualViolation, notNullValue());
+        assertThat("Correct violation has been reported.",actualViolation.getMessage(),
+            is(violationMessageTranslationModel));
+    }
+
+    @Test
+    public void reportsError_whenCoverageDatesGreaterThanNominalDate() throws Exception {
+
+        final Violation expectedViolation = new Violation(Collections.emptySet(), violationMessageTranslationModel);
+
+        // Given
+        final Property coverageStartProperty = mock(Property.class);
+        given(coverageStartProperty.getDate()).willReturn(generateHippoDateTodayAddDays(7));
+        given(documentNode.getProperty(HIPPO_COVERAGE_START_PROPERTY_NAME)).willReturn(coverageStartProperty);
+
+        final Property coverageEndProperty = mock(Property.class);
+        given(coverageEndProperty.getDate()).willReturn(generateHippoDateTodayAddDays(7));
+        given(documentNode.getProperty(HIPPO_COVERAGE_END_PROPERTY_NAME)).willReturn(coverageEndProperty);
+
+        final Property nominalDateProperty = mock(Property.class);
+        given(nominalDateProperty.getDate()).willReturn(generateHippoDateTodayAddDays(2));
+        given(documentNode.getProperty(HIPPO_NOMINAL_DATE_PROPERTY_NAME)).willReturn(nominalDateProperty);
+
+
+        given(documentNodeModel.getNode()).willReturn(documentNode);
+
+        given(fieldValidator.newValueViolation(eq(documentNodeModel), isA(IModel.class)))
+            .willReturn(expectedViolation);
+
+        // when
+        final Set<Violation> actualValidationViolations =
+            coverageDatesValidator.validate(fieldValidator, documentNodeModel, fieldModel);
+
+        // then
+        then(documentNode).should().getProperty(HIPPO_COVERAGE_START_PROPERTY_NAME);
+        then(documentNode).should().getProperty(HIPPO_COVERAGE_END_PROPERTY_NAME);
+        then(documentNode).should().getProperty(HIPPO_NOMINAL_DATE_PROPERTY_NAME);
+
+        assertThat("Exactly one violation has been reported", actualValidationViolations, hasSize(1));
+
+        final Violation actualViolation = actualValidationViolations.iterator().next();
+        assertThat("Violation is not null", actualViolation, notNullValue());
+        assertThat("Correct violation has been reported.",actualViolation.getMessage(),
+            is(violationMessageTranslationModel));
+    }
+
+    private void initialiseWicketApplication() {
+        // This initialises various statically stored values that Wicket uses,
+        // most notably, Session and Application whose absence was causing NullPointerException during call to
+        // org.hippoecm.frontend.editor.validator.plugins.AbstractCmsValidator.getTranslation(java.lang.String).
+        new WicketTester(new WebApplication() {
+            public Class<? extends Page> getHomePage() {
+                return null;
+            }
+        });
+    }
+
+    private String newRandomString() {
+        return UUID.randomUUID().toString();
+    }
+
+    private void programMocksForPreValidationTestForHappyPath() {
+
+        given(fieldValidator.getFieldDescriptor()).willReturn(fieldDescriptor);
+        given(fieldDescriptor.getTypeDescriptor()).willReturn(typeDescriptor);
+        given(typeDescriptor.getName()).willReturn(SUPPORTED_FIELD_TYPE_NAME);
+        given(fieldDescriptor.getPath()).willReturn(newRandomString());
+    }
+
+    private Calendar generateHippoDateEmpty() {
+        // Hippo empty dates are stored as 0001-01-01T12:00:00Z
+        Calendar emptyDate = Calendar.getInstance();
+        emptyDate.clear();
+        emptyDate.set(1,Calendar.JANUARY,1,0,0,0);
+
+        return emptyDate;
+    }
+
+    private Calendar generateHippoDateTodayAddDays(int daysToAdd) {
+        Calendar date = Calendar.getInstance();
+        date.add(Calendar.DAY_OF_MONTH, daysToAdd);
+        return date;
+    }
+}

--- a/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms-validators.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms-validators.yaml
@@ -15,6 +15,9 @@ definitions:
     /hippo:configuration/hippo:frontend/cms/cms-validators/publicationsystem-blank-related-link:
       jcr:primaryType: frontend:plugin
       plugin.class: uk.nhs.digital.ps.BlankRelatedLinkFieldValidator
+    /hippo:configuration/hippo:frontend/cms/cms-validators/publicationsystem-coverage-dates:
+      jcr:primaryType: frontend:plugin
+      plugin.class: uk.nhs.digital.ps.CoverageDatesValidator
     /hippo:configuration/hippo:frontend/cms/cms-validators/publicationsystem-title:
       jcr:primaryType: frontend:plugin
       max_length: 250

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/cms.yaml
@@ -8,5 +8,14 @@ definitions:
         URL provided. Please remove it or enter a URL.
       publicationsystem-blank-staticdropdown: '{0} has a ''''Choose One'''' placeholder
         without a value. Please remove the placeholder or select a value.'
+      publicationsystem-coverage-dates#dates-after-nominal: Coverage dates must not
+        be after nominal publication date.
+      publicationsystem-coverage-dates#end-before-start: Coverage End date must not
+        be before Coverage Start date.
+      publicationsystem-coverage-dates#no-end-provided: Coverage End date required.
+        If no end date exists and a snapshot date is required, set the Coverage End
+        to the same as Coverage Start.
+      publicationsystem-coverage-dates#no-start-provided: Coverage End date requires
+        a corresponding Coverage Start date.
       publicationsystem-title: Title must be 250 characters or less
       valid-url: Link URL must start with http:// or https://

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/dataset.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/dataset.yaml
@@ -88,6 +88,8 @@ definitions:
               jcr:primaryType: frontend:pluginconfig
             caption: Coverage Start
             field: CoverageStart
+            hint: For snapshot date, set the Coverage Start and End dates to be the
+              same
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.right.item
@@ -96,7 +98,8 @@ definitions:
               jcr:primaryType: frontend:pluginconfig
             caption: Coverage End
             field: CoverageEnd
-            hint: ''
+            hint: For snapshot date, set the Coverage Start and End dates to be the
+              same
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.right.item
@@ -140,6 +143,8 @@ definitions:
             hipposysedit:path: publicationsystem:CoverageEnd
             hipposysedit:primary: false
             hipposysedit:type: CalendarDate
+            hipposysedit:validators:
+            - publicationsystem-coverage-dates
             jcr:primaryType: hipposysedit:field
           /CoverageStart:
             hipposysedit:mandatory: false

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
@@ -105,6 +105,8 @@ definitions:
               jcr:primaryType: frontend:pluginconfig
             caption: Coverage Start
             field: coverage_start
+            hint: For snapshot date, set the Coverage Start and End dates to be the
+              same
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.css:
@@ -115,7 +117,8 @@ definitions:
               jcr:primaryType: frontend:pluginconfig
             caption: Coverage End
             field: coverage_end
-            hint: ''
+            hint: For snapshot date, set the Coverage Start and End dates to be the
+              same
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.css:
@@ -244,6 +247,8 @@ definitions:
             hipposysedit:path: publicationsystem:CoverageEnd
             hipposysedit:primary: false
             hipposysedit:type: CalendarDate
+            hipposysedit:validators:
+            - publicationsystem-coverage-dates
             jcr:primaryType: hipposysedit:field
           /coverage_start:
             hipposysedit:mandatory: false

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/dataset.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/dataset.ftl
@@ -4,6 +4,7 @@
 
 <#assign dateFormat="dd/MM/yyyy"/>
 <#assign formatFileSize="uk.nhs.digital.ps.directives.FileSizeFormatterDirective"?new() >
+<#assign formatCoverageDates="uk.nhs.digital.ps.directives.CoverageDatesFormatterDirective"?new() >
 
 <#if dataset??>
 
@@ -25,14 +26,8 @@
                     <dl class="media__body">
                         <dt>Date Range</dt>
                         <dd data-uipath="ps.dataset.date-range">
-                            <#if dataset.coverageStart?? >
-                                <@fmt.formatDate value=dataset.coverageStart.time type="Date" pattern=dateFormat />
-                            <#else>
-                                (Not specified)
-                            </#if>
-                            to
-                            <#if dataset.coverageEnd?? >
-                                <@fmt.formatDate value=dataset.coverageEnd.time type="Date" pattern=dateFormat />
+                            <#if dataset.coverageStart?? && dataset.coverageEnd??>
+                                <@formatCoverageDates start=dataset.coverageStart.time end=dataset.coverageEnd.time/>
                             <#else>
                                 (Not specified)
                             </#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
@@ -3,6 +3,7 @@
 <#assign dateFormat="dd/MM/yyyy"/>
 <#assign formatFileSize="uk.nhs.digital.ps.directives.FileSizeFormatterDirective"?new() />
 <#assign formatRestrictableDate="uk.nhs.digital.ps.directives.RestrictableDateFormatterDirective"?new() />
+<#assign formatCoverageDates="uk.nhs.digital.ps.directives.CoverageDatesFormatterDirective"?new() >
 
 <@hst.setBundle basename="publicationsystem.headers"/>
 
@@ -91,14 +92,8 @@
                         <dl class="media__body">
                             <dt>Date Range</dt>
                             <dd data-uipath="ps.publication.date-range">
-                                <#if publication.coverageStart?? >
-                                    <@fmt.formatDate value=publication.coverageStart.time type="Date" pattern=dateFormat />
-                                <#else>
-                                    (Not specified)
-                                </#if>
-                                to
-                                <#if publication.coverageEnd?? >
-                                    <@fmt.formatDate value=publication.coverageEnd.time type="Date" pattern=dateFormat />
+                                <#if publication.coverageStart?? && publication.coverageEnd??>
+                                    <@formatCoverageDates start=publication.coverageStart.time end=publication.coverageEnd.time/>
                                 <#else>
                                     (Not specified)
                                 </#if>

--- a/site/src/main/java/uk/nhs/digital/ps/directives/CoverageDatesFormatterDirective.java
+++ b/site/src/main/java/uk/nhs/digital/ps/directives/CoverageDatesFormatterDirective.java
@@ -1,0 +1,67 @@
+package uk.nhs.digital.ps.directives;
+
+import freemarker.core.Environment;
+import freemarker.template.*;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Map;
+
+import static java.text.MessageFormat.format;
+
+/**
+ * Example usage in Freemarker template:
+ * <pre>
+ *
+ *     <#assign formatCoverageDates="uk.nhs.digital.ps.directives.CoverageDatesFormatterDirective"?new() >
+ *         ...
+ *     &lt;p&gt;<@formatCoverageDates start=document.coverageStart end=document.coverageEnd/>.&lt;/p&gt;
+ * </pre>
+ *
+ */
+public class CoverageDatesFormatterDirective implements TemplateDirectiveModel {
+
+    private static final String START_PARAM_NAME = "start";
+    private static final String END_PARAM_NAME = "end";
+    private static final String SNAPSHOT_WORDING = "Snapshot on ";
+
+
+    @Override
+    public void execute(Environment environment, Map parameters, TemplateModel[] templateModels,
+                        TemplateDirectiveBody templateDirectiveBody) throws TemplateException, IOException {
+
+        assertRequiredParameterPresent(parameters, environment, START_PARAM_NAME);
+        assertRequiredParameterPresent(parameters, environment, END_PARAM_NAME);
+
+        final Date start = getValueAsDate(parameters, START_PARAM_NAME);
+        final Date end = getValueAsDate(parameters, END_PARAM_NAME);
+        final String result = formatCoverageDates(start, end);
+
+        environment.getOut().append(result);
+    }
+
+    private String formatCoverageDates(final Date start, final Date end) {
+        if (start.equals(end)) {
+            return format("{0} {1}", SNAPSHOT_WORDING ,formatDate(start));  // Snapshot date
+        } else {
+            return format("{0} to {1}", formatDate(start), formatDate(end));            // Range date
+        }
+    }
+
+    private String formatDate(final Date dateToFormat) {
+        SimpleDateFormat requiredFormat = new SimpleDateFormat("dd/MM/yyyy");
+        return requiredFormat.format(dateToFormat);
+    }
+
+    private Date getValueAsDate(final Map parameters, final String paramName) {
+        return ((SimpleDate)parameters.get(paramName)).getAsDate();
+    }
+
+    private void assertRequiredParameterPresent(final Map parameters, final Environment environment, String parameterName) throws TemplateException {
+        if (!parameters.containsKey(parameterName)) {
+            throw new TemplateException(format("Required parameter ''{0}'' was not provided to template {1}.",
+                parameterName, getClass().getName()), environment);
+        }
+    }
+}


### PR DESCRIPTION
Added CMS input validation for coverage dates and formatting
of the output dates on the site
- end must not be earlier than start
- start and end dates must be before nominal publication date
- if start and end same, then expressed as 'snapshot on' date
in the rendered publication
- not mandatory, but if one field is populated, then the other
must be populated too (and vice versa)