### PR TITLE
[RPS-241] Tests for download URLs

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/AbstractSitePage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/AbstractSitePage.java
@@ -5,7 +5,7 @@ import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
 
 public abstract class AbstractSitePage extends AbstractPage {
 
-    protected static final String URL = "http://localhost:8080/site";
+    public static final String URL = "http://localhost:8080/site";
 
     public AbstractSitePage(WebDriverProvider webDriverProvider) {
         super(webDriverProvider);

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
@@ -3,6 +3,8 @@ package uk.nhs.digital.ps.test.acceptance.util;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.openqa.selenium.net.Urls.urlEncode;
+
 public class TestContentUrls {
 
     private final Map<String, String> urlLookup = new HashMap();
@@ -56,6 +58,24 @@ public class TestContentUrls {
 
         // about pages
         add("terms and conditions", "/publications/about/terms-and-conditions");
+
+        // attachments
+        add("attachment-text.pdf",
+            getAttachmentUrl("attachment-test/content/content", "Attachments-v3"));
+        add("attachment.pdf",
+            getAttachmentUrl("attachment-test/content/content", "Attachments-v3[2]"));
+
+        add("dataset-attachment-text.pdf",
+            getAttachmentUrl("attachment-test/dataset/dataset", "Files-v3"));
+        add("dataset-attachment.pdf",
+            getAttachmentUrl("attachment-test/dataset/dataset", "Files-v3[2]"));
+    }
+
+    private String getAttachmentUrl(String siteUrl, String attachmentTag) {
+        return "/binaries/content/documents/corporate-website/publication-system/acceptance-tests/"
+            + siteUrl + "/"
+            + urlEncode("publicationsystem:" + attachmentTag) + "/"
+            + urlEncode("publicationsystem:attachmentResource");
     }
 
     private void add(String pageName, String url) {

--- a/acceptance-tests/src/test/resources/features/site/datasets.feature
+++ b/acceptance-tests/src/test/resources/features/site/datasets.feature
@@ -18,8 +18,6 @@ Scenario: View resource links and download attachments from dataset
     Then I should also see "Dataset Resources" with:
         | Google Resource Link          |
         | attachment.pdf; size: 7.2 kB  |
-    And I can download following files:
-        | attachment.pdf | attachment.pdf |
 
 Scenario: Find data set in publication resources
     Given I navigate to "publication with datasets" publication page
@@ -59,10 +57,9 @@ Scenario: Show new v3 files with text along with old v2 files
     Given I navigate to "attachment test dataset" page
     Then I should see publication page titled "Attachment Test Dataset"
     And I should also see "Dataset Resources" with:
-        | attachment.pdf; size: 7.2 kB       |
+        | dataset-attachment.pdf; size: 7.2 kB       |
         | Attachment with text; size: 7.2 kB |
         | attachment-old.pdf; size: 7.2 kB   |
     And I can download following files:
-        | attachment.pdf       | attachment.pdf      |
-        | Attachment with text | attachment-text.pdf |
-        | attachment-old.pdf   | attachment-old.pdf  |
+        | dataset-attachment.pdf | dataset-attachment.pdf      |
+        | Attachment with text   | dataset-attachment-text.pdf |

--- a/acceptance-tests/src/test/resources/features/site/publication.feature
+++ b/acceptance-tests/src/test/resources/features/site/publication.feature
@@ -59,4 +59,3 @@ Scenario: Show new v3 attachments with text along with old v2 attachments
     And I can download following files:
         | attachment.pdf       | attachment.pdf      |
         | Attachment with text | attachment-text.pdf |
-        | attachment-old.pdf   | attachment-old.pdf  |

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/attachment-test/dataset.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/attachment-test/dataset.yaml
@@ -28,7 +28,7 @@
       jcr:primaryType: publicationsystem:resource
     /publicationsystem:Files-v3[1]:
       /publicationsystem:attachmentResource:
-        hippo:filename: attachment-text.pdf
+        hippo:filename: dataset-attachment-text.pdf
         hippo:text:
           resource: /content/documents/corporate-website/publication-system/acceptance-tests/attachment-test/dataset/Files-v3[1]/attachmentResource/text.pdf
           type: binary
@@ -43,7 +43,7 @@
       publicationsystem:displayName: Attachment with text
     /publicationsystem:Files-v3[2]:
       /publicationsystem:attachmentResource:
-        hippo:filename: attachment.pdf
+        hippo:filename: dataset-attachment.pdf
         hippo:text:
           resource: /content/documents/corporate-website/publication-system/acceptance-tests/attachment-test/dataset/Files-v3[2]/attachmentResource/text.pdf
           type: binary
@@ -103,7 +103,7 @@
       jcr:primaryType: publicationsystem:resource
     /publicationsystem:Files-v3[1]:
       /publicationsystem:attachmentResource:
-        hippo:filename: attachment-text.pdf
+        hippo:filename: dataset-attachment-text.pdf
         hippo:text:
           resource: /content/documents/corporate-website/publication-system/acceptance-tests/attachment-test/dataset/Files-v3[1]/attachmentResource/text.pdf
           type: binary
@@ -118,7 +118,7 @@
       publicationsystem:displayName: Attachment with text
     /publicationsystem:Files-v3[2]:
       /publicationsystem:attachmentResource:
-        hippo:filename: attachment.pdf
+        hippo:filename: dataset-attachment.pdf
         hippo:text:
           resource: /content/documents/corporate-website/publication-system/acceptance-tests/attachment-test/dataset/Files-v3[2]/attachmentResource/text.pdf
           type: binary
@@ -180,7 +180,7 @@
       jcr:primaryType: publicationsystem:resource
     /publicationsystem:Files-v3[1]:
       /publicationsystem:attachmentResource:
-        hippo:filename: attachment-text.pdf
+        hippo:filename: dataset-attachment-text.pdf
         hippo:text:
           resource: /content/documents/corporate-website/publication-system/acceptance-tests/attachment-test/dataset/Files-v3[1]/attachmentResource/text.pdf
           type: binary
@@ -195,7 +195,7 @@
       publicationsystem:displayName: Attachment with text
     /publicationsystem:Files-v3[2]:
       /publicationsystem:attachmentResource:
-        hippo:filename: attachment.pdf
+        hippo:filename: dataset-attachment.pdf
         hippo:text:
           resource: /content/documents/corporate-website/publication-system/acceptance-tests/attachment-test/dataset/Files-v3[2]/attachmentResource/text.pdf
           type: binary


### PR DESCRIPTION
Added an extra step to the download tests that check the href in the
link for a file download, is what we expect it to be.
This will be able to run in headless mode as well so provides a more
comprehensive test for download links.