### PR TITLE
[RPS-233] Change nominal publication date to mandatory

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ContentPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ContentPage.java
@@ -8,6 +8,7 @@ import uk.nhs.digital.ps.test.acceptance.models.PublicationSeries;
 import uk.nhs.digital.ps.test.acceptance.pages.widgets.*;
 import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -84,7 +85,7 @@ public class ContentPage extends AbstractCmsPage {
         getAttachmentsWidget().uploadAttachments(publication.getAttachments());
     }
 
-    private DateCmsWidget findNominalDateField() {
+    public DateCmsWidget findNominalDateField() {
         return new DateCmsWidget(helper, "nominal-date");
     }
 
@@ -125,6 +126,14 @@ public class ContentPage extends AbstractCmsPage {
 
     public void populateDocumentSummary(final String documentSummary) {
         findSummaryElement().sendKeys(documentSummary);
+    }
+
+    public void populateDocumentNominalDate(final Instant documentNominalDate) {
+        findNominalDateField().populateWith(documentNominalDate);
+    }
+
+    public void populateDocumentNominalDate() {
+        findNominalDateField().setToToday();
     }
 
     public WebElement findSummaryElement() {

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/DateCmsWidget.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/DateCmsWidget.java
@@ -35,4 +35,14 @@ public class DateCmsWidget {
             + "//div[contains(@class, '" + dateFieldClass + "')]//input[@type='text' and @class='date']"
         ));
     }
+
+    public void setToToday() {
+        WebElement resetButton = find().findElement(By.xpath("//a[contains(@class, 'hippo-datepicker-reset')]"));
+        resetButton.click();
+    }
+
+    public void clear() {
+        find().clear();
+    }
+
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/cms/ps/CmsSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/cms/ps/CmsSteps.java
@@ -334,6 +334,7 @@ public class CmsSteps extends AbstractSpringSteps {
         // these are the only mandatory fields on the dataset.
         contentPage.populateDocumentTitle(newRandomString());
         contentPage.populateDocumentSummary(newRandomString());
+        contentPage.populateDocumentNominalDate();
     }
 
     @When("^I populate the publication$")
@@ -361,5 +362,10 @@ public class CmsSteps extends AbstractSpringSteps {
     @When("^I clear the summary$")
     public void iClearTheSummary() throws Throwable {
         contentPage.findSummaryElement().clear();
+    }
+
+    @When("^I clear the nominal date")
+    public void iClearTheNominalDate() throws Throwable {
+        contentPage.findNominalDateField().clear();
     }
 }

--- a/acceptance-tests/src/test/resources/features/cms/datasetValidation.feature
+++ b/acceptance-tests/src/test/resources/features/cms/datasetValidation.feature
@@ -23,6 +23,15 @@ Feature: Dataset edit screen - validation
 
 
     @DiscardAfter
+    Scenario: Nominal date validation
+        Given I have a dataset opened for editing
+        And I populate the dataset
+        When I clear the nominal date
+        And I save the dataset
+        Then the save is rejected with error message containing "A required field is not present"
+
+
+    @DiscardAfter
     Scenario: Long title validation
         Given I have a dataset opened for editing
         When I populate the title with text longer than the maximum allowed limit of 250 characters

--- a/acceptance-tests/src/test/resources/features/cms/publicationValidation.feature
+++ b/acceptance-tests/src/test/resources/features/cms/publicationValidation.feature
@@ -23,6 +23,15 @@ Feature: Publication edit screen - validation
 
 
     @DiscardAfter
+    Scenario: Nominal date validation
+        Given I have a publication opened for editing
+        And I populate the publication
+        When I clear the nominal date
+        And I save the publication
+        Then the save is rejected with error message containing "A required field is not present"
+
+
+    @DiscardAfter
     Scenario: Long title validation
         Given I have a publication opened for editing
         When I populate the title with text longer than the maximum allowed limit of 250 characters

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/dataset.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/dataset.yaml
@@ -85,8 +85,11 @@ definitions:
               jcr:primaryType: frontend:pluginconfig
             caption: Nominal Date
             field: NominalDate
+            hint: ''
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.css:
+            - nominal-date
             wicket.id: ${cluster.id}.right.item
           /NextPublicationDate:
             /cluster.options:
@@ -210,6 +213,8 @@ definitions:
             hipposysedit:path: publicationsystem:NominalDate
             hipposysedit:primary: false
             hipposysedit:type: CalendarDate
+            hipposysedit:validators:
+            - required
             jcr:primaryType: hipposysedit:field
           /ResourceLinks:
             hipposysedit:mandatory: false

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
@@ -61,6 +61,7 @@ definitions:
               jcr:primaryType: frontend:pluginconfig
             caption: Nominal Publication Date
             field: nominal_date
+            hint: ''
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.css:
@@ -299,6 +300,8 @@ definitions:
             hipposysedit:path: publicationsystem:NominalDate
             hipposysedit:primary: false
             hipposysedit:type: CalendarDate
+            hipposysedit:validators:
+            - required
             jcr:primaryType: hipposysedit:field
           /publicly_accessible:
             hipposysedit:mandatory: false

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/attachment-test/dataset.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/attachment-test/dataset.yaml
@@ -73,7 +73,7 @@
     publicationsystem:Granularity:
     - ''
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
-    publicationsystem:NominalDate: 0001-01-01T12:00:00Z
+    publicationsystem:NominalDate: 2017-12-13T00:00:00Z
     publicationsystem:Summary: Attachment Test Dataset
     publicationsystem:Title: Attachment Test Dataset
   /dataset[2]:
@@ -150,7 +150,7 @@
     publicationsystem:Granularity:
     - ''
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
-    publicationsystem:NominalDate: 0001-01-01T12:00:00Z
+    publicationsystem:NominalDate: 2017-12-13T00:00:00Z
     publicationsystem:Summary: Attachment Test Dataset
     publicationsystem:Title: Attachment Test Dataset
   /dataset[3]:
@@ -227,7 +227,7 @@
     publicationsystem:Granularity:
     - ''
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
-    publicationsystem:NominalDate: 0001-01-01T12:00:00Z
+    publicationsystem:NominalDate: 2017-12-13T00:00:00Z
     publicationsystem:Summary: Attachment Test Dataset
     publicationsystem:Title: Attachment Test Dataset
   jcr:mixinTypes:


### PR DESCRIPTION
Updated nominal publication date fields on publication and dataset document types
to be mandatory. Added tests to check validation correctly occurs.