### PR TITLE
[RPS-227] Enforce HTTPS connections

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/hst/hosts.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/hosts.yaml
@@ -34,6 +34,7 @@ definitions:
                 jcr:primaryType: hst:virtualhost
               jcr:primaryType: hst:virtualhost
             jcr:primaryType: hst:virtualhost
+          hst:scheme: http
           hst:showcontextpath: false
           jcr:primaryType: hst:virtualhost
         hst:cmslocation: http://blackhole-hippo-authoring.web.dev.ps.nhsd.io/cms
@@ -70,6 +71,7 @@ definitions:
                 jcr:primaryType: hst:virtualhost
               jcr:primaryType: hst:virtualhost
             jcr:primaryType: hst:virtualhost
+          hst:scheme: http
           hst:showcontextpath: false
           jcr:primaryType: hst:virtualhost
         hst:cmslocation: http://hippo-authoring.web.dev.ps.nhsd.io/cms
@@ -135,4 +137,5 @@ definitions:
           jcr:primaryType: hst:virtualhost
         hst:cmslocation: https://cms-nhs.test.onehippo.com
         jcr:primaryType: hst:virtualhostgroup
+      hst:scheme: https
       jcr:primaryType: hst:virtualhosts

--- a/repository-data/development/src/main/resources/hcm-config/hst/hosts.yaml
+++ b/repository-data/development/src/main/resources/hcm-config/hst/hosts.yaml
@@ -19,6 +19,7 @@ definitions:
             hst:homepage: root
             hst:mountpoint: /hst:hst/hst:sites/common
             jcr:primaryType: hst:mount
+          hst:scheme: http
           jcr:primaryType: hst:virtualhost
         hst:cmslocation: http://localhost:8080/cms
         hst:defaultport: 8080
@@ -41,6 +42,7 @@ definitions:
               hst:mountpoint: /hst:hst/hst:sites/common
               jcr:primaryType: hst:mount
             jcr:primaryType: hst:virtualhost
+          hst:scheme: http
           hst:showcontextpath: false
           jcr:primaryType: hst:virtualhost
         hst:cmslocation: http://hippo-authoring.int:8080/cms


### PR DESCRIPTION
Set HTTPS to be the default scheme (default was HTTP).
If you visit the http URL you will be redirected to https.
Overwritten this value for AWS and localhost as these envirnoments
don't have certificates set up, therefore this will only affect
OnDemand.