### PR TITLE
[RPS-204] CI migration: make folder names human-friendly

### DIFF
--- a/migrator/README.md
+++ b/migrator/README.md
@@ -62,17 +62,14 @@ so on. File names are prefixed with a zero-padded sequential number generated in
 idea is to create a file for parent folders before generating files for content to go into these folders. The
 [import script] then reads the files in the same order to ensure that folders are created before the files.
 
-NOTE: at the moment of writing, the import script actually ignores the folder files and creates folder structure from
-paths embedded in 'document' JSON files. This will likely be addressed later as the folders generated that way do not
-have a 'user friendly' names.
-
 ## Importing
-Having logged into CMS as an administrator, navigate to `Admin > Updater Editor` and click `Registry > EximImport`
-script. In parameters section, set `targetBaseFolderPath` to point to the directory containing the impoort JSON files;
-note that, by default, the script is configured to look under temp directory resolved via `${java.io.tmpdir}` which
-does not necessarily point to the `/tmp` so it's often better to provide full path in here.
+Having logged into CMS as an administrator, navigate to `Admin > Updater Editor` and click `Registry > MigratorImporterScript`
+script. In parameters section, set `sourceBaseFolderPath` to point to the directory containing the import JSON files.
 
-Given that we want to import the items one by one, set `Batch Size` to `1`.
+Keep `Batch Size`  set to `1` to ensure that folder files are correctly processed; the reason is that EXIM appears to only commit
+changes between individual batches and if parent and child folders are created in the same batch, the parent cannot be
+found when the child is being created. Keeping batch size set to `1` ensures that changes from each import file are committed
+before the next file is processed. 
 
 Click `Execute` and watch the log.       
       
@@ -84,4 +81,4 @@ Click `Execute` and watch the log.
 [EXIM]:                         https://onehippo-forge.github.io/content-export-import/index.html
 [Updater Editor]:               https://www.onehippo.org/library/concepts/update/using-the-updater-editor.html
 [Groovy]:                       http://groovy-lang.org/
