### PR TITLE
[RPS-212] Fix search bug with stopwords from other locales

### DIFF
--- a/cms/src/main/resources/org/hippoecm/repository/query/lucene/StandardHippoAnalyzer.properties
+++ b/cms/src/main/resources/org/hippoecm/repository/query/lucene/StandardHippoAnalyzer.properties
@@ -1,0 +1,6 @@
+# Used to prevent stop words from other locales affecting search results
+# i.e. "SIE" wasnt being found in the search because it is a German stop word.
+# https://www.onehippo.org/library/administration/lucene-analyzer.html
+
+# Available locale strings for ResourceBundle properties file defining stopwords.
+stopwords.locales=en


### PR DESCRIPTION
Set stopwords to use the English (en) locale only