### PR TITLE
[RPS-248] Fix .ftlh design time content refresh issue

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates.yaml
@@ -3,9 +3,9 @@ definitions:
   config:
     /hst:hst/hst:configurations/common/hst:templates:
       /facets:
-        hst:renderpath: webfile:/freemarker/common/facets.ftlh
+        hst:renderpath: webfile:/freemarker/common/facets.ftl
         jcr:primaryType: hst:template
       /footer:
-        hst:renderpath: webfile:/freemarker/common/base-footer.ftlh
+        hst:renderpath: webfile:/freemarker/common/base-footer.ftl
         jcr:primaryType: hst:template
       jcr:primaryType: hst:templates

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates/404.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates/404.yaml
@@ -2,5 +2,5 @@
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:templates/404:
-      hst:renderpath: webfile:/freemarker/common/404.ftlh
+      hst:renderpath: webfile:/freemarker/common/404.ftl
       jcr:primaryType: hst:template

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates/base.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates/base.yaml
@@ -2,5 +2,5 @@
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:templates/base:
-      hst:renderpath: webfile:/freemarker/common/base-layout.ftlh
+      hst:renderpath: webfile:/freemarker/common/base-layout.ftl
       jcr:primaryType: hst:template

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates/search.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates/search.yaml
@@ -2,5 +2,5 @@
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:templates/search:
-      hst:renderpath: webfile:/freemarker/common/search.ftlh
+      hst:renderpath: webfile:/freemarker/common/search.ftl
       jcr:primaryType: hst:template

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates/searchresults.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates/searchresults.yaml
@@ -2,5 +2,5 @@
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:templates/searchresults:
-      hst:renderpath: webfile:/freemarker/common/searchresults.ftlh
+      hst:renderpath: webfile:/freemarker/common/searchresults.ftl
       jcr:primaryType: hst:template

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/templates.yaml
@@ -3,21 +3,21 @@ definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:templates:
       /about:
-        hst:renderpath: webfile:/freemarker/publicationsystem/about.ftlh
+        hst:renderpath: webfile:/freemarker/publicationsystem/about.ftl
         jcr:primaryType: hst:template
       /dataset:
-        hst:renderpath: webfile:/freemarker/publicationsystem/dataset.ftlh
+        hst:renderpath: webfile:/freemarker/publicationsystem/dataset.ftl
         jcr:primaryType: hst:template
       /folder:
-        hst:renderpath: webfile:/freemarker/publicationsystem/folder.ftlh
+        hst:renderpath: webfile:/freemarker/publicationsystem/folder.ftl
         jcr:primaryType: hst:template
       /publication:
-        hst:renderpath: webfile:/freemarker/publicationsystem/publication.ftlh
+        hst:renderpath: webfile:/freemarker/publicationsystem/publication.ftl
         jcr:primaryType: hst:template
       /publications-overview-template:
-        hst:renderpath: webfile:/freemarker/publicationsystem/publications-overview.ftlh
+        hst:renderpath: webfile:/freemarker/publicationsystem/publications-overview.ftl
         jcr:primaryType: hst:template
       /series:
-        hst:renderpath: webfile:/freemarker/publicationsystem/series.ftlh
+        hst:renderpath: webfile:/freemarker/publicationsystem/series.ftl
         jcr:primaryType: hst:template
       jcr:primaryType: hst:templates

--- a/repository-data/application/src/main/resources/hcm-config/main.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/main.yaml
@@ -38,11 +38,6 @@ definitions:
         value:
         - editor
     /hippo:configuration/hippo:modules/webfiles/hippo:moduleconfig:
-      includedFiles:
-        operation: add
-        type: string
-        value:
-        - '*.ftlh'
       watchedModules:
       - repository-data/webfiles
   namespace:

--- a/repository-data/webfiles/pom.xml
+++ b/repository-data/webfiles/pom.xml
@@ -29,6 +29,15 @@
             <artifactId>hippo-essentials-components-hst</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/404.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/404.ftl
@@ -1,4 +1,5 @@
-<#include "../include/imports.ftlh">
+<#ftl output_format="HTML">
+<#include "../include/imports.ftl">
 
 <section class="document-header">
     <div class="document-header__inner">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/base-footer.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/base-footer.ftl
@@ -1,4 +1,5 @@
-<#include "../include/imports.ftlh">
+<#ftl output_format="HTML">
+<#include "../include/imports.ftl">
 <hr/>
 <div class="footer__inner">
     <ul>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/base-layout.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/base-layout.ftl