-[import script]:                ../repository-data/application/src/main/resources/hcm-config/configuration/update/import.groovy
+[import script]:                ../repository-data/application/src/main/resources/hcm-config/configuration/update/MigratorImporterScript.groovy

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/MigratorImporterScript.groovy
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/MigratorImporterScript.groovy
@@ -1,0 +1,143 @@
+
+import org.apache.commons.lang.text.StrSubstitutor
+import org.apache.commons.vfs2.FileObject
+import org.apache.commons.vfs2.VFS
+import org.hippoecm.repository.api.HippoWorkspace
+import org.hippoecm.repository.api.WorkflowManager
+import org.onehippo.forge.content.exim.core.ContentMigrationRecord
+import org.onehippo.forge.content.exim.core.DocumentManager
+import org.onehippo.forge.content.exim.core.impl.WorkflowDocumentManagerImpl
+import org.onehippo.forge.content.exim.core.impl.WorkflowDocumentVariantImportTask
+import org.onehippo.forge.content.exim.core.util.HippoNodeUtils
+import org.onehippo.forge.content.pojo.model.ContentNode
+import org.onehippo.repository.update.BaseNodeUpdateVisitor
+
+import javax.jcr.Node
+import javax.jcr.Session
+
+
+class MigratorImporterScript extends BaseNodeUpdateVisitor {
+
+    DocumentManager documentManager
+    WorkflowDocumentVariantImportTask importTask
+    FileObject sourceBaseFolder
+    Session session
+
+    WorkflowManager workflowManager
+
+    void initialize(Session session) {
+        this.session = session
+
+        def sourceBaseFolderPath = StrSubstitutor.replaceSystemProperties(parametersMap.get("sourceBaseFolderPath"))
+        sourceBaseFolder = VFS.getManager().resolveFile(sourceBaseFolderPath)
+
+        workflowManager = ((HippoWorkspace)session.getWorkspace()).getWorkflowManager()
+
+        documentManager = new WorkflowDocumentManagerImpl(session)
+        importTask = new WorkflowDocumentVariantImportTask(documentManager)
+        importTask.setLogger(log)
+        importTask.start()
+    }
+
+    boolean doUpdate(Node node) {
+
+        // This method is called for each node in the jcr,
+        // we obviously only want to do the import once so only do it for the root directory
+        if (!node.getPath().equals("/")) {
+            return false
+        }
+
+        FileObject[] files = findImportFiles()
+
+        if (!files) {
+            log.error "No files found to import in ${sourceBaseFolder}. Aborting with no attempt of importing anything having been made."
+            return false
+        }
+
+        log.info "Files to import found: ${files.length}"
+
+        files
+            .toSorted { left, right -> left.getName().compareTo(right.getName()) }
+            .eachWithIndex { FileObject file, int i ->
+
+                log.info "Processing file [${i + 1}/${files.length}]: ${file.name.path}"
+
+                ContentNode contentNode = importTask.readContentNodeFromJsonFile(file)
+
+                ContentMigrationRecord contentMigrationRecord
+                String nodeFullPath = ""
+
+                String primaryTypeName = contentNode.getPrimaryType()
+
+                try {
+
+                    nodeFullPath = contentNode.getProperty("jcr:path").getValue()
+
+                    // record instance to store execution status and detail of a unit of migration work item.
+                    // these record instances will be collected and summarized when #logSummary() invoked later.
+                    contentMigrationRecord = importTask.beginRecord("", nodeFullPath)
+                    contentMigrationRecord.setProcessed(true)
+                    contentMigrationRecord.setAttribute("file", file.name.path)
+                    contentMigrationRecord.setContentType(primaryTypeName)
+
+                    String localizedName = contentNode.getProperty("jcr:localizedName").getValue()
+
+                    log.info("Creating ${primaryTypeName}: ${nodeFullPath}")
+
+                    if ("hippostd:folder".equals(primaryTypeName)) {
+
+                        Node folderNode = HippoNodeUtils.createMissingHippoFolders(session, nodeFullPath)
+
+                        folderNode.addMixin("hippo:named")
+                        folderNode.setProperty("hippo:name", localizedName)
+
+                    } else {
+
+                        String locale = (contentNode.hasProperty("hippotranslation:locale")) \
+                            ? contentNode.getProperty("hippotranslation:locale").getValue() \
+                            : null
+
+                        String updatedDocumentLocation = importTask.createOrUpdateDocumentFromVariantContentNode(
+                            contentNode,
+                            primaryTypeName,
+                            nodeFullPath,
+                            locale,
+                            localizedName
+                        )
+
+                        // By default, the created or updated document is left as preview status.
+                        // Optionally, if you want, you can publish the document right away here by uncommenting the following line.
+                        documentManager.publishDocument(updatedDocumentLocation)
+                    }
+
+                    visitorContext.reportUpdated(nodeFullPath)
+                    contentMigrationRecord.setSucceeded(true)
+
+                    log.info("Created ${primaryTypeName}: ${nodeFullPath}")
+                } catch (e) {
+                    log.error("Failed to import ${primaryTypeName}: ${nodeFullPath}", e)
+                    visitorContext.reportFailed(nodeFullPath)
+                    contentMigrationRecord.setErrorMessage(e.toString())
+                } finally {
+                    importTask.endRecord()
+                }
+        }
+
+        return true
+    }
+
+    boolean undoUpdate(Node node) {
+        throw new UnsupportedOperationException('Updater does not implement undoUpdate method')
+    }
+
+    void destroy() {
+        importTask.stop()
+        importTask.logSummary()
+    }
+
+    private FileObject[] findImportFiles() {
+        FileObject[] files = importTask.findFilesByNamePattern(sourceBaseFolder, "^.+\\.json\$", 1, 10)
+
+        return files == null ? [] : files;
+    }
+}

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/MigratorImporterScript.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/MigratorImporterScript.yaml
@@ -1,0 +1,27 @@
+---
+definitions:
+  config:
+    /hippo:configuration/hippo:update/hippo:registry/MigratorImporterScript:
+      hipposys:batchsize: 1
+      hipposys:description: " This script constitutes the 'importer' component of\
+        \ the Migrator application and should ONLY be used to import JSON files generated\
+        \ by the latter:\n- with each file containing definition of only one document\
+        \ or folder,\n- with files being named in the way where when ordered ascendingly\
+        \ by their names, files defining folders will be processed before those defining\
+        \ their content.\n\nKeep batch size set to 1 to ensure that folder files are\
+        \ correctly processed; the system appears to only commit changes between individual\
+        \ batches and if parent and child folders are created in the same batch, the\
+        \ parent cannot be found when the child is being created. Keeping batch size\
+        \ set to 1 ensures that changes from each import file are committed before\
+        \ the next file is processed.\n\nNOTE that the expectation is that the script\
+        \ will only ever be executed once as it has no logic to deal with partial\
+        \ imports - if, say, a failure occurs and the script is re-run, duplicates\
+        \ or further errors can be expected. "
+      hipposys:dryrun: false
+      hipposys:parameters: '{"sourceBaseFolderPath": "file:/tmp/exim-import/"}'
+      hipposys:path: /
+      hipposys:script:
+        resource: /configuration/update/MigratorImporterScript.groovy
+        type: string
+      hipposys:throttle: 100
+      jcr:primaryType: hipposys:updaterinfo


### PR DESCRIPTION
EximImport was re-set to its original version and MigratorImporterScript
was added as THE import script to use to import content generated by
the Migrator application; readme has been updated accordingly.

This is to reflect the fact that MigratorImporterScript is tailored
specifically to consume content generated by the Migrator rather than
more generic output of EximExport.

'FOLDER' JSON files generated by the Migrator application are now being
processed by the import script and so the folders are now created with
display names as specified by property 'jcr:localizedName' in files
generated by the Migrator.

It is now also possible to create empty folders upon migration.