### PR TITLE
[RPS-192] Migrate CI Compendium

### DIFF
--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/config/ExecutionConfigurator.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/config/ExecutionConfigurator.java
@@ -12,17 +12,17 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static uk.nhs.digital.ps.migrator.misc.Descriptor.describe;
 
-public class ExecutionConfigurer {
+public class ExecutionConfigurator {
 
     public static final String HELP_FLAG = "help";
 
-    // rktodo better names (enum?)
     public static final String NESSTAR_ZIP_FILE_PATH = "nesstarUnzipFrom";
     public static final String NESSTAR_FORCE_UNZIP_FLAG = "nesstarForceUnzip";
     public static final String NESSTAR_CONVERT_FLAG = "nesstarConvert";
+    public static final String NESSTAR_ATTACHMENT_DOWNLOAD_FOLDER = "nesstarAttachmentDownloadFolder";
+    public static final String NESSTAR_COMPENDIUM_MAPPING_FILE = "nesstarCompendiumMappingFile";
 
     public static final String HIPPO_IMPORT_DIR = "hippoImportDir";
-    public static final String ATTACHMENT_DOWNLOAD_FOLDER = "attachmentDownloadFolder";
 
     public static final String TAXONOMY_SPREADSHEET_PATH = "taxonomySpreadsheetPath";
     public static final String TAXONOMY_OUTPUT_PATH = "taxonomyOutputPath";
@@ -37,18 +37,20 @@ public class ExecutionConfigurer {
     private static final Path TEMP_DIR_PATH = Paths.get(System.getProperty("java.io.tmpdir"));
 
 
-    public ExecutionConfigurer(final ExecutionParameters executionParameters) {
+    public ExecutionConfigurator(final ExecutionParameters executionParameters) {
         this.executionParameters = executionParameters;
     }
 
 
     public void initExecutionParameters(final ApplicationArguments args) {
 
-        executionParameters.setIsNesstarUnzipForce(args.containsOption(NESSTAR_FORCE_UNZIP_FLAG));
+        executionParameters.setNesstarUnzipForce(args.containsOption(NESSTAR_FORCE_UNZIP_FLAG));
 
         executionParameters.setNesstarZippedExportFile(getPathArg(args, NESSTAR_ZIP_FILE_PATH));
 
         executionParameters.setConvertNesstar(args.containsOption(NESSTAR_CONVERT_FLAG));
+
+        executionParameters.setNesstarCompendiumMappingFile(getPathArg(args, NESSTAR_COMPENDIUM_MAPPING_FILE));
 
         executionParameters.setTaxonomySpreadsheetPath(getPathArg(args, TAXONOMY_SPREADSHEET_PATH));
 
@@ -68,12 +70,12 @@ public class ExecutionConfigurer {
     }
 
     public void initDownloadDir(final ApplicationArguments args) {
-        Path pathArg = getPathArg(args, ATTACHMENT_DOWNLOAD_FOLDER);
+        Path pathArg = getPathArg(args, NESSTAR_ATTACHMENT_DOWNLOAD_FOLDER);
         if (pathArg == null) {
             pathArg = Paths.get(TEMP_DIR_PATH.toString(), ATTACHMENT_DOWNLOAD_DIR_NAME_DEFAULT);
         }
 
-        executionParameters.setAttachmentDownloadDir(pathArg);
+        executionParameters.setNesstarAttachmentDownloadDir(pathArg);
     }
 
     private void initTaxonomyOutputPath(final ApplicationArguments args) {
@@ -108,6 +110,33 @@ public class ExecutionConfigurer {
             describe(
                 NESSTAR_ZIP_FILE_PATH,
                 "Path to the ZIP file containing data exported from Nesstar."
+            ),
+            describe(
+                NESSTAR_ATTACHMENT_DOWNLOAD_FOLDER,
+                "Directory where the migrator will download attachments into." +
+                    " Optional - if not provided, one will be created in a temporary space." +
+                    " NOTE that the files will not be downloaded if they exist in the folder already."
+            ),
+            describe(
+                NESSTAR_COMPENDIUM_MAPPING_FILE,
+                "File containing mapping of Clinical Indicators Compendium." +
+                    " Required if --" + NESSTAR_CONVERT_FLAG + " is specified, optional otherwise."
+            ),
+            describe(
+                HIPPO_IMPORT_DIR,
+                "Directory where the migrator will generate import files for Hippo to read them from." +
+                    " Optional - if not provided, one will be created in a temporary space." +
+                    " NOTE that the directory is deleted and re-created on each run."
+            ),
+            describe(
+                TAXONOMY_SPREADSHEET_PATH,
+                "Path to the spreadsheet that contains the taxonomy we want to import into hippo." +
+                    " Optional - if not provided, taxonomy will not be imported."
+            ),
+            describe(
+                TAXONOMY_OUTPUT_PATH,
+                "Path to output the taxonomy JSON to import into hippo." +
+                    " Optional - if not provided, one will be created in a temporary space."
             )
         );
     }
@@ -127,28 +156,6 @@ public class ExecutionConfigurer {
             describe(
                 NESSTAR_CONVERT_FLAG,
                 "Triggers conversion of Nesstar export to Hippo import format."
-            ),
-            describe(
-                HIPPO_IMPORT_DIR,
-                "Directory where the migrator will generate import files for Hippo to read them from." +
-                    " Optional - if not provided, one will be created in a temporary space." +
-                    " NOTE that the directory is deleted and re-created on each run."
-            ),
-            describe(
-                ATTACHMENT_DOWNLOAD_FOLDER,
-                "Directory where the migrator will download attachments into." +
-                    " Optional - if not provided, one will be created in a temporary space." +
-                    " NOTE that the files will not be downloaded if they exist in the folder already."
-            ),
-            describe(
-                TAXONOMY_SPREADSHEET_PATH,
-                "Path to the spreadsheet that contains the taxonomy we want to import into hippo." +
-                    " Optional - if not provided, taxonomy will not be imported."
-            ),
-            describe(
-                TAXONOMY_OUTPUT_PATH,
-                "Path to output the taxonomy JSON to import into hippo." +
-                    " Optional - if not provided, one will be created in a temporary space."
             )
         );
     }

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/config/ExecutionParameters.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/config/ExecutionParameters.java
@@ -14,9 +14,10 @@ public class ExecutionParameters {
     private Path nesstarZippedExportFile;
     private boolean isNesstarUnzipForce;
     private boolean convertNesstar;
+    private Path nesstarAttachmentDownloadDir;
+    private Path nesstarCompendiumMappingFile;
 
     private Path hippoImportDir;
-    private Path attachmentDownloadDir;
     private Path taxonomySpreadsheetPath;
     private Path taxonomyOutputPath;
 
@@ -36,7 +37,7 @@ public class ExecutionParameters {
         return nesstarZippedExportFile;
     }
 
-    public void setIsNesstarUnzipForce(final boolean isNesstarUnzipForce) {
+    public void setNesstarUnzipForce(final boolean isNesstarUnzipForce) {
         this.isNesstarUnzipForce = isNesstarUnzipForce;
     }
 
@@ -52,19 +53,6 @@ public class ExecutionParameters {
         this.convertNesstar = convertNesstar;
     }
 
-    public List<Descriptor> descriptions() {
-        return asList(
-            describe("nesstarUnzippedExportDir", nesstarUnzippedExportDir),
-            describe("nesstarZippedExportFile", nesstarZippedExportFile),
-            describe("isNesstarUnzipForce", isNesstarUnzipForce),
-            describe("convertNesstar", convertNesstar),
-            describe("hippoImportDir", hippoImportDir),
-            describe("attachmentDownloadFolder", attachmentDownloadDir),
-            describe("taxonomySpreadsheetPath", taxonomySpreadsheetPath),
-            describe("taxonomyOutputPath", taxonomyOutputPath)
-        );
-    }
-
     public Path getHippoImportDir() {
         return hippoImportDir;
     }
@@ -73,12 +61,20 @@ public class ExecutionParameters {
         this.hippoImportDir = hippoImportDir;
     }
 
-    public Path getAttachmentDownloadDir() {
-        return attachmentDownloadDir;
+    public Path getNesstarAttachmentDownloadDir() {
+        return nesstarAttachmentDownloadDir;
     }
 
-    public void setAttachmentDownloadDir(Path attachmentDownloadDir) {
-        this.attachmentDownloadDir = attachmentDownloadDir;
+    public void setNesstarAttachmentDownloadDir(Path nesstarAttachmentDownloadDir) {
+        this.nesstarAttachmentDownloadDir = nesstarAttachmentDownloadDir;
+    }
+
+    public Path getNesstarCompendiumMappingFile() {
+        return nesstarCompendiumMappingFile;
+    }
+
+    public void setNesstarCompendiumMappingFile(final Path nesstarCompendiumMappingFile) {
+        this.nesstarCompendiumMappingFile = nesstarCompendiumMappingFile;
     }
 
     public Path getTaxonomySpreadsheetPath() {
@@ -95,5 +91,19 @@ public class ExecutionParameters {
 
     public void setTaxonomyOutputPath(Path taxonomyOutputPath) {
         this.taxonomyOutputPath = taxonomyOutputPath;
+    }
+
+    public List<Descriptor> descriptions() {
+        return asList(
+            describe("nesstarUnzippedExportDir", nesstarUnzippedExportDir),
+            describe("nesstarZippedExportFile", nesstarZippedExportFile),
+            describe("isNesstarUnzipForce", isNesstarUnzipForce),
+            describe("convertNesstar", convertNesstar),
+            describe("hippoImportDir", hippoImportDir),
+            describe("nesstarAttachmentDownloadDir", nesstarAttachmentDownloadDir),
+            describe("nesstarCompendiumMappingFile", nesstarCompendiumMappingFile),
+            describe("taxonomySpreadsheetPath", taxonomySpreadsheetPath),
+            describe("taxonomyOutputPath", taxonomyOutputPath)
+        );
     }
 }

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/config/MigratorConfiguration.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/config/MigratorConfiguration.java
@@ -3,6 +3,10 @@ package uk.nhs.digital.ps.migrator.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.nhs.digital.ps.migrator.task.*;
+import uk.nhs.digital.ps.migrator.task.importables.CcgImportables;
+import uk.nhs.digital.ps.migrator.task.importables.CompendiumImportables;
+import uk.nhs.digital.ps.migrator.task.importables.NhsOutcomesFrameworkImportables;
+import uk.nhs.digital.ps.migrator.task.importables.SocialCareImportables;
 
 import java.util.List;
 
@@ -12,10 +16,22 @@ import static java.util.Arrays.asList;
 public class MigratorConfiguration {
 
     @Bean
-    public List<Task> tasks(final ExecutionParameters executionParameters) {
+    public List<MigrationTask> tasks(final ExecutionParameters executionParameters,
+                                     final ImportableItemsFactory importableItemsFactory,
+                                     final SocialCareImportables socialCareImportables,
+                                     final CcgImportables ccgImportables,
+                                     final NhsOutcomesFrameworkImportables nhsOutcomesFrameworkImportables,
+                                     final CompendiumImportables compendiumImportables) {
+
         return asList(
-            new UnzipNesstarFileTask(executionParameters),
-            new GenerateImportContentTask(executionParameters),
+            new UnzipNesstarExportFileTask(executionParameters),
+            new GenerateNesstarImportContentTask(
+                executionParameters,
+                importableItemsFactory,
+                socialCareImportables,
+                ccgImportables,
+                nhsOutcomesFrameworkImportables,
+                compendiumImportables),
             new GenerateTaxonomyTask(executionParameters)
         );
     }
@@ -26,8 +42,33 @@ public class MigratorConfiguration {
     }
 
     @Bean
-    public ExecutionConfigurer commandLineArgsParser(final ExecutionParameters executionParameters) {
-        return new ExecutionConfigurer(executionParameters);
+    public ExecutionConfigurator commandLineArgsParser(final ExecutionParameters executionParameters) {
+        return new ExecutionConfigurator(executionParameters);
     }
 
+    @Bean
+    public ImportableItemsFactory importableItemsFactory(final ExecutionParameters executionParameters) {
+        return new ImportableItemsFactory(executionParameters);
+    }
+
+    @Bean
+    public CcgImportables ccgImportables(final ImportableItemsFactory importableItemsFactory) {
+        return new CcgImportables(importableItemsFactory);
+    }
+
+    @Bean
+    public SocialCareImportables socialCareImportables(final ImportableItemsFactory importableItemsFactory) {
+        return new SocialCareImportables(importableItemsFactory);
+    }
+
+    @Bean
+    public NhsOutcomesFrameworkImportables nhsOutcomesFrameworkImportables(final ImportableItemsFactory importableItemsFactory) {
+        return new NhsOutcomesFrameworkImportables(importableItemsFactory);
+    }
+
+    @Bean
+    public CompendiumImportables compendiumImportables(final ExecutionParameters executionParameters,
+                                                       final ImportableItemsFactory importableItemsFactory) {
+        return new CompendiumImportables(executionParameters, importableItemsFactory);
+    }
 }

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/Attachment.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/Attachment.java
@@ -3,8 +3,6 @@ package uk.nhs.digital.ps.migrator.model.hippo;
 import org.apache.tika.Tika;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.nhs.digital.ps.migrator.PublicationSystemMigrator;
-import uk.nhs.digital.ps.migrator.config.ExecutionParameters;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -27,8 +25,10 @@ public class Attachment {
 
     private final String title;
     private final String uri;
+    private final Path attachmentDownloadDir;
 
-    public Attachment(String title, String uri) {
+    public Attachment(final Path attachmentDownloadDir, String title, String uri) {
+        this.attachmentDownloadDir = attachmentDownloadDir;
         this.title = title;
         this.uri = uri;
     }
@@ -42,8 +42,7 @@ public class Attachment {
     }
 
     public String getFilePath() {
-        ExecutionParameters executionParameters = PublicationSystemMigrator.getExecutionParameters();
-        return executionParameters.getAttachmentDownloadDir() + getUri();
+        return attachmentDownloadDir + getUri();
     }
 
     public String getFileName() {
@@ -59,7 +58,7 @@ public class Attachment {
         }
     }
 
-    public void downloadAttachment() {
+    public void download() {
 
         try {
             File file = new File(getFilePath());

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/nesstar/DataSetRepository.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/nesstar/DataSetRepository.java
@@ -18,7 +18,7 @@ public class DataSetRepository {
             );
     }
 
-    PublishingPackage findById(final String id) {
+    public PublishingPackage findById(final String id) {
         return datasetsByIds.get(id);
     }
 }

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/nesstar/PublishingPackage.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/nesstar/PublishingPackage.java
@@ -27,7 +27,7 @@ public class PublishingPackage {
         initXpath();
     }
 
-    String getUniqueIdentifier() {
+    public String getUniqueIdentifier() {
         return idXpath.evaluateFirst(rootElement).getTextTrim();
     }
 

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/GenerateTaxonomyTask.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/GenerateTaxonomyTask.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-public class GenerateTaxonomyTask implements Task {
+public class GenerateTaxonomyTask implements MigrationTask {
 
     private static final String TAXONOMY_COLUMN = "concept";
     private static final String TAXONOMY_JCR_PATH = "/content/taxonomies/publication_taxonomy";

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/ImportableFileWriter.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/ImportableFileWriter.java
@@ -6,6 +6,7 @@ import freemarker.template.TemplateExceptionHandler;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.nhs.digital.ps.migrator.model.hippo.DataSet;
 import uk.nhs.digital.ps.migrator.model.hippo.HippoImportableItem;
 
 import java.io.StringWriter;

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/MigrationTask.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/MigrationTask.java
@@ -1,6 +1,6 @@
 package uk.nhs.digital.ps.migrator.task;
 
-public interface Task {
+public interface MigrationTask {
 
     void execute();
 

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/UnzipNesstarExportFileTask.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/UnzipNesstarExportFileTask.java
@@ -17,13 +17,13 @@ import static org.apache.commons.io.FileUtils.deleteDirectory;
 import static org.apache.commons.io.FilenameUtils.getBaseName;
 import static org.apache.commons.io.FilenameUtils.getExtension;
 
-public class UnzipNesstarFileTask implements Task {
+public class UnzipNesstarExportFileTask implements MigrationTask {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     private final ExecutionParameters executionParameters;
 
-    public UnzipNesstarFileTask(final ExecutionParameters executionParameters) {
+    public UnzipNesstarExportFileTask(final ExecutionParameters executionParameters) {
         this.executionParameters = executionParameters;
     }
 

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/CompendiumImportables.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/CompendiumImportables.java
@@ -1,0 +1,285 @@
+package uk.nhs.digital.ps.migrator.task.importables;
+
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.slf4j.Logger;
+import uk.nhs.digital.ps.migrator.config.ExecutionParameters;
+import uk.nhs.digital.ps.migrator.model.hippo.Folder;
+import uk.nhs.digital.ps.migrator.model.hippo.HippoImportableItem;
+import uk.nhs.digital.ps.migrator.model.hippo.Publication;
+import uk.nhs.digital.ps.migrator.model.hippo.Series;
+import uk.nhs.digital.ps.migrator.model.nesstar.DataSetRepository;
+import uk.nhs.digital.ps.migrator.model.nesstar.PublishingPackage;
+import uk.nhs.digital.ps.migrator.task.ImportableItemsFactory;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static java.util.stream.StreamSupport.stream;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class CompendiumImportables {
+
+    private final static Logger log = getLogger(CompendiumImportables.class);
+
+    private final ExecutionParameters executionParameters;
+    private final ImportableItemsFactory factory;
+
+    private static final Pattern P_CODE_REGEX = Pattern.compile("P\\d+");
+
+    public CompendiumImportables(final ExecutionParameters executionParameters,
+                                 final ImportableItemsFactory importableItemsFactory) {
+
+        this.executionParameters = executionParameters;
+        this.factory = importableItemsFactory;
+    }
+
+    public Collection<HippoImportableItem> create(final DataSetRepository dataSetRepository, final Folder ciRootFolder) {
+
+        assertRequiredArgs(executionParameters.getNesstarCompendiumMappingFile());
+
+        final List<HippoImportableItem> importableItems = new ArrayList<>();
+
+        final ImportablePrototypes importablePrototypes = readMapping();
+
+
+        // Target CMS structure:
+        //
+        // A)  Compendium of population health indicators             FOLDER
+        // B)    Compendium cancer incidence, survival and screening  FOLDER
+        // C)      Current                                            FOLDER
+        // D)        content                                          SERIES
+        // E)        Cancer Incidence                                 FOLDER
+        // F)          content                                        PUBLICATION
+        // G)          DataSet                                        DATASET
+        // H)    Archive                                              FOLDER
+        // I)      Cancer Incidence                                   FOLDER
+        // J)        content                                          SERIES
+        // K)        Dec 2016                                         PUBLICATION (to be created manually by editors)
+
+        // A)
+        final Folder compendiumRootFolder = factory.newFolder(ciRootFolder, "Compendium of population health indicators");
+        importableItems.add(compendiumRootFolder);
+
+        importablePrototypes.getSeriesPrototypes().forEach(seriesPrototype -> {
+
+            // B)
+            final Folder seriesRootFolder = factory.newFolder(compendiumRootFolder, "Compendium " + seriesPrototype.getName());
+            importableItems.add(seriesRootFolder);
+
+            // C)
+            final Folder seriesCurrentFolder = factory.newFolder(seriesRootFolder, "Current");
+            importableItems.add(seriesCurrentFolder);
+
+            // D)
+            final Series series = factory.newSeries(seriesCurrentFolder, seriesRootFolder.getLocalizedName());
+            importableItems.add(series);
+
+            seriesPrototype.getPublicationPrototypes().forEach(publicationPrototype -> {
+
+                // E)
+                final Folder publicationFolder = factory.newFolder(seriesCurrentFolder, publicationPrototype.getName());
+                importableItems.add(publicationFolder);
+
+                // F)
+                final Publication publication = factory.newPublication(
+                    publicationFolder,
+                    "content",
+                    publicationPrototype.getName()
+                );
+                importableItems.add(publication);
+
+                // G)
+                publicationPrototype.getDatasetIds().forEach(datasetId -> {
+                    final PublishingPackage publishingPackage = dataSetRepository.findById(datasetId);
+                    if (publishingPackage == null) {
+                        // todo error reporting - invalid datasetId (no match found)
+                        log.error("No dataset found with id {}", datasetId);
+
+                    } else {
+                        try {
+                            importableItems.add(factory.toDataSet(publicationFolder, publishingPackage));
+                        } catch (final Exception e) {
+                            // todo error reporting
+                            log.error("Failed to convert dataset " + datasetId, e);
+                        }
+
+                    }
+                });
+
+            });
+
+            // H)
+            final Folder archiveFolder = factory.newFolder(seriesRootFolder, "Archive");
+            importableItems.add(archiveFolder);
+
+            seriesPrototype.getPublicationPrototypes().forEach(publicationPrototype -> {
+
+                // I) - what used to be publication in 'Current', turns into a series in 'Archive'
+                final Folder seriesArchiveFolder = factory.newFolder(archiveFolder, publicationPrototype.getName());
+                importableItems.add(seriesArchiveFolder);
+
+                // J)
+                final Series seriesArchivedContent = factory.newSeries(seriesArchiveFolder, "Archived " + seriesArchiveFolder.getLocalizedName());
+                importableItems.add(seriesArchivedContent);
+            });
+
+        });
+
+        return importableItems;
+    }
+
+    private ImportablePrototypes readMapping() { // todo name
+
+        XSSFWorkbook workbook;
+        try {
+            final InputStream excelFile = new FileInputStream(
+                executionParameters.getNesstarCompendiumMappingFile().toFile()
+            );
+
+            workbook = new XSSFWorkbook(excelFile);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read Clinical Indicators Compendium mapping from file " + executionParameters.getNesstarCompendiumMappingFile(), e);
+        }
+
+        final XSSFSheet sheet3 = workbook.getSheet("Sheet3");
+
+        streamRows(sheet3)
+            .filter(row -> row.getCell(3) != null)
+            .filter(row -> row.getCell(3).getStringCellValue().trim().matches("P\\d+.+"))
+
+            .filter(row -> row.getCell(1) == null || isBlank(row.getCell(1).getStringCellValue()))
+            .filter(row -> row.getCell(2) == null || isBlank(row.getCell(2).getStringCellValue()))
+
+            .forEach(row ->
+                // todo proper error reporting
+                log.error("Found P-code without matching series or publication definition: {}:{}:{}",
+                    row.getCell(1) == null ? "" : row.getCell(1).getStringCellValue(),
+                    row.getCell(2) == null ? "" : row.getCell(2).getStringCellValue(),
+                    row.getCell(3) == null ? "" : row.getCell(3).getStringCellValue()
+                )
+            );
+
+        return streamRows(sheet3)
+            // only use rows that actually have a dataset indicator (the 'P-value')
+            .filter(row -> row.getCell(3) != null)
+            .filter(row -> row.getCell(3).getStringCellValue().trim().matches("P\\d+\\D*"))
+            // only use rows where mapping is defined for a dataset
+            // (reject rows with P-value but without Series or Publication values)
+            .filter(row -> !(row.getCell(1) == null || isBlank(row.getCell(1).getStringCellValue())))
+            .filter(row -> !(row.getCell(2) == null || isBlank(row.getCell(2).getStringCellValue())))
+            .map(row -> {
+                final String seriesName = row.getCell(1).getStringCellValue().trim();
+                final String publicationName = row.getCell(2).getStringCellValue().trim();
+
+                // some P-codes (dataset ids) in the spreadsheet were found with extra characters,
+                // (likely copy-paste debris) we need to sanitise such values
+                final Matcher pCodeMatcher = P_CODE_REGEX.matcher(
+                    row.getCell(3).getStringCellValue().trim()
+                );
+                pCodeMatcher.find();
+                final String datasetId = pCodeMatcher.group();
+
+                return new String[]{seriesName, publicationName, datasetId};
+            })
+            .collect(
+                ImportablePrototypes::new,
+                (prototypes, row) -> prototypes.add(row[0], row[1], row[2]),
+                (l, r) -> { /* no-op - no need for a combinator in serial stream */ }
+            );
+    }
+
+    private Stream<Row> streamRows(final XSSFSheet sheet3) {
+        return stream(((Iterable<Row>) sheet3::rowIterator).spliterator(), false);
+    }
+
+    private void assertRequiredArgs(final Path nesstarMappingFile) {
+
+        if (nesstarMappingFile == null) {
+            throw new IllegalArgumentException(
+                "Required path to Clinical Indicators Compendium mapping file was not specified."
+            );
+        }
+
+        if (!Files.isRegularFile(nesstarMappingFile)) {
+            throw new IllegalArgumentException(
+                "Nesstar mapping file does not exist: " + nesstarMappingFile
+            );
+        }
+    }
+
+    static class PublicationPrototype {
+        private String name;
+        private Set<String> datasets = new HashSet<>(); // todo error report: duplicate P-codes
+
+        public PublicationPrototype(final String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void add(final String datasetId) {
+            datasets.add(datasetId);
+        }
+
+        public Set<String> getDatasetIds() {
+            return datasets;
+        }
+    }
+
+    static class SeriesPrototype {
+        private String name;
+        private Map<String, PublicationPrototype> publications = new HashMap<>();
+
+        public SeriesPrototype(final String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void add(final String publicationName, final String datasetId) {
+            if (!publications.containsKey(publicationName)) {
+                publications.put(publicationName, new PublicationPrototype(publicationName));
+            }
+
+            publications.get(publicationName).add(datasetId);
+        }
+
+        public Collection<PublicationPrototype> getPublicationPrototypes() {
+            return publications.values();
+        }
+    }
+
+    static class ImportablePrototypes {
+
+        private Map<String, SeriesPrototype> series = new HashMap<>();
+
+        public void add(final String seriesName, final String publicationName, final String datasetId) {
+
+            if (!series.containsKey(seriesName)) {
+                series.put(seriesName, new SeriesPrototype(seriesName));
+            }
+
+            series.get(seriesName).add(publicationName, datasetId);
+        }
+
+        public List<SeriesPrototype> getSeriesPrototypes() {
+            return new ArrayList<>(series.values());
+        }
+    }
+
+}

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/NhsOutcomesFrameworkImportables.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/NhsOutcomesFrameworkImportables.java
@@ -6,17 +6,23 @@ import uk.nhs.digital.ps.migrator.model.hippo.Publication;
 import uk.nhs.digital.ps.migrator.model.hippo.Series;
 import uk.nhs.digital.ps.migrator.model.nesstar.Catalog;
 import uk.nhs.digital.ps.migrator.model.nesstar.CatalogStructure;
+import uk.nhs.digital.ps.migrator.task.ImportableItemsFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
-import static uk.nhs.digital.ps.migrator.task.ImportableItemsFactory.*;
 
 public class NhsOutcomesFrameworkImportables {
 
-    static public List<HippoImportableItem> create(final CatalogStructure catalogStructure, final Folder ciRootFolder) {
+    private final ImportableItemsFactory importableItemsFactory;
+
+    public NhsOutcomesFrameworkImportables(final ImportableItemsFactory importableItemsFactory) {
+        this.importableItemsFactory = importableItemsFactory;
+    }
+
+    public List<HippoImportableItem> create(final CatalogStructure catalogStructure, final Folder ciRootFolder) {
         final List<HippoImportableItem> importableItems = new ArrayList<>();
 
         // Target CMS structure:
@@ -32,22 +38,22 @@ public class NhsOutcomesFrameworkImportables {
 
         // A)
         final Catalog rootCatalog = catalogStructure.findCatalogByLabel("NHS Outcomes Framework");
-        final Folder rootFolder = toFolder(rootCatalog, ciRootFolder);
+        final Folder nfoRootFolder = importableItemsFactory.toFolder(ciRootFolder, rootCatalog);
 
         // B)
-        final String currentQuarterFolderName = "current";
-        final Folder quarterlyPublicationFolder = newFolder(currentQuarterFolderName, rootFolder);
-        quarterlyPublicationFolder.setLocalizedName("Current");
+        final Folder currentPublicationFolder = importableItemsFactory.newFolder(nfoRootFolder, "Current");
 
         // C)
-        final Publication quarterlyPublication = newPublication("content", rootCatalog.getLabel(), quarterlyPublicationFolder);
+        final Publication currentPublication = importableItemsFactory.newPublication(
+            currentPublicationFolder, "content", nfoRootFolder.getLocalizedName()
+        );
 
         // D)
         final List<HippoImportableItem> domainsWithDatasets = rootCatalog.getChildCatalogs()
             .stream()
             .filter(domainCatalog -> !"NHS Outcomes Framework (NHS OF) summary dashboard and useful links".equals(domainCatalog.getLabel()))
             .flatMap(domainCatalog -> {
-                final Folder domainFolder = toFolder(domainCatalog, quarterlyPublicationFolder);
+                final Folder domainFolder = importableItemsFactory.toFolder(currentPublicationFolder, domainCatalog);
 
                 return Stream.concat(
                     Stream.of(domainFolder),
@@ -57,16 +63,14 @@ public class NhsOutcomesFrameworkImportables {
             }).collect(toList());
 
         // F)
-        final String archiveFolderName = "archive";
-        final Folder archiveFolder = newFolder(archiveFolderName, rootFolder);
-        archiveFolder.setLocalizedName("Archive");
+        final Folder archiveFolder = importableItemsFactory.newFolder(nfoRootFolder, "Archive");
 
         // G
-        final Series series = toSeries(archiveFolder, "Archive NHS Outcomes Framework Indicators");
+        final Series series = importableItemsFactory.newSeries(archiveFolder, "Archived " + nfoRootFolder.getLocalizedName());
 
-        importableItems.add(rootFolder);
-        importableItems.add(quarterlyPublicationFolder);
-        importableItems.add(quarterlyPublication);
+        importableItems.add(nfoRootFolder);
+        importableItems.add(currentPublicationFolder);
+        importableItems.add(currentPublication);
         importableItems.addAll(domainsWithDatasets);
         importableItems.add(archiveFolder);
         importableItems.add(series);
@@ -74,12 +78,12 @@ public class NhsOutcomesFrameworkImportables {
         return importableItems;
     }
 
-    private static Stream<HippoImportableItem> getImportableDatasetsFromCatalog(Catalog rootCatalog, Folder rootFolder) {
+    private Stream<HippoImportableItem> getImportableDatasetsFromCatalog(Catalog rootCatalog, Folder rootFolder) {
         List<Catalog> catalogs = rootCatalog.getChildCatalogs();
 
         if (catalogs.isEmpty()) {
             return rootCatalog.findPublishingPackages().stream().map(domainPublishingPackage ->
-                toDataSet(domainPublishingPackage, rootFolder)
+                importableItemsFactory.toDataSet(rootFolder, domainPublishingPackage)
             );
         }
 

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/SocialCareImportables.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/SocialCareImportables.java
@@ -5,18 +5,23 @@ import uk.nhs.digital.ps.migrator.model.hippo.HippoImportableItem;
 import uk.nhs.digital.ps.migrator.model.hippo.Publication;
 import uk.nhs.digital.ps.migrator.model.nesstar.Catalog;
 import uk.nhs.digital.ps.migrator.model.nesstar.CatalogStructure;
+import uk.nhs.digital.ps.migrator.task.ImportableItemsFactory;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
-import static uk.nhs.digital.ps.migrator.task.ImportableItemsFactory.*;
-import static uk.nhs.digital.ps.migrator.task.ImportableItemsFactory.toDataSet;
-import static uk.nhs.digital.ps.migrator.task.ImportableItemsFactory.toFolder;
 
 public class SocialCareImportables {
 
-    static public List<HippoImportableItem> create(final CatalogStructure catalogStructure, final Folder ciRootFolder) {
+    private final ImportableItemsFactory importableItemsFactory;
+
+    public SocialCareImportables(final ImportableItemsFactory importableItemsFactory) {
+        this.importableItemsFactory = importableItemsFactory;
+    }
+
+    public List<HippoImportableItem> create(final CatalogStructure catalogStructure, final Folder ciRootFolder) {
 
         // Target CMS structure:
         //
@@ -27,22 +32,22 @@ public class SocialCareImportables {
 
         // A)
         final Catalog rootCatalog = catalogStructure.findCatalogByLabel("Adult Social Care Outcomes Framework (ASCOF)");
-        final Folder rootFolder = toFolder(rootCatalog, ciRootFolder);
+        final Folder rootFolder = importableItemsFactory.toFolder(ciRootFolder, rootCatalog);
 
         // B)
-        final Publication publication = toPublication(rootCatalog, rootFolder);
+        final Publication publication = importableItemsFactory.toPublication(rootFolder, rootCatalog);
 
         // C)
         final List<Catalog> domainCatalogs = rootCatalog.getChildCatalogs();
         final List<HippoImportableItem> domainsWithDatasets = domainCatalogs.stream()
             .flatMap(domainCatalog -> {
-                final Folder domainFolder = toFolder(domainCatalog, rootFolder);
+                final Folder domainFolder = importableItemsFactory.toFolder(rootFolder, domainCatalog);
 
                 // D)
                 return Stream.concat(
                     Stream.of(domainFolder),
                     domainCatalog.findPublishingPackages().stream().map(domainPublishingPackage ->
-                        toDataSet(domainPublishingPackage, domainFolder)
+                        importableItemsFactory.toDataSet(domainFolder, domainPublishingPackage)
                     )
                 );
             }).collect(toList());


### PR DESCRIPTION
The Migrator application now includes in the migrated content
Compendium.

Confluence page 'Structure Mapping' contains Excel spreadsheet, whose
third sheet is used as the source of mapping. Note that while the
structure of this file is expected to not change, its content is a work
in progress and we expect to get updated version(s) of it in the near
future as CI team completes the mapping.

Also, as per the same Confluence page:

Titles of Publications and Series are now generated correctly
accross the board (not just Compendium), that is, they are now set to
the names of appropriate 'ancestor' folders (with appropriate
'Archived' prefixes, where applicable).

Folders immediately under 'root' Compendium folder are now prefixed
with 'Compendium'.