@@ -1,5 +1,6 @@
+<#ftl output_format="HTML">
 <!DOCTYPE html>
-<#include "../include/imports.ftlh">
+<#include "../include/imports.ftl">
 <html lang="en">
   <head>
 

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/base-top-menu.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/base-top-menu.ftl
@@ -1,4 +1,5 @@
-<#include "../include/imports.ftlh">
+<#ftl output_format="HTML">
+<#include "../include/imports.ftl">
 
 <#-- @ftlvariable name="menu" type="org.hippoecm.hst.core.sitemenu.HstSiteMenu" -->
 <#-- @ftlvariable name="editMode" type="java.lang.Boolean"-->

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/facets.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/facets.ftl
@@ -1,4 +1,5 @@
-<#include "../include/imports.ftlh">
+<#ftl output_format="HTML">
+<#include "../include/imports.ftl">
 <!--Need to have a single setBundle call as subsequent ones will overwrite the previous values-->
 <@hst.setBundle basename="document-types,month-names"/>
 

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/search.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/search.ftl
@@ -1,4 +1,5 @@
-<#include "../include/imports.ftlh">
+<#ftl output_format="HTML">
+<#include "../include/imports.ftl">
 
 <@hst.link siteMapItemRefId="search" mount="common-context" var="searchLink"/>
 

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/searchresults.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/searchresults.ftl
@@ -1,4 +1,5 @@
-<#include "../include/imports.ftlh">
+<#ftl output_format="HTML">
+<#include "../include/imports.ftl">
 <#assign formatRestrictableDate="uk.nhs.digital.ps.directives.RestrictableDateFormatterDirective"?new() />
 
 <#if pageable??>
@@ -21,7 +22,7 @@
             </#list>
 
             <#if cparam.showPagination>
-                <#include "../include/pagination.ftlh">
+                <#include "../include/pagination.ftl">
             </#if>
 
         </#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/include/imports.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/include/imports.ftl
@@ -1,3 +1,4 @@
+<#ftl output_format="HTML">
 <#assign hst=JspTaglibs["http://www.hippoecm.org/jsp/hst/core"] >
 <#assign fmt=JspTaglibs["http://java.sun.com/jsp/jstl/fmt"] >
 

--- a/repository-data/webfiles/src/main/resources/site/freemarker/include/pagination.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/include/pagination.ftl
@@ -1,3 +1,4 @@
+<#ftl output_format="HTML">
 <div class="pagination">
     <ul class="pagination__list">
         <#if pageable.totalPages gt 1>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/about.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/about.ftl
@@ -1,3 +1,4 @@
+<#ftl output_format="HTML">
 <#include "../include/imports.ftlh">
 <section class="document-content">
     <#if document??>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/dataset.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/dataset.ftl
@@ -1,5 +1,6 @@
-<#include "../include/imports.ftlh">
-<#include "./macro/structured-text.ftlh">
+<#ftl output_format="HTML">
+<#include "../include/imports.ftl">
+<#include "./macro/structured-text.ftl">
 <@hst.setBundle basename="publicationsystem.headers"/>
 
 <#assign dateFormat="dd/MM/yyyy"/>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/folder.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/folder.ftl
@@ -1,9 +1,10 @@
-<#include "../include/imports.ftlh">
+<#ftl output_format="HTML">
+<#include "../include/imports.ftl">
 
   <#if series??>
-      <#include "./series.ftlh">
+      <#include "./series.ftl">
   <#elseif publication??>
-      <#include "./publication.ftlh">
+      <#include "./publication.ftl">
   <#else>
     <h2>Page not found</h2>
     <p>The page you're looking for does not exist. But we did find some other content.</p>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/macro/structured-text.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/macro/structured-text.ftl
@@ -1,4 +1,5 @@
-<#include "../../include/imports.ftlh">
+<#ftl output_format="HTML">
+<#include "../../include/imports.ftl">
 
 <#macro structuredText item uipath>
     <#list item.elements as element>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
@@ -1,5 +1,6 @@
-<#include "../include/imports.ftlh">
-<#include "./macro/structured-text.ftlh">
+<#ftl output_format="HTML">
+<#include "../include/imports.ftl">
+<#include "./macro/structured-text.ftl">
 <#assign dateFormat="dd/MM/yyyy"/>
 <#assign formatFileSize="uk.nhs.digital.ps.directives.FileSizeFormatterDirective"?new() />
 <#assign formatRestrictableDate="uk.nhs.digital.ps.directives.RestrictableDateFormatterDirective"?new() />

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publications-overview.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publications-overview.ftl
@@ -1,5 +1,6 @@
+<#ftl output_format="HTML">
 <#-- DECLARATIONS: -->
