### PR TITLE
[RPS-231] Make Link Text mandatory

### DIFF
--- a/acceptance-tests/src/test/resources/features/editScreenValidation.feature
+++ b/acceptance-tests/src/test/resources/features/editScreenValidation.feature
@@ -46,8 +46,8 @@ Feature: Edit screen - validation
     Scenario: Blank Related Links field rejection
         Given I have a publication opened for editing
         When I add an empty related link field
-        And I save the publication
-        Then the save is rejected with error message containing "There is a related link field with no URL provided."
+        And I populate and save the publication
+        Then the save is rejected with error message containing "A mandatory string input field is empty"
 
 
     @DiscardAfter

--- a/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms-validators.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms-validators.yaml
@@ -12,9 +12,6 @@ definitions:
       fieldDisplayName: Information Type
       jcr:primaryType: frontend:plugin
       plugin.class: uk.nhs.digital.ps.BlankStaticDropdownSelectionFieldValidator
-    /hippo:configuration/hippo:frontend/cms/cms-validators/publicationsystem-blank-related-link:
-      jcr:primaryType: frontend:plugin
-      plugin.class: uk.nhs.digital.ps.BlankRelatedLinkFieldValidator
     /hippo:configuration/hippo:frontend/cms/cms-validators/publicationsystem-coverage-dates:
       jcr:primaryType: frontend:plugin
       plugin.class: uk.nhs.digital.ps.CoverageDatesValidator

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/cms.yaml
@@ -4,8 +4,6 @@ definitions:
     /hippo:configuration/hippo:translations/hippo:cms/validators/en:
       publicationsystem-blank-attachment: There is an attachment field without an
         attachment. Please remove it or upload a file.
-      publicationsystem-blank-related-link: There is a related link field with no
-        URL provided. Please remove it or enter a URL.
       publicationsystem-blank-staticdropdown: '{0} has a ''''Choose One'''' placeholder
         without a value. Please remove the placeholder or select a value.'
       publicationsystem-coverage-dates#dates-after-nominal: Coverage dates must not

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
@@ -317,8 +317,6 @@ definitions:
             hipposysedit:path: publicationsystem:RelatedLinks
             hipposysedit:primary: false
             hipposysedit:type: publicationsystem:relatedlink
-            hipposysedit:validators:
-            - publicationsystem-blank-related-link
             jcr:primaryType: hipposysedit:field
           /summary:
             hipposysedit:mandatory: true

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/relatedlink.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/relatedlink.yaml
@@ -51,6 +51,9 @@ definitions:
             hipposysedit:path: publicationsystem:linkText
             hipposysedit:primary: false
             hipposysedit:type: String
+            hipposysedit:validators:
+            - non-empty
+            - required
             jcr:primaryType: hipposysedit:field
           /link_url:
             hipposysedit:mandatory: false


### PR DESCRIPTION
Link text for resource links and related links will now be mandatory.
Also removed the custom validation that was only applied to resource
links as it duplicates the behaviour of the build-in validation for
required fields.