### PR TITLE
[RPS-210] Add terms and conditions

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/abstractpages/basepage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/abstractpages/basepage.yaml
@@ -2,6 +2,9 @@
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:abstractpages/basepage:
+      /footer:
+        hst:template: footer
+        jcr:primaryType: hst:component
       /top:
         hst:componentclassname: org.onehippo.cms7.essentials.components.EssentialsSearchComponent
         hst:template: search

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates.yaml
@@ -5,4 +5,7 @@ definitions:
       /facets:
         hst:renderpath: webfile:/freemarker/common/facets.ftlh
         jcr:primaryType: hst:template
+      /footer:
+        hst:renderpath: webfile:/freemarker/common/base-footer.ftlh
+        jcr:primaryType: hst:template
       jcr:primaryType: hst:templates

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/components/about.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/components/about.yaml
@@ -1,0 +1,6 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/publicationsystem/hst:components/about:
+      hst:componentclassname: uk.nhs.digital.ps.components.AboutComponent
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/pages/about.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/pages/about.yaml
@@ -1,0 +1,10 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/publicationsystem/hst:pages/about:
+      /main:
+        hst:componentclassname: uk.nhs.digital.ps.components.AboutComponent
+        hst:template: about
+        jcr:primaryType: hst:component
+      hst:referencecomponent: hst:abstractpages/basepage
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/sitemap.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/sitemap.yaml
@@ -9,11 +9,13 @@ definitions:
         - hippostd:folder
         - publicationsystem:publication
         - publicationsystem:series
+        - publicationsystem:about
         hst:componentconfigurationmappingvalues:
         - hst:pages/dataset
         - hst:pages/folder
         - hst:pages/publication
         - hst:pages/series
+        - hst:pages/about
         hst:relativecontentpath: ${1}
         jcr:primaryType: hst:sitemapitem
       /root:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/templates.yaml
@@ -2,6 +2,9 @@
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:templates:
+      /about:
+        hst:renderpath: webfile:/freemarker/publicationsystem/about.ftlh
+        jcr:primaryType: hst:template
       /dataset:
         hst:renderpath: webfile:/freemarker/publicationsystem/dataset.ftlh
         jcr:primaryType: hst:template

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem.cnd
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem.cnd
@@ -10,6 +10,9 @@
 [publicationsystem:basedocument] > hippo:document, hippostd:publishableSummary, hippostdpubwf:document
   orderable
 
+[publicationsystem:about] > hippostd:relaxed, hippotranslation:translated, publicationsystem:basedocument
+  orderable
+
 [publicationsystem:dataset] > hippostd:relaxed, hippotranslation:translated, publicationsystem:basedocument
   orderable
 
@@ -23,4 +26,3 @@
 
 [publicationsystem:series] > hippostd:relaxed, hippotranslation:translated, publicationsystem:basedocument
   orderable
-

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/about.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/about.yaml
@@ -1,0 +1,95 @@
+---
+definitions:
+  config:
+    /hippo:namespaces/publicationsystem/about:
+      /editor:templates:
+        /_default_:
+          jcr:primaryType: frontend:plugincluster
+          frontend:properties:
+          - mode
+          frontend:references:
+          - wicket.model
+          - model.compareTo
+          - engine
+          - validator.id
+          frontend:services:
+          - wicket.id
+          - validator.id
+          /root:
+            item: ${cluster.id}.field
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+          /Title:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Title
+            field: Title
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /Content:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Content
+            field: Content
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.field
+        jcr:primaryType: editor:templateset
+      /hipposysedit:nodetype:
+        /hipposysedit:nodetype:
+          /Content:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:Content
+            hipposysedit:primary: false
+            hipposysedit:type: hippostd:html
+            jcr:primaryType: hipposysedit:field
+          /Title:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:Title
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            hipposysedit:validators:
+            - non-empty
+            - required
+            jcr:primaryType: hipposysedit:field
+          hipposysedit:node: true
+          hipposysedit:supertype:
+          - publicationsystem:basedocument
+          - hippostd:relaxed
+          - hippotranslation:translated
+          hipposysedit:uri: http://digital.nhs.uk/jcr/publicationsystem/nt/1.0
+          jcr:mixinTypes:
+          - mix:referenceable
+          - hipposysedit:remodel
+          jcr:primaryType: hipposysedit:nodetype
+        jcr:mixinTypes:
+        - mix:referenceable
+        jcr:primaryType: hippo:handle
+      /hipposysedit:prototypes:
+        /hipposysedit:prototype:
+          /publicationsystem:Content:
+            hippostd:content: ''
+            jcr:primaryType: hippostd:html
+          hippostd:holder: holder
+          hippostd:state: draft
+          hippostdpubwf:createdBy: ''
+          hippostdpubwf:creationDate: 2017-12-22T14:56:10.307Z
+          hippostdpubwf:lastModificationDate: 2017-12-22T14:56:10.307Z
+          hippostdpubwf:lastModifiedBy: ''
+          hippotranslation:id: document-type-locale-id
+          hippotranslation:locale: document-type-locale
+          jcr:mixinTypes:
+          - mix:referenceable
+          jcr:primaryType: publicationsystem:about
+          publicationsystem:Title: ''
+        jcr:primaryType: hipposysedit:prototypeset
+      jcr:mixinTypes:
+      - editor:editable
+      - mix:referenceable
+      jcr:primaryType: hipposysedit:templatetype

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/about.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/about.yaml
@@ -1,0 +1,13 @@
+---
+/content/documents/corporate-website/publication-system/about:
+  hippo:name: About
+  hippostd:foldertype:
+  - new-translated-folder
+  - new-document
+  hippotranslation:id: 00000000-0000-0000-0000-000000000000
+  hippotranslation:locale: en
+  jcr:mixinTypes:
+  - hippo:named
+  - hippotranslation:translated
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/about/terms-and-conditions.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/about/terms-and-conditions.yaml
@@ -1,0 +1,57 @@
+---
+/content/documents/corporate-website/publication-system/about/terms-and-conditions:
+  /terms-and-conditions[1]:
+    /publicationsystem:Content:
+      hippostd:content: ''
+      jcr:primaryType: hippostd:html
+    hippo:availability: []
+    hippostd:state: draft
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2017-12-22T15:05:58.519Z
+    hippostdpubwf:lastModificationDate: 2017-12-22T15:06:57.069Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: f2ec2ee1-308c-4270-a070-b97334bf5543
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:about
+    publicationsystem:Title: Terms and Conditions
+  /terms-and-conditions[2]:
+    /publicationsystem:Content:
+      hippostd:content: ''
+      jcr:primaryType: hippostd:html
+    hippo:availability:
+    - preview
+    hippostd:state: unpublished
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2017-12-22T15:05:58.519Z
+    hippostdpubwf:lastModificationDate: 2017-12-22T15:07:01.668Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: f2ec2ee1-308c-4270-a070-b97334bf5543
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:about
+    publicationsystem:Title: Terms and Conditions
+  /terms-and-conditions[3]:
+    /publicationsystem:Content:
+      hippostd:content: ''
+      jcr:primaryType: hippostd:html
+    hippo:availability:
+    - live
+    hippostd:state: published
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2017-12-22T15:05:58.519Z
+    hippostdpubwf:lastModificationDate: 2017-12-22T15:07:01.668Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippostdpubwf:publicationDate: 2017-12-22T15:07:05.033Z
+    hippotranslation:id: f2ec2ee1-308c-4270-a070-b97334bf5543
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:about
+    publicationsystem:Title: Terms and Conditions
+  jcr:mixinTypes:
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-actions.yaml
+++ b/repository-data/development/src/main/resources/hcm-actions.yaml
@@ -2,3 +2,4 @@
 action-lists:
 - 1.1:
     /content/taxonomies/publication_taxonomy: reload