-<#include "../include/imports.ftlh">
+<#include "../include/imports.ftl">
 
 <#macro restrictableDate date>
     <#assign formatRestrictableDate="uk.nhs.digital.ps.directives.RestrictableDateFormatterDirective"?new() />

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/series.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/series.ftl
@@ -1,5 +1,6 @@
-<#include "../include/imports.ftlh">
-<#include "./macro/structured-text.ftlh">
+<#ftl output_format="HTML">
+<#include "../include/imports.ftl">
+<#include "./macro/structured-text.ftl">
 
 <@hst.setBundle basename="publicationsystem.headers"/>
 

--- a/repository-data/webfiles/src/test/java/resources/site/freemarker/FreemarkerFileTest.java
+++ b/repository-data/webfiles/src/test/java/resources/site/freemarker/FreemarkerFileTest.java
@@ -1,0 +1,84 @@
+package resources.site.freemarker;
+
+import org.junit.Test;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.apache.commons.io.FilenameUtils.getExtension;
+import static org.hamcrest.core.Is.is;
+
+/**
+ * Test to check freemarker .ftl templates have correct output formatting and auto escaping set as the first line
+ * in the .ftl template file.  Freemarker recommend using *.ftlh files along with version 2.3.24 or higher to auto set
+ * output formatting (https://freemarker.apache.org/docs/pgui_config_outputformatsautoesc.html), however at present,
+ * doing this affects the design time refreshing of content in Hippo ftl templates (the refresh takes place,
+ * however, the content is not updated until a full rebuild takes place). Currently acknowledged that Hippo does not
+ * work out of the box correctly with *.ftlh (https://issues.onehippo.com/browse/ARCHE-523)
+ */
+public class FreemarkerFileTest {
+
+    private final static String FTL_FILES_DIRECTORY = System.getProperty("user.dir") + "/src/main/resources/site/freemarker";
+    private final static String DIRECTIVE_OUTPUT_FORMAT_HTML = "<#ftl output_format=\"HTML\">";
+
+    @Test
+    public void checkOutputFormatDirectiveIncluded() {
+
+        // given (files in freemarker directory)
+
+        // when
+        final List<String> filesMissingOutputFormatDirective = CheckFtlFilesForMissingOutputFormatDirective(FTL_FILES_DIRECTORY);
+
+        // then
+        assertThat("Output Format correctly set in all freemarker templates.",
+            filesMissingOutputFormatDirective,
+            is(empty()));
+    }
+
+    private List<String> CheckFtlFilesForMissingOutputFormatDirective(final String pathToCheck) {
+
+        final List<String> filesMissingOutputFormatDirective = new ArrayList<>();
+
+        try {
+            // Check for files in this folder and all sub folders
+            Files.walkFileTree(Paths.get(pathToCheck), new SimpleFileVisitor<Path>()
+            {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                    throws IOException {
+                    if (attrs.isDirectory()) {
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    if ("ftl".equalsIgnoreCase(getExtension(file.getFileName().toString()))) {
+
+                        // Directive must always be first line in ftl file
+                        try (Stream<String> stream = Files.lines(file.toAbsolutePath())) {
+                            stream
+                                .limit(1)
+                                .filter(s -> !s.contains(DIRECTIVE_OUTPUT_FORMAT_HTML))
+                                .map(f -> file.getFileName())
+                                .forEach(element -> filesMissingOutputFormatDirective.add(element.toString()));
+
+                        } catch (final Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (final Exception e) {
+            throw new RuntimeException("Failed to check ftl files in " + pathToCheck, e);
+        }
+
+        return filesMissingOutputFormatDirective;
+    }
+}

--- a/site/src/main/webapp/WEB-INF/web.xml
+++ b/site/src/main/webapp/WEB-INF/web.xml
@@ -203,7 +203,7 @@
 
   <servlet-mapping>
     <servlet-name>freemarker</servlet-name>
-    <url-pattern>*.ftlh</url-pattern>
+    <url-pattern>*.ftl</url-pattern>
   </servlet-mapping>
 
   <servlet-mapping>


### PR DESCRIPTION
Revert Freemarker templates back to use *.ftl extension to correct content refresh
issue discovered after RPS-220 (Set Freemarker template MIME type). Output
format and auto escaping is now set directly in the Freemarker template header.
Test added to check all freemarker templates have this directive included as the
first line of the file.