+    /content/documents/corporate-website/publication-system/about/terms-and-conditions: reload

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/about/terms-and-conditions.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/about/terms-and-conditions.yaml
@@ -1,0 +1,1167 @@
+---
+/content/documents/corporate-website/publication-system/about/terms-and-conditions:
+  /terms-and-conditions[1]:
+    /publicationsystem:Content:
+      hippostd:content: |-
+        <p><strong>1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>About these terms</strong></p>
+
+        <p>1.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Please read these terms and conditions carefully before you start to use this website (being&nbsp;<a rel="nofollow" href="https://digital.nhs.uk/">https://digital.nhs.uk/</a>&nbsp;and all sections and pages). You may access and use this website if you agree to be legally bound by these terms and conditions set out here. If you do not agree to be legally bound by these terms and conditions please do not access and/or use this website.</p>
+
+        <p>&nbsp;</p>
+
+        <p>1.2&nbsp; Where indicated, additional terms and conditions apply to specific sections (for example&nbsp;<a rel="nofollow" href="http://www.content.digital.nhs.uk/">http://www.content.digital.nhs.uk/</a>).</p>
+
+        <p>&nbsp;</p>
+
+        <p>1.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; References in these terms and conditions to “NHS Digital”, “we”, “our” and “us” are references to the Health and Social Care Information Centre, a non-departmental public body established under primary legislation and known as NHS Digital. The entire contents of this website, and the individual articles, items, media files and assets published are owned by NHS Digital, unless otherwise indicated.</p>
+
+        <p>&nbsp;</p>
+
+        <p>1.4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; This website is intended for use only by people who live in the United Kingdom. References to ‘the NHS’ mean ‘the NHS in England’ unless otherwise stated. Services and arrangements may differ elsewhere in the UK.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>1.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; If you have any queries in respect of your use of this website please contact us at:&nbsp;<a rel="nofollow" href="mailto:enquiries@nhsdigital.nhs.uk">enquiries@nhsdigital.nhs.uk</a>&nbsp;or</p>
+
+        <p>NHS Digital<br />
+        1 Trevelyan Square<br />
+        Boar Lane<br />
+        Leeds<br />
+        West Yorkshire<br />
+        LS1 6AE</p>
+
+        <p>1.6&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; We may make changes to these terms and conditions, the terms and conditions applicable to any specific sub-site, the privacy and cookies policy and any other policies applicable to your use of this website, at any time. Your continuing use of this website constitutes your acceptance of and agreement to any such changed terms and conditions and policies.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>1.7&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; To the extent that we are practically able to do so, we may terminate your access to any part of this website at any time without notice if you breach any of these terms and conditions.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Accessibility and browsers</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>2.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital aims to make this website and the material provided accessible to as many people as possible. This website is designed to work with the latest versions of Microsoft Edge, Google Chrome and Apple Safari, and uses standards which should work on the majority of browsers in use.&nbsp; We offer no warranty for this website working in any particular browser or configuration. Please note that you may see inconsistencies in the presentation of pages if you are using an older or deprecated version of a browser.&nbsp;Read further information on&nbsp;<a rel="nofollow" href="https://digital.nhs.uk/article/773/Accessibility-help">the accessibility of this website</a>.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Information about you and your visits to this website</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>3.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital processes information about you in accordance with our&nbsp;<a rel="nofollow" href="https://digital.nhs.uk/article/236/Privacy-and-cookies">privacy and cookies policy</a><a rel="nofollow" href="file:///C:/Users/owda1/AppData/Local/Microsoft/Windows/Temporary%20Internet%20Files/Content.Outlook/3XQDEC15/NHSD%20website%20terms%20and%20conditions.%20v.3.2%20(5%20Oct)%20clean%20(2).docx#_msocom_1">[LM1]</a>&nbsp;.&nbsp;By using this website, you consent to such processing and you warrant that all data provided by you is accurate.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Freedom of Information</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>4.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The data rights and responsibilities of NHS Digital, its staff and of patients is governed by the Freedom of Information Act 2000 and the Data Protection Act 1998. For policy and other information see&nbsp;<a rel="nofollow" href="https://digital.nhs.uk/article/253/Freedom-of-Information">Freedom of Information.</a></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Registering to use this website</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>5.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; In order to access certain content, systems or interactive features on this website you may be asked to choose, or be provided with, a password or other log in details to access parts of this website. As a minimum, passwords you set for use with this website must have a level of complexity which ensures they cannot be easily guessed by hackers or malicious software.&nbsp; They should:</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>be at least twelve characters long;</li>
+         <li>not contain your user name, real name, or organisation name;</li>
+         <li>not appear in the&nbsp;<a rel="nofollow" href="http://www.passwordrandom.com/most-popular-passwords">list of top 10,000 passwords</a>;</li>
+         <li>not use sequential key characters on the keyboard (e.g. qwerty, asdfg, 12345)</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <p>5.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; In line with&nbsp;<a rel="nofollow" href="https://www.ncsc.gov.uk/blog-post/three-random-words-or-thinkrandom-0">Government best practice</a>, we recommend using the ‘three random words’ approach, which uses three or more randomly chosen words like ‘saloonbadgertree’ or ‘coffeetrainfish’.&nbsp; These words should be random, and not related personally to you (so not involving a favourite thing, holiday, relative). Passwords must not under any circumstances be shared with anyone.&nbsp; &nbsp;</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>5.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; You may terminate your account registration using the relevant link in your account pages. This will clear any personal information you have saved. Subscriptions to our emails can be terminated using the ‘Unsubscribe’ links provided in the emails. &nbsp;</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>6&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Prohibited Uses of this Website</strong></p>
+
+        <p>&nbsp;</p>
+
+        <p>6.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; You may use this website only for lawful purposes. You may not use this website:</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>in any way that breaches any applicable local, national or international law or regulation;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>in any way that is unlawful, fraudulent or harmful to other users, or has any unlawful, fraudulent or harmful purpose or effect;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>to send, knowingly receive, upload, download, use or re-use any material which does not comply with these terms and conditions;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>to transmit, or produce the sending of, any unsolicited or unauthorised advertising or promotional material or any other form of similar solicitation (spam); and</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>to knowingly transmit any data, send or upload any material that contains viruses, Trojan horses, worms, spyware or any other harmful programs or similar computer code designed to adversely affect the operation of any computer software or hardware.</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <p>6.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; You also agree not to access without authority, interfere with, damage or disrupt any part of this website; any equipment or network on which this website is stored; any software used in the provision of this website; or any equipment or network or software owned or used by any third-party.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>7&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Material on this website</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>7.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The material on this website includes information, data, text, images, videos, Information Standards, interactive services, link to products and apps and other works (“<strong>NHS Digital Content</strong>”).&nbsp; You acknowledge that all rights in copyright, patents, design rights, trade marks and other intellectual property rights (whether registered, capable of registration or otherwise) throughout the world, in this website and all NHS Digital Content are owned by, or licensed to NHS Digital, unless otherwise indicated. Some NHS Digital Content includes identifiable third-party content for which we will have sought permission for its inclusion.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>7.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Except for your use of this website in accordance with these terms and conditions, you are granted no rights in respect of this website or any NHS Digital Content.</p>
+
+        <p>&nbsp;</p>
+
+        <p>7.3&nbsp; The Information Standards are published by us and apply to organisations in the health and social care sector.&nbsp; They relate to the processing of information such that data can be shared, compared and understood across the sector, and used for planning, monitoring and good patient care. For further details please see&nbsp;<a rel="nofollow" href="https://digital.nhs.uk/information-standards">https://digital.nhs.uk/information-standards</a>. The Data Co-ordination Board (DCB) assures the quality of information standards.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>8&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Your use of the NHS Digital Content</strong></p>
+
+        <p>&nbsp;</p>
+
+        <p>8.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Copyright and database rights in the NHS Digital Content are released free-of-charge under the current version of the&nbsp;<a rel="nofollow" href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence</a>&nbsp;(“<strong>OGL</strong>”), except where specified, either in these terms and conditions, elsewhere on this website or in the OGL terms.&nbsp; This licence does not extend to any other intellectual property rights, including but not limited to patents, design rights and trade marks. If there is any conflict between the OGL terms and these terms and conditions these terms and conditions shall take precedence.&nbsp;</p>
+
+        <p>&nbsp;</p>
+
+        <p>8.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; This means that you can use NHS Digital Content, including copying it, adapting it, and using it for any purpose, including commercially, provided you follow these terms and conditions and the terms of the OGL.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>8.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The OGL terms do not apply to the following categories of NHS Digital Content, and therefore these must not be used without our or the relevant owner’s prior consent:</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>any logos, visuals, image rights, trademarks, trade names and design styles (except where these are integral to a document or data set) of NHS Digital, or any predecessor or linked body, as well as of any partner or contributor;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>the Information Standards.&nbsp; NHS Digital permits the copying and re-use of Information Standards, in whole or in part, for commercial and non-commercial purposes but, to protect the integrity of the Information Standards, you are not permitted to adapt, amend or decompile the Information Standards for any purpose without our prior consent;<a rel="nofollow" href="file:///C:/Users/owda1/AppData/Local/Microsoft/Windows/Temporary%20Internet%20Files/Content.Outlook/3XQDEC15/NHSD%20website%20terms%20and%20conditions.%20v.3.2%20(5%20Oct)%20clean%20(2).docx#_msocom_2">[LM2]</a>&nbsp;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>software, source code and any technical documentation relating to software or source code except where released on&nbsp;<a rel="nofollow" href="https://developer.nhs.uk/">https://developer.nhs.uk/</a>, a public repository on GitHub, or any other platform we may specify from time-to-time;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>information owned by third parties which we are not authorised to licence on to you.&nbsp; This information will be clearly marked.&nbsp; If in doubt, contact us using the details above;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>information gained through any services or sections on this website (or linked websites) which can only be accessed by logged-in users; and</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>any information which is marked as being under a different licence, or not for release.</li>
+        </ul>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>8.4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; If you do use any NHS Digital Content you must attribute it with the following statement:</p>
+
+        <p>“<strong>Information from NHS Digital, licenced under the current version of the Open Government Licence</strong>”.</p>
+
+        <ul>
+         <li>or in cases where the NHS Digital Content is combined, adapted, or otherwise modified in line with these terms and conditions:</li>
+        </ul>
+
+        <p>“<strong>Contains information from NHS Digital, licenced under the current version of the Open Government Licence</strong>”.</p>
+
+        <p>8.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; By using any NHS Digital Content you accept and agree to the following terms:</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>you must not alter, adapt, edit or modify any NHS Digital branding where this is integral to a document or data set;</li>
+        </ul>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>if you do alter, adapt, edit or modify any NHS Digital Content in accordance with<strong>&nbsp;</strong>these terms and conditions, where possible, you should remove the NHS Digital branding;</li>
+        </ul>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>you may not directly or indirectly suggest any endorsement or approval by NHS Digital of your site or any non-NHS Digital entity, product or content or any views expressed within your site or service;</li>
+        </ul>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>NHS Digital has absolute editorial control over all NHS Digital Content and reserves the right to alter, adapt, edit, modify or restrict the availability of NHS Digital Content without prior notice; and</li>
+        </ul>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>you should refresh cached content every 24 hours to ensure you have the most up-to-date version.</li>
+        </ul>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>9&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Uploading material to this website</strong></p>
+
+        <p>&nbsp;</p>
+
+        <p>9.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Whenever you make use of a feature that allows you to upload material to this website, for example when you participate in online discussions, contact other users of this website or submit any apps or products, you must comply with the standards set out in the comments and moderation policy<a rel="nofollow" href="file:///C:/Users/owda1/AppData/Local/Microsoft/Windows/Temporary%20Internet%20Files/Content.Outlook/3XQDEC15/NHSD%20website%20terms%20and%20conditions.%20v.3.2%20(5%20Oct)%20clean%20(2).docx#_msocom_3">[LM3]</a>&nbsp;. You warrant that any such contribution does comply with those standards, and you indemnify us for any breach of that warranty.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>9.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Any material you upload to this website will be considered non-confidential and non-proprietary, and NHS Digital has the right to use, copy, distribute and disclose to third-parties any such material for any purpose. Furthermore NHS Digital also has the right to disclose your identity to any third-party who is claiming that any material posted or uploaded by you to this website constitutes a violation of their intellectual property rights, or their right to privacy.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>9.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital will not be responsible, or liable to any third-party, for the content or accuracy of any materials posted by your or any other user of this website.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>9.4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital has the right to remove any material or posting you make on this website if, in our opinion, such material does not comply with the standards set out in these terms and conditions and the comments and moderation policy<a rel="nofollow" href="file:///C:/Users/owda1/AppData/Local/Microsoft/Windows/Temporary%20Internet%20Files/Content.Outlook/3XQDEC15/NHSD%20website%20terms%20and%20conditions.%20v.3.2%20(5%20Oct)%20clean%20(2).docx#_msocom_4">[LM4]</a>&nbsp;.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>9.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Comments posted should relate to your personal experience or that of someone close to you. You should not name any individuals (other than yourself) or include information through which someone else could identify an individual about whom you are writing. If you want to comment on someone else’s experience, (e.g. a relative or someone you care for) then you may do so if you ensure that you are not named in the posting and you state how the other person is connected to you (e.g. “my father”). You warrant that all statements of fact in any comment you submit are true, and that any expression of opinion is your honestly held opinion on those facts, or that of the person on whose behalf you are writing.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>9.6&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; If you find any comments offensive or objectionable you may make a complaint to the moderator using the ‘Report’ link provided at the foot of each published comment.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>9.7&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; We have many measures in place to keep your information safe. But it is important that you also play your part&nbsp;– visit&nbsp;the Government's&nbsp;<a rel="nofollow" href="https://www.getsafeonline.org/">Get Safe Online</a>website for advice on how to do this.&nbsp;&nbsp;</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>10&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Social media, bookmarking and digital engagement</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>10.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital may from time to time provide third party or owned social media and interactive services on this website or linked to this website, currently this includes and is not limited to:</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>Youtube – for sharing video content;</li>
+         <li>Twitter – for sharing news and participating in conversations with users;</li>
+         <li>Blogs –&nbsp; to share the opinions of NHS Digital’s staff and other key figures;</li>
+         <li>Discussion Forums – for participation in conversations with users;</li>
+         <li>RSS feeds – for sharing news;</li>
+         <li>Social bookmarking – to allow users to share our content more easily on popular social media platforms.</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <p>10.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital is under no obligation to oversee, monitor or moderate any interactive services we provide from this website, and we expressly exclude our liability for any loss or damage arising from the use of these interactive services by a user in contravention of these terms and conditions, whether the service is moderated or not.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>10.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Our RSS feeds can be used as part of your website; however, we do require that proper format and attribution are used. The attribution text should read “<strong>NHS Digital</strong><strong>&nbsp;</strong><strong>RSS feeds</strong>”. We reserve the right from time to time to restrict the distribution of NHS Digital RSS feed content and do not accept any liability for these feeds.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>10.4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Use of our social bookmarking links is subject to these terms and conditions, see ‘Linking from this website’ below.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>10.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Although we do monitor and review discussions, chat, postings, transmissions, bulletin boards and the like on this website and its subsections, we are under no obligation to do so and assume no responsibility or liability arising from the content of any such locations nor for any error, omission, infringement, defamation, obscenity, or inaccuracy contained in any information within such locations on this website.</p>
+
+        <p>&nbsp;</p>
+
+        <p>10.6&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The use of any of the interactive features on this website by a minor is subject to the consent of their parent or guardian, and we advise parents to communicate with their children about their safety online, as moderation is not foolproof. Minors who are using any interactive service should be made aware of the potential risks to them. Where we do moderate any of the interactive features on this website, we will normally provide you with a means of contacting the moderator, should a concern or difficulty arise.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>11&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Linking to this website</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>11.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; We do not object to you linking directly to pages on this website.&nbsp;We reserve the right to move or change this website’s URLs at any time. Rather than deep linking we recommend linking to section homepages, which are less likely to move or change.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>11.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; However, we don’t give permission to suggest that your website is associated, or endorsed by us.</p>
+
+        <h3>&nbsp;</h3>
+
+        <p><strong>12&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Linking from this website</strong></p>
+
+        <p>&nbsp;</p>
+
+        <p>12.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; We are not responsible for the content or reliability of the websites we link to and do not necessarily endorse the views expressed within them.&nbsp;We aim to replace broken links to other sites but cannot guarantee that these links will always work as we have no control over the availability of other sites.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>12.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Due to the very nature of the internet we cannot guarantee this website or other websites we link to will always be available to you.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>13&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Disclaimer and Liabilities</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>13.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; This website, all NHS Digital Content and all material relating to Government information, products and services (or to third-party information, products and services), is provided ‘as is’, without any endorsement and without warranty of any kind whether express or implied, including but not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility, security and accuracy.&nbsp; This means that whilst we do try to ensure that all our information is correct, we are not liable for any errors or omissions, and cannot be responsible for any impact these have on you.&nbsp;</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>13.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; If the need arises, we reserve the right to amend, delete, suspend or withdraw all or any part of this website without notice. NHS Digital will not be liable if for any reason this website or any parts are unavailable at any time.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>13.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; We do not warrant that the functions of this website will be uninterrupted or error free, that defects will be corrected, or that this website or the server that makes it available will be free of viruses or represent the full functionality, accuracy or reliability of the materials. You should use your own virus protection software.</p>
+
+        <p>&nbsp;</p>
+
+        <p>13.4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital and any approving bodies are not the owners, managers or suppliers of various products which can be accessed from this website. NHS Digital or the approving body sets standards for reviewing the products, but this does not mean that NHS Digital or the approving body has itself reviewed all aspects of each product, or version of the same product.&nbsp;NHS Digital or the approving body is not responsible or liable for any advice, or any other information, services or products that you obtain using any such products.</p>
+
+        <p>&nbsp;</p>
+
+        <p>13.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Material on this website is provided for information and educational purposes only and we do not guarantee that information we provide will meet your health or medical requirements. NHS Digital does not give medical advice in relation to any individual case or patient, nor does NHS Digital provide medical or diagnostic services. For less urgent health needs, contact your GP or local pharmacist in the usual way. If you have an urgent medical need you should call 111. If a life is at risk, call 999.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>13.6&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; In no event will we be liable for any loss or damage including, without limitation, indirect or consequential loss or damage, or any loss or damages whatsoever arising from use or loss of use of, data or profits arising out of or in connection with the use of this website. Nothing in these terms and conditions will operate to limit or exclude liability for death or personal injury arising from our negligence, nor our liability for fraudulent misrepresentation, nor any other liability which cannot be excluded or limited under applicable law.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>14&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>General</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>14.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; If any of these terms and conditions are determined to be illegal, invalid or otherwise unenforceable then the remaining terms and conditions shall remain in full force and effect.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>14.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The laws of England shall apply exclusively to these terms and conditions and to all matters relating to use of this website. Any cause of action arising under these terms and conditions or the use of this website shall be subject to the exclusive jurisdiction of the courts of England and Wales.</p>
+      jcr:primaryType: hippostd:html
+    hippo:availability: []
+    hippostd:state: draft
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2017-12-22T15:05:58.519Z
+    hippostdpubwf:lastModificationDate: 2017-12-22T15:06:57.069Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: f2ec2ee1-308c-4270-a070-b97334bf5543
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:about
+    publicationsystem:Title: Terms and Conditions
+  /terms-and-conditions[2]:
+    /publicationsystem:Content:
+      hippostd:content: |-
+        <p><strong>1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>About these terms</strong></p>
+
+        <p>1.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Please read these terms and conditions carefully before you start to use this website (being&nbsp;<a rel="nofollow" href="https://digital.nhs.uk/">https://digital.nhs.uk/</a>&nbsp;and all sections and pages). You may access and use this website if you agree to be legally bound by these terms and conditions set out here. If you do not agree to be legally bound by these terms and conditions please do not access and/or use this website.</p>
+
+        <p>&nbsp;</p>
+
+        <p>1.2&nbsp; Where indicated, additional terms and conditions apply to specific sections (for example&nbsp;<a rel="nofollow" href="http://www.content.digital.nhs.uk/">http://www.content.digital.nhs.uk/</a>).</p>
+
+        <p>&nbsp;</p>
+
+        <p>1.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; References in these terms and conditions to “NHS Digital”, “we”, “our” and “us” are references to the Health and Social Care Information Centre, a non-departmental public body established under primary legislation and known as NHS Digital. The entire contents of this website, and the individual articles, items, media files and assets published are owned by NHS Digital, unless otherwise indicated.</p>
+
+        <p>&nbsp;</p>
+
+        <p>1.4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; This website is intended for use only by people who live in the United Kingdom. References to ‘the NHS’ mean ‘the NHS in England’ unless otherwise stated. Services and arrangements may differ elsewhere in the UK.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>1.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; If you have any queries in respect of your use of this website please contact us at:&nbsp;<a rel="nofollow" href="mailto:enquiries@nhsdigital.nhs.uk">enquiries@nhsdigital.nhs.uk</a>&nbsp;or</p>
+
+        <p>NHS Digital<br />
+        1 Trevelyan Square<br />
+        Boar Lane<br />
+        Leeds<br />
+        West Yorkshire<br />
+        LS1 6AE</p>
+
+        <p>1.6&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; We may make changes to these terms and conditions, the terms and conditions applicable to any specific sub-site, the privacy and cookies policy and any other policies applicable to your use of this website, at any time. Your continuing use of this website constitutes your acceptance of and agreement to any such changed terms and conditions and policies.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>1.7&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; To the extent that we are practically able to do so, we may terminate your access to any part of this website at any time without notice if you breach any of these terms and conditions.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Accessibility and browsers</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>2.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital aims to make this website and the material provided accessible to as many people as possible. This website is designed to work with the latest versions of Microsoft Edge, Google Chrome and Apple Safari, and uses standards which should work on the majority of browsers in use.&nbsp; We offer no warranty for this website working in any particular browser or configuration. Please note that you may see inconsistencies in the presentation of pages if you are using an older or deprecated version of a browser.&nbsp;Read further information on&nbsp;<a rel="nofollow" href="https://digital.nhs.uk/article/773/Accessibility-help">the accessibility of this website</a>.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Information about you and your visits to this website</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>3.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital processes information about you in accordance with our&nbsp;<a rel="nofollow" href="https://digital.nhs.uk/article/236/Privacy-and-cookies">privacy and cookies policy</a><a rel="nofollow" href="file:///C:/Users/owda1/AppData/Local/Microsoft/Windows/Temporary%20Internet%20Files/Content.Outlook/3XQDEC15/NHSD%20website%20terms%20and%20conditions.%20v.3.2%20(5%20Oct)%20clean%20(2).docx#_msocom_1">[LM1]</a>&nbsp;.&nbsp;By using this website, you consent to such processing and you warrant that all data provided by you is accurate.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Freedom of Information</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>4.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The data rights and responsibilities of NHS Digital, its staff and of patients is governed by the Freedom of Information Act 2000 and the Data Protection Act 1998. For policy and other information see&nbsp;<a rel="nofollow" href="https://digital.nhs.uk/article/253/Freedom-of-Information">Freedom of Information.</a></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Registering to use this website</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>5.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; In order to access certain content, systems or interactive features on this website you may be asked to choose, or be provided with, a password or other log in details to access parts of this website. As a minimum, passwords you set for use with this website must have a level of complexity which ensures they cannot be easily guessed by hackers or malicious software.&nbsp; They should:</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>be at least twelve characters long;</li>
+         <li>not contain your user name, real name, or organisation name;</li>
+         <li>not appear in the&nbsp;<a rel="nofollow" href="http://www.passwordrandom.com/most-popular-passwords">list of top 10,000 passwords</a>;</li>
+         <li>not use sequential key characters on the keyboard (e.g. qwerty, asdfg, 12345)</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <p>5.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; In line with&nbsp;<a rel="nofollow" href="https://www.ncsc.gov.uk/blog-post/three-random-words-or-thinkrandom-0">Government best practice</a>, we recommend using the ‘three random words’ approach, which uses three or more randomly chosen words like ‘saloonbadgertree’ or ‘coffeetrainfish’.&nbsp; These words should be random, and not related personally to you (so not involving a favourite thing, holiday, relative). Passwords must not under any circumstances be shared with anyone.&nbsp; &nbsp;</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>5.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; You may terminate your account registration using the relevant link in your account pages. This will clear any personal information you have saved. Subscriptions to our emails can be terminated using the ‘Unsubscribe’ links provided in the emails. &nbsp;</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>6&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Prohibited Uses of this Website</strong></p>
+
+        <p>&nbsp;</p>
+
+        <p>6.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; You may use this website only for lawful purposes. You may not use this website:</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>in any way that breaches any applicable local, national or international law or regulation;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>in any way that is unlawful, fraudulent or harmful to other users, or has any unlawful, fraudulent or harmful purpose or effect;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>to send, knowingly receive, upload, download, use or re-use any material which does not comply with these terms and conditions;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>to transmit, or produce the sending of, any unsolicited or unauthorised advertising or promotional material or any other form of similar solicitation (spam); and</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>to knowingly transmit any data, send or upload any material that contains viruses, Trojan horses, worms, spyware or any other harmful programs or similar computer code designed to adversely affect the operation of any computer software or hardware.</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <p>6.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; You also agree not to access without authority, interfere with, damage or disrupt any part of this website; any equipment or network on which this website is stored; any software used in the provision of this website; or any equipment or network or software owned or used by any third-party.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>7&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Material on this website</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>7.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The material on this website includes information, data, text, images, videos, Information Standards, interactive services, link to products and apps and other works (“<strong>NHS Digital Content</strong>”).&nbsp; You acknowledge that all rights in copyright, patents, design rights, trade marks and other intellectual property rights (whether registered, capable of registration or otherwise) throughout the world, in this website and all NHS Digital Content are owned by, or licensed to NHS Digital, unless otherwise indicated. Some NHS Digital Content includes identifiable third-party content for which we will have sought permission for its inclusion.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>7.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Except for your use of this website in accordance with these terms and conditions, you are granted no rights in respect of this website or any NHS Digital Content.</p>
+
+        <p>&nbsp;</p>
+
+        <p>7.3&nbsp; The Information Standards are published by us and apply to organisations in the health and social care sector.&nbsp; They relate to the processing of information such that data can be shared, compared and understood across the sector, and used for planning, monitoring and good patient care. For further details please see&nbsp;<a rel="nofollow" href="https://digital.nhs.uk/information-standards">https://digital.nhs.uk/information-standards</a>. The Data Co-ordination Board (DCB) assures the quality of information standards.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>8&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Your use of the NHS Digital Content</strong></p>
+
+        <p>&nbsp;</p>
+
+        <p>8.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Copyright and database rights in the NHS Digital Content are released free-of-charge under the current version of the&nbsp;<a rel="nofollow" href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence</a>&nbsp;(“<strong>OGL</strong>”), except where specified, either in these terms and conditions, elsewhere on this website or in the OGL terms.&nbsp; This licence does not extend to any other intellectual property rights, including but not limited to patents, design rights and trade marks. If there is any conflict between the OGL terms and these terms and conditions these terms and conditions shall take precedence.&nbsp;</p>
+
+        <p>&nbsp;</p>
+
+        <p>8.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; This means that you can use NHS Digital Content, including copying it, adapting it, and using it for any purpose, including commercially, provided you follow these terms and conditions and the terms of the OGL.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>8.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The OGL terms do not apply to the following categories of NHS Digital Content, and therefore these must not be used without our or the relevant owner’s prior consent:</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>any logos, visuals, image rights, trademarks, trade names and design styles (except where these are integral to a document or data set) of NHS Digital, or any predecessor or linked body, as well as of any partner or contributor;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>the Information Standards.&nbsp; NHS Digital permits the copying and re-use of Information Standards, in whole or in part, for commercial and non-commercial purposes but, to protect the integrity of the Information Standards, you are not permitted to adapt, amend or decompile the Information Standards for any purpose without our prior consent;<a rel="nofollow" href="file:///C:/Users/owda1/AppData/Local/Microsoft/Windows/Temporary%20Internet%20Files/Content.Outlook/3XQDEC15/NHSD%20website%20terms%20and%20conditions.%20v.3.2%20(5%20Oct)%20clean%20(2).docx#_msocom_2">[LM2]</a>&nbsp;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>software, source code and any technical documentation relating to software or source code except where released on&nbsp;<a rel="nofollow" href="https://developer.nhs.uk/">https://developer.nhs.uk/</a>, a public repository on GitHub, or any other platform we may specify from time-to-time;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>information owned by third parties which we are not authorised to licence on to you.&nbsp; This information will be clearly marked.&nbsp; If in doubt, contact us using the details above;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>information gained through any services or sections on this website (or linked websites) which can only be accessed by logged-in users; and</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>any information which is marked as being under a different licence, or not for release.</li>
+        </ul>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>8.4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; If you do use any NHS Digital Content you must attribute it with the following statement:</p>
+
+        <p>“<strong>Information from NHS Digital, licenced under the current version of the Open Government Licence</strong>”.</p>
+
+        <ul>
+         <li>or in cases where the NHS Digital Content is combined, adapted, or otherwise modified in line with these terms and conditions:</li>
+        </ul>
+
+        <p>“<strong>Contains information from NHS Digital, licenced under the current version of the Open Government Licence</strong>”.</p>
+
+        <p>8.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; By using any NHS Digital Content you accept and agree to the following terms:</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>you must not alter, adapt, edit or modify any NHS Digital branding where this is integral to a document or data set;</li>
+        </ul>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>if you do alter, adapt, edit or modify any NHS Digital Content in accordance with<strong>&nbsp;</strong>these terms and conditions, where possible, you should remove the NHS Digital branding;</li>
+        </ul>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>you may not directly or indirectly suggest any endorsement or approval by NHS Digital of your site or any non-NHS Digital entity, product or content or any views expressed within your site or service;</li>
+        </ul>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>NHS Digital has absolute editorial control over all NHS Digital Content and reserves the right to alter, adapt, edit, modify or restrict the availability of NHS Digital Content without prior notice; and</li>
+        </ul>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>you should refresh cached content every 24 hours to ensure you have the most up-to-date version.</li>
+        </ul>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>9&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Uploading material to this website</strong></p>
+
+        <p>&nbsp;</p>
+
+        <p>9.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Whenever you make use of a feature that allows you to upload material to this website, for example when you participate in online discussions, contact other users of this website or submit any apps or products, you must comply with the standards set out in the comments and moderation policy<a rel="nofollow" href="file:///C:/Users/owda1/AppData/Local/Microsoft/Windows/Temporary%20Internet%20Files/Content.Outlook/3XQDEC15/NHSD%20website%20terms%20and%20conditions.%20v.3.2%20(5%20Oct)%20clean%20(2).docx#_msocom_3">[LM3]</a>&nbsp;. You warrant that any such contribution does comply with those standards, and you indemnify us for any breach of that warranty.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>9.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Any material you upload to this website will be considered non-confidential and non-proprietary, and NHS Digital has the right to use, copy, distribute and disclose to third-parties any such material for any purpose. Furthermore NHS Digital also has the right to disclose your identity to any third-party who is claiming that any material posted or uploaded by you to this website constitutes a violation of their intellectual property rights, or their right to privacy.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>9.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital will not be responsible, or liable to any third-party, for the content or accuracy of any materials posted by your or any other user of this website.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>9.4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital has the right to remove any material or posting you make on this website if, in our opinion, such material does not comply with the standards set out in these terms and conditions and the comments and moderation policy<a rel="nofollow" href="file:///C:/Users/owda1/AppData/Local/Microsoft/Windows/Temporary%20Internet%20Files/Content.Outlook/3XQDEC15/NHSD%20website%20terms%20and%20conditions.%20v.3.2%20(5%20Oct)%20clean%20(2).docx#_msocom_4">[LM4]</a>&nbsp;.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>9.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Comments posted should relate to your personal experience or that of someone close to you. You should not name any individuals (other than yourself) or include information through which someone else could identify an individual about whom you are writing. If you want to comment on someone else’s experience, (e.g. a relative or someone you care for) then you may do so if you ensure that you are not named in the posting and you state how the other person is connected to you (e.g. “my father”). You warrant that all statements of fact in any comment you submit are true, and that any expression of opinion is your honestly held opinion on those facts, or that of the person on whose behalf you are writing.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>9.6&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; If you find any comments offensive or objectionable you may make a complaint to the moderator using the ‘Report’ link provided at the foot of each published comment.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>9.7&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; We have many measures in place to keep your information safe. But it is important that you also play your part&nbsp;– visit&nbsp;the Government's&nbsp;<a rel="nofollow" href="https://www.getsafeonline.org/">Get Safe Online</a>website for advice on how to do this.&nbsp;&nbsp;</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>10&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Social media, bookmarking and digital engagement</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>10.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital may from time to time provide third party or owned social media and interactive services on this website or linked to this website, currently this includes and is not limited to:</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>Youtube – for sharing video content;</li>
+         <li>Twitter – for sharing news and participating in conversations with users;</li>
+         <li>Blogs –&nbsp; to share the opinions of NHS Digital’s staff and other key figures;</li>
+         <li>Discussion Forums – for participation in conversations with users;</li>
+         <li>RSS feeds – for sharing news;</li>
+         <li>Social bookmarking – to allow users to share our content more easily on popular social media platforms.</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <p>10.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital is under no obligation to oversee, monitor or moderate any interactive services we provide from this website, and we expressly exclude our liability for any loss or damage arising from the use of these interactive services by a user in contravention of these terms and conditions, whether the service is moderated or not.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>10.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Our RSS feeds can be used as part of your website; however, we do require that proper format and attribution are used. The attribution text should read “<strong>NHS Digital</strong><strong>&nbsp;</strong><strong>RSS feeds</strong>”. We reserve the right from time to time to restrict the distribution of NHS Digital RSS feed content and do not accept any liability for these feeds.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>10.4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Use of our social bookmarking links is subject to these terms and conditions, see ‘Linking from this website’ below.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>10.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Although we do monitor and review discussions, chat, postings, transmissions, bulletin boards and the like on this website and its subsections, we are under no obligation to do so and assume no responsibility or liability arising from the content of any such locations nor for any error, omission, infringement, defamation, obscenity, or inaccuracy contained in any information within such locations on this website.</p>
+
+        <p>&nbsp;</p>
+
+        <p>10.6&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The use of any of the interactive features on this website by a minor is subject to the consent of their parent or guardian, and we advise parents to communicate with their children about their safety online, as moderation is not foolproof. Minors who are using any interactive service should be made aware of the potential risks to them. Where we do moderate any of the interactive features on this website, we will normally provide you with a means of contacting the moderator, should a concern or difficulty arise.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>11&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Linking to this website</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>11.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; We do not object to you linking directly to pages on this website.&nbsp;We reserve the right to move or change this website’s URLs at any time. Rather than deep linking we recommend linking to section homepages, which are less likely to move or change.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>11.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; However, we don’t give permission to suggest that your website is associated, or endorsed by us.</p>
+
+        <h3>&nbsp;</h3>
+
+        <p><strong>12&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Linking from this website</strong></p>
+
+        <p>&nbsp;</p>
+
+        <p>12.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; We are not responsible for the content or reliability of the websites we link to and do not necessarily endorse the views expressed within them.&nbsp;We aim to replace broken links to other sites but cannot guarantee that these links will always work as we have no control over the availability of other sites.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>12.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Due to the very nature of the internet we cannot guarantee this website or other websites we link to will always be available to you.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>13&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Disclaimer and Liabilities</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>13.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; This website, all NHS Digital Content and all material relating to Government information, products and services (or to third-party information, products and services), is provided ‘as is’, without any endorsement and without warranty of any kind whether express or implied, including but not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility, security and accuracy.&nbsp; This means that whilst we do try to ensure that all our information is correct, we are not liable for any errors or omissions, and cannot be responsible for any impact these have on you.&nbsp;</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>13.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; If the need arises, we reserve the right to amend, delete, suspend or withdraw all or any part of this website without notice. NHS Digital will not be liable if for any reason this website or any parts are unavailable at any time.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>13.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; We do not warrant that the functions of this website will be uninterrupted or error free, that defects will be corrected, or that this website or the server that makes it available will be free of viruses or represent the full functionality, accuracy or reliability of the materials. You should use your own virus protection software.</p>
+
+        <p>&nbsp;</p>
+
+        <p>13.4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital and any approving bodies are not the owners, managers or suppliers of various products which can be accessed from this website. NHS Digital or the approving body sets standards for reviewing the products, but this does not mean that NHS Digital or the approving body has itself reviewed all aspects of each product, or version of the same product.&nbsp;NHS Digital or the approving body is not responsible or liable for any advice, or any other information, services or products that you obtain using any such products.</p>
+
+        <p>&nbsp;</p>
+
+        <p>13.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Material on this website is provided for information and educational purposes only and we do not guarantee that information we provide will meet your health or medical requirements. NHS Digital does not give medical advice in relation to any individual case or patient, nor does NHS Digital provide medical or diagnostic services. For less urgent health needs, contact your GP or local pharmacist in the usual way. If you have an urgent medical need you should call 111. If a life is at risk, call 999.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>13.6&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; In no event will we be liable for any loss or damage including, without limitation, indirect or consequential loss or damage, or any loss or damages whatsoever arising from use or loss of use of, data or profits arising out of or in connection with the use of this website. Nothing in these terms and conditions will operate to limit or exclude liability for death or personal injury arising from our negligence, nor our liability for fraudulent misrepresentation, nor any other liability which cannot be excluded or limited under applicable law.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>14&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>General</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>14.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; If any of these terms and conditions are determined to be illegal, invalid or otherwise unenforceable then the remaining terms and conditions shall remain in full force and effect.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>14.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The laws of England shall apply exclusively to these terms and conditions and to all matters relating to use of this website. Any cause of action arising under these terms and conditions or the use of this website shall be subject to the exclusive jurisdiction of the courts of England and Wales.</p>
+      jcr:primaryType: hippostd:html
+    hippo:availability:
+    - preview
+    hippostd:state: unpublished
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2017-12-22T15:05:58.519Z
+    hippostdpubwf:lastModificationDate: 2017-12-22T15:07:01.668Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: f2ec2ee1-308c-4270-a070-b97334bf5543
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:about
+    publicationsystem:Title: Terms and Conditions
+  /terms-and-conditions[3]:
+    /publicationsystem:Content:
+      hippostd:content: |-
+        <p><strong>1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>About these terms</strong></p>
+
+        <p>1.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Please read these terms and conditions carefully before you start to use this website (being&nbsp;<a rel="nofollow" href="https://digital.nhs.uk/">https://digital.nhs.uk/</a>&nbsp;and all sections and pages). You may access and use this website if you agree to be legally bound by these terms and conditions set out here. If you do not agree to be legally bound by these terms and conditions please do not access and/or use this website.</p>
+
+        <p>&nbsp;</p>
+
+        <p>1.2&nbsp; Where indicated, additional terms and conditions apply to specific sections (for example&nbsp;<a rel="nofollow" href="http://www.content.digital.nhs.uk/">http://www.content.digital.nhs.uk/</a>).</p>
+
+        <p>&nbsp;</p>
+
+        <p>1.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; References in these terms and conditions to “NHS Digital”, “we”, “our” and “us” are references to the Health and Social Care Information Centre, a non-departmental public body established under primary legislation and known as NHS Digital. The entire contents of this website, and the individual articles, items, media files and assets published are owned by NHS Digital, unless otherwise indicated.</p>
+
+        <p>&nbsp;</p>
+
+        <p>1.4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; This website is intended for use only by people who live in the United Kingdom. References to ‘the NHS’ mean ‘the NHS in England’ unless otherwise stated. Services and arrangements may differ elsewhere in the UK.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>1.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; If you have any queries in respect of your use of this website please contact us at:&nbsp;<a rel="nofollow" href="mailto:enquiries@nhsdigital.nhs.uk">enquiries@nhsdigital.nhs.uk</a>&nbsp;or</p>
+
+        <p>NHS Digital<br />
+        1 Trevelyan Square<br />
+        Boar Lane<br />
+        Leeds<br />
+        West Yorkshire<br />
+        LS1 6AE</p>
+
+        <p>1.6&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; We may make changes to these terms and conditions, the terms and conditions applicable to any specific sub-site, the privacy and cookies policy and any other policies applicable to your use of this website, at any time. Your continuing use of this website constitutes your acceptance of and agreement to any such changed terms and conditions and policies.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>1.7&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; To the extent that we are practically able to do so, we may terminate your access to any part of this website at any time without notice if you breach any of these terms and conditions.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Accessibility and browsers</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>2.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital aims to make this website and the material provided accessible to as many people as possible. This website is designed to work with the latest versions of Microsoft Edge, Google Chrome and Apple Safari, and uses standards which should work on the majority of browsers in use.&nbsp; We offer no warranty for this website working in any particular browser or configuration. Please note that you may see inconsistencies in the presentation of pages if you are using an older or deprecated version of a browser.&nbsp;Read further information on&nbsp;<a rel="nofollow" href="https://digital.nhs.uk/article/773/Accessibility-help">the accessibility of this website</a>.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Information about you and your visits to this website</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>3.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital processes information about you in accordance with our&nbsp;<a rel="nofollow" href="https://digital.nhs.uk/article/236/Privacy-and-cookies">privacy and cookies policy</a><a rel="nofollow" href="file:///C:/Users/owda1/AppData/Local/Microsoft/Windows/Temporary%20Internet%20Files/Content.Outlook/3XQDEC15/NHSD%20website%20terms%20and%20conditions.%20v.3.2%20(5%20Oct)%20clean%20(2).docx#_msocom_1">[LM1]</a>&nbsp;.&nbsp;By using this website, you consent to such processing and you warrant that all data provided by you is accurate.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Freedom of Information</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>4.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The data rights and responsibilities of NHS Digital, its staff and of patients is governed by the Freedom of Information Act 2000 and the Data Protection Act 1998. For policy and other information see&nbsp;<a rel="nofollow" href="https://digital.nhs.uk/article/253/Freedom-of-Information">Freedom of Information.</a></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Registering to use this website</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>5.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; In order to access certain content, systems or interactive features on this website you may be asked to choose, or be provided with, a password or other log in details to access parts of this website. As a minimum, passwords you set for use with this website must have a level of complexity which ensures they cannot be easily guessed by hackers or malicious software.&nbsp; They should:</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>be at least twelve characters long;</li>
+         <li>not contain your user name, real name, or organisation name;</li>
+         <li>not appear in the&nbsp;<a rel="nofollow" href="http://www.passwordrandom.com/most-popular-passwords">list of top 10,000 passwords</a>;</li>
+         <li>not use sequential key characters on the keyboard (e.g. qwerty, asdfg, 12345)</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <p>5.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; In line with&nbsp;<a rel="nofollow" href="https://www.ncsc.gov.uk/blog-post/three-random-words-or-thinkrandom-0">Government best practice</a>, we recommend using the ‘three random words’ approach, which uses three or more randomly chosen words like ‘saloonbadgertree’ or ‘coffeetrainfish’.&nbsp; These words should be random, and not related personally to you (so not involving a favourite thing, holiday, relative). Passwords must not under any circumstances be shared with anyone.&nbsp; &nbsp;</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>5.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; You may terminate your account registration using the relevant link in your account pages. This will clear any personal information you have saved. Subscriptions to our emails can be terminated using the ‘Unsubscribe’ links provided in the emails. &nbsp;</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>6&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Prohibited Uses of this Website</strong></p>
+
+        <p>&nbsp;</p>
+
+        <p>6.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; You may use this website only for lawful purposes. You may not use this website:</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>in any way that breaches any applicable local, national or international law or regulation;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>in any way that is unlawful, fraudulent or harmful to other users, or has any unlawful, fraudulent or harmful purpose or effect;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>to send, knowingly receive, upload, download, use or re-use any material which does not comply with these terms and conditions;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>to transmit, or produce the sending of, any unsolicited or unauthorised advertising or promotional material or any other form of similar solicitation (spam); and</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>to knowingly transmit any data, send or upload any material that contains viruses, Trojan horses, worms, spyware or any other harmful programs or similar computer code designed to adversely affect the operation of any computer software or hardware.</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <p>6.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; You also agree not to access without authority, interfere with, damage or disrupt any part of this website; any equipment or network on which this website is stored; any software used in the provision of this website; or any equipment or network or software owned or used by any third-party.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>7&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Material on this website</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>7.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The material on this website includes information, data, text, images, videos, Information Standards, interactive services, link to products and apps and other works (“<strong>NHS Digital Content</strong>”).&nbsp; You acknowledge that all rights in copyright, patents, design rights, trade marks and other intellectual property rights (whether registered, capable of registration or otherwise) throughout the world, in this website and all NHS Digital Content are owned by, or licensed to NHS Digital, unless otherwise indicated. Some NHS Digital Content includes identifiable third-party content for which we will have sought permission for its inclusion.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>7.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Except for your use of this website in accordance with these terms and conditions, you are granted no rights in respect of this website or any NHS Digital Content.</p>
+
+        <p>&nbsp;</p>
+
+        <p>7.3&nbsp; The Information Standards are published by us and apply to organisations in the health and social care sector.&nbsp; They relate to the processing of information such that data can be shared, compared and understood across the sector, and used for planning, monitoring and good patient care. For further details please see&nbsp;<a rel="nofollow" href="https://digital.nhs.uk/information-standards">https://digital.nhs.uk/information-standards</a>. The Data Co-ordination Board (DCB) assures the quality of information standards.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>8&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Your use of the NHS Digital Content</strong></p>
+
+        <p>&nbsp;</p>
+
+        <p>8.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Copyright and database rights in the NHS Digital Content are released free-of-charge under the current version of the&nbsp;<a rel="nofollow" href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence</a>&nbsp;(“<strong>OGL</strong>”), except where specified, either in these terms and conditions, elsewhere on this website or in the OGL terms.&nbsp; This licence does not extend to any other intellectual property rights, including but not limited to patents, design rights and trade marks. If there is any conflict between the OGL terms and these terms and conditions these terms and conditions shall take precedence.&nbsp;</p>
+
+        <p>&nbsp;</p>
+
+        <p>8.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; This means that you can use NHS Digital Content, including copying it, adapting it, and using it for any purpose, including commercially, provided you follow these terms and conditions and the terms of the OGL.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>8.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The OGL terms do not apply to the following categories of NHS Digital Content, and therefore these must not be used without our or the relevant owner’s prior consent:</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>any logos, visuals, image rights, trademarks, trade names and design styles (except where these are integral to a document or data set) of NHS Digital, or any predecessor or linked body, as well as of any partner or contributor;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>the Information Standards.&nbsp; NHS Digital permits the copying and re-use of Information Standards, in whole or in part, for commercial and non-commercial purposes but, to protect the integrity of the Information Standards, you are not permitted to adapt, amend or decompile the Information Standards for any purpose without our prior consent;<a rel="nofollow" href="file:///C:/Users/owda1/AppData/Local/Microsoft/Windows/Temporary%20Internet%20Files/Content.Outlook/3XQDEC15/NHSD%20website%20terms%20and%20conditions.%20v.3.2%20(5%20Oct)%20clean%20(2).docx#_msocom_2">[LM2]</a>&nbsp;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>software, source code and any technical documentation relating to software or source code except where released on&nbsp;<a rel="nofollow" href="https://developer.nhs.uk/">https://developer.nhs.uk/</a>, a public repository on GitHub, or any other platform we may specify from time-to-time;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>information owned by third parties which we are not authorised to licence on to you.&nbsp; This information will be clearly marked.&nbsp; If in doubt, contact us using the details above;</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>information gained through any services or sections on this website (or linked websites) which can only be accessed by logged-in users; and</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <ul>
+         <li>any information which is marked as being under a different licence, or not for release.</li>
+        </ul>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>8.4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; If you do use any NHS Digital Content you must attribute it with the following statement:</p>
+
+        <p>“<strong>Information from NHS Digital, licenced under the current version of the Open Government Licence</strong>”.</p>
+
+        <ul>
+         <li>or in cases where the NHS Digital Content is combined, adapted, or otherwise modified in line with these terms and conditions:</li>
+        </ul>
+
+        <p>“<strong>Contains information from NHS Digital, licenced under the current version of the Open Government Licence</strong>”.</p>
+
+        <p>8.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; By using any NHS Digital Content you accept and agree to the following terms:</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>you must not alter, adapt, edit or modify any NHS Digital branding where this is integral to a document or data set;</li>
+        </ul>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>if you do alter, adapt, edit or modify any NHS Digital Content in accordance with<strong>&nbsp;</strong>these terms and conditions, where possible, you should remove the NHS Digital branding;</li>
+        </ul>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>you may not directly or indirectly suggest any endorsement or approval by NHS Digital of your site or any non-NHS Digital entity, product or content or any views expressed within your site or service;</li>
+        </ul>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>NHS Digital has absolute editorial control over all NHS Digital Content and reserves the right to alter, adapt, edit, modify or restrict the availability of NHS Digital Content without prior notice; and</li>
+        </ul>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>you should refresh cached content every 24 hours to ensure you have the most up-to-date version.</li>
+        </ul>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>9&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Uploading material to this website</strong></p>
+
+        <p>&nbsp;</p>
+
+        <p>9.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Whenever you make use of a feature that allows you to upload material to this website, for example when you participate in online discussions, contact other users of this website or submit any apps or products, you must comply with the standards set out in the comments and moderation policy<a rel="nofollow" href="file:///C:/Users/owda1/AppData/Local/Microsoft/Windows/Temporary%20Internet%20Files/Content.Outlook/3XQDEC15/NHSD%20website%20terms%20and%20conditions.%20v.3.2%20(5%20Oct)%20clean%20(2).docx#_msocom_3">[LM3]</a>&nbsp;. You warrant that any such contribution does comply with those standards, and you indemnify us for any breach of that warranty.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>9.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Any material you upload to this website will be considered non-confidential and non-proprietary, and NHS Digital has the right to use, copy, distribute and disclose to third-parties any such material for any purpose. Furthermore NHS Digital also has the right to disclose your identity to any third-party who is claiming that any material posted or uploaded by you to this website constitutes a violation of their intellectual property rights, or their right to privacy.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>9.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital will not be responsible, or liable to any third-party, for the content or accuracy of any materials posted by your or any other user of this website.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>9.4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital has the right to remove any material or posting you make on this website if, in our opinion, such material does not comply with the standards set out in these terms and conditions and the comments and moderation policy<a rel="nofollow" href="file:///C:/Users/owda1/AppData/Local/Microsoft/Windows/Temporary%20Internet%20Files/Content.Outlook/3XQDEC15/NHSD%20website%20terms%20and%20conditions.%20v.3.2%20(5%20Oct)%20clean%20(2).docx#_msocom_4">[LM4]</a>&nbsp;.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>9.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Comments posted should relate to your personal experience or that of someone close to you. You should not name any individuals (other than yourself) or include information through which someone else could identify an individual about whom you are writing. If you want to comment on someone else’s experience, (e.g. a relative or someone you care for) then you may do so if you ensure that you are not named in the posting and you state how the other person is connected to you (e.g. “my father”). You warrant that all statements of fact in any comment you submit are true, and that any expression of opinion is your honestly held opinion on those facts, or that of the person on whose behalf you are writing.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>9.6&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; If you find any comments offensive or objectionable you may make a complaint to the moderator using the ‘Report’ link provided at the foot of each published comment.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>9.7&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; We have many measures in place to keep your information safe. But it is important that you also play your part&nbsp;– visit&nbsp;the Government's&nbsp;<a rel="nofollow" href="https://www.getsafeonline.org/">Get Safe Online</a>website for advice on how to do this.&nbsp;&nbsp;</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>10&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Social media, bookmarking and digital engagement</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>10.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital may from time to time provide third party or owned social media and interactive services on this website or linked to this website, currently this includes and is not limited to:</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <ul>
+         <li>Youtube – for sharing video content;</li>
+         <li>Twitter – for sharing news and participating in conversations with users;</li>
+         <li>Blogs –&nbsp; to share the opinions of NHS Digital’s staff and other key figures;</li>
+         <li>Discussion Forums – for participation in conversations with users;</li>
+         <li>RSS feeds – for sharing news;</li>
+         <li>Social bookmarking – to allow users to share our content more easily on popular social media platforms.</li>
+        </ul>
+
+        <p>&nbsp;</p>
+
+        <p>10.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital is under no obligation to oversee, monitor or moderate any interactive services we provide from this website, and we expressly exclude our liability for any loss or damage arising from the use of these interactive services by a user in contravention of these terms and conditions, whether the service is moderated or not.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>10.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Our RSS feeds can be used as part of your website; however, we do require that proper format and attribution are used. The attribution text should read “<strong>NHS Digital</strong><strong>&nbsp;</strong><strong>RSS feeds</strong>”. We reserve the right from time to time to restrict the distribution of NHS Digital RSS feed content and do not accept any liability for these feeds.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>10.4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Use of our social bookmarking links is subject to these terms and conditions, see ‘Linking from this website’ below.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>10.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Although we do monitor and review discussions, chat, postings, transmissions, bulletin boards and the like on this website and its subsections, we are under no obligation to do so and assume no responsibility or liability arising from the content of any such locations nor for any error, omission, infringement, defamation, obscenity, or inaccuracy contained in any information within such locations on this website.</p>
+
+        <p>&nbsp;</p>
+
+        <p>10.6&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The use of any of the interactive features on this website by a minor is subject to the consent of their parent or guardian, and we advise parents to communicate with their children about their safety online, as moderation is not foolproof. Minors who are using any interactive service should be made aware of the potential risks to them. Where we do moderate any of the interactive features on this website, we will normally provide you with a means of contacting the moderator, should a concern or difficulty arise.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>11&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Linking to this website</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>11.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; We do not object to you linking directly to pages on this website.&nbsp;We reserve the right to move or change this website’s URLs at any time. Rather than deep linking we recommend linking to section homepages, which are less likely to move or change.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>11.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; However, we don’t give permission to suggest that your website is associated, or endorsed by us.</p>
+
+        <h3>&nbsp;</h3>
+
+        <p><strong>12&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Linking from this website</strong></p>
+
+        <p>&nbsp;</p>
+
+        <p>12.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; We are not responsible for the content or reliability of the websites we link to and do not necessarily endorse the views expressed within them.&nbsp;We aim to replace broken links to other sites but cannot guarantee that these links will always work as we have no control over the availability of other sites.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>12.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Due to the very nature of the internet we cannot guarantee this website or other websites we link to will always be available to you.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>13&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>Disclaimer and Liabilities</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>13.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; This website, all NHS Digital Content and all material relating to Government information, products and services (or to third-party information, products and services), is provided ‘as is’, without any endorsement and without warranty of any kind whether express or implied, including but not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility, security and accuracy.&nbsp; This means that whilst we do try to ensure that all our information is correct, we are not liable for any errors or omissions, and cannot be responsible for any impact these have on you.&nbsp;</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>13.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; If the need arises, we reserve the right to amend, delete, suspend or withdraw all or any part of this website without notice. NHS Digital will not be liable if for any reason this website or any parts are unavailable at any time.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>13.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; We do not warrant that the functions of this website will be uninterrupted or error free, that defects will be corrected, or that this website or the server that makes it available will be free of viruses or represent the full functionality, accuracy or reliability of the materials. You should use your own virus protection software.</p>
+
+        <p>&nbsp;</p>
+
+        <p>13.4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; NHS Digital and any approving bodies are not the owners, managers or suppliers of various products which can be accessed from this website. NHS Digital or the approving body sets standards for reviewing the products, but this does not mean that NHS Digital or the approving body has itself reviewed all aspects of each product, or version of the same product.&nbsp;NHS Digital or the approving body is not responsible or liable for any advice, or any other information, services or products that you obtain using any such products.</p>
+
+        <p>&nbsp;</p>
+
+        <p>13.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Material on this website is provided for information and educational purposes only and we do not guarantee that information we provide will meet your health or medical requirements. NHS Digital does not give medical advice in relation to any individual case or patient, nor does NHS Digital provide medical or diagnostic services. For less urgent health needs, contact your GP or local pharmacist in the usual way. If you have an urgent medical need you should call 111. If a life is at risk, call 999.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>13.6&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; In no event will we be liable for any loss or damage including, without limitation, indirect or consequential loss or damage, or any loss or damages whatsoever arising from use or loss of use of, data or profits arising out of or in connection with the use of this website. Nothing in these terms and conditions will operate to limit or exclude liability for death or personal injury arising from our negligence, nor our liability for fraudulent misrepresentation, nor any other liability which cannot be excluded or limited under applicable law.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p><strong>14&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</strong><strong>General</strong></p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>14.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; If any of these terms and conditions are determined to be illegal, invalid or otherwise unenforceable then the remaining terms and conditions shall remain in full force and effect.</p>
+
+        <p><strong>&nbsp;</strong></p>
+
+        <p>14.2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The laws of England shall apply exclusively to these terms and conditions and to all matters relating to use of this website. Any cause of action arising under these terms and conditions or the use of this website shall be subject to the exclusive jurisdiction of the courts of England and Wales.</p>
+      jcr:primaryType: hippostd:html
+    hippo:availability:
+    - live
+    hippostd:state: published
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2017-12-22T15:05:58.519Z
+    hippostdpubwf:lastModificationDate: 2017-12-22T15:07:01.668Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippostdpubwf:publicationDate: 2017-12-22T15:07:05.033Z
+    hippotranslation:id: f2ec2ee1-308c-4270-a070-b97334bf5543
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:about
+    publicationsystem:Title: Terms and Conditions
+  jcr:mixinTypes:
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/base-footer.ftlh
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/base-footer.ftlh
@@ -1,22 +1,16 @@
 <#include "../include/imports.ftlh">
-
-<@hst.setBundle basename="essentials.global"/>
-<div>
-  <@hst.include ref="container"/>
-</div>
 <hr/>
-<div class="text-center">
-  <sub><@fmt.message key="footer.text" var="footer"/>${footer}</sub>
+<div class="footer__inner">
+    <ul>
+        <@hst.link var="termslink" path="/publications/about/terms-and-conditions"/>
+        <li><a href="${termslink}">Terms &amp; Conditions</a></li>
+        <li><a href="#">Privacy and cookies</a></li>
+        <li><a href="#">Accessibility help</a></li>
+    </ul>
 </div>
-
 
 Have a question? Call us on 0300 303 5678 or contact enquiries@nhsdigital.nhs.uk.
 Tell us what you think of the new website beta.
-Accessibility help
-
-Privacy and cookies
-
-Terms and conditions
 © 2017 NHS Digital
 
 Follow us:

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/about.ftlh
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/about.ftlh
@@ -1,0 +1,9 @@
+<#include "../include/imports.ftlh">
+<section class="document-content">
+    <#if document??>
+        <h2>${document.title}</h2>
+        <div>
+            <@hst.html hippohtml=document.content />
+        </div>
+    </#if>
+</section>

--- a/site/src/main/java/uk/nhs/digital/ps/beans/About.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/About.java
@@ -1,0 +1,19 @@
+package uk.nhs.digital.ps.beans;
+
+import org.hippoecm.hst.content.beans.Node;
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+import org.hippoecm.hst.content.beans.standard.HippoHtml;
+
+@HippoEssentialsGenerated(internalName = "publicationsystem:about")
+@Node(jcrType = "publicationsystem:about")
+public class About extends BaseDocument {
+    @HippoEssentialsGenerated(internalName = "publicationsystem:Title")
+    public String getTitle() {
+        return getProperty("publicationsystem:Title");
+    }
+
+    @HippoEssentialsGenerated(internalName = "publicationsystem:Content")
+    public HippoHtml getContent() {
+        return getHippoHtml("publicationsystem:Content");
+    }
+}

--- a/site/src/main/java/uk/nhs/digital/ps/components/AboutComponent.java
+++ b/site/src/main/java/uk/nhs/digital/ps/components/AboutComponent.java
@@ -1,0 +1,20 @@
+package uk.nhs.digital.ps.components;
+
+import org.hippoecm.hst.component.support.bean.BaseHstComponent;
+import org.hippoecm.hst.core.component.HstComponentException;
+import org.hippoecm.hst.core.component.HstRequest;
+import org.hippoecm.hst.core.component.HstResponse;
+import org.hippoecm.hst.core.request.HstRequestContext;
+import uk.nhs.digital.ps.beans.About;
+
+public class AboutComponent extends BaseHstComponent {
+
+    @Override
+    public void doBeforeRender(final HstRequest request, final HstResponse response) throws HstComponentException {
+        super.doBeforeRender(request, response);
+        final HstRequestContext ctx = request.getRequestContext();
+        About document = (About) ctx.getContentBean();
+
+        request.setAttribute("document", document);
+    }
+}


### PR DESCRIPTION
Added new document type called "About" which will cater for general site
documents such as terms and conditions, accessibility, privacy policy etc. Added
footer component to basepage, along with initial link to terms and conditions document.

Enabled a populated version of terms and conditions document to be bootstraped in the
development module, with a blank document being bootstraped in other environments on
first deployment for the user to populate and maintain (similar to taxonomy). For
subsequent deployments, as the document will already exist, the user maintained version
will not be overwritten.

Note: new document type currently resides under the ps namespace.  Separate ticket to
move this into the common namespace.