### PR TITLE
[RPS-267] Fix broken pagination links caused by HTML output formatting

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/CommonPageElements.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/CommonPageElements.java
@@ -7,13 +7,14 @@ import org.openqa.selenium.WebElement;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.text.MessageFormat.format;
-
 public class CommonPageElements implements PageElements {
 
     private final static Map<String, By> pageElements = new HashMap<String, By>() {{
         put("Search Box",
             By.xpath("//input[@name='query']"));
+        put("Pagination page",
+            By.xpath("//li[contains(@class, " +
+            "'pagination__list__item pagination__list__item--current')]/span"));
     }};
 
     @Override

--- a/acceptance-tests/src/test/resources/features/site/search.feature
+++ b/acceptance-tests/src/test/resources/features/site/search.feature
@@ -25,3 +25,23 @@ Feature: Basic search
         Given I navigate to the "home" page
         When I search for "test"
         Then I can click on the "Statistical Publication" link
+
+    Scenario: Clickable pagination links
+        Given I navigate to the "home" page
+        When I search for "lorem"
+        Then I can click on the "Page 2" link
+        And I should see:
+            | Pagination page | 2 |
+        When I can click on the "Previous" link
+        Then I should see:
+            | Pagination page | 1 |
+        When I can click on the "Next" link
+        Then I should see:
+            | Pagination page | 2 |
+        When I can click on the "First" link
+        Then I should see:
+            | Pagination page | 1 |
+        When I can click on the "Last" link
+        Then I can click on the "First" link
+        # Check for "Last" link intentionally followed by click on "First" link
+        # since 'last' page number could increase if more lorem test documents added.

--- a/repository-data/webfiles/src/main/resources/site/freemarker/include/pagination.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/include/pagination.ftl
@@ -13,18 +13,24 @@
                             <@hst.param name="page" value="1"/>
                             <@hst.param name="pageSize" value="${pageable.pageSize}"/>
                         </@hst.renderURL>
-                        <li class="pagination__list__item pagination__list__item--first"><a href="${pageUrlFirst}" title="First"><span class="next">First</span></a></li>
+                        <li class="pagination__list__item pagination__list__item--first">
+                            <#outputformat "undefined"><a href="${pageUrlFirst}" title="First"><span class="next">First</span></a></#outputformat>
+                        </li>
                         <@hst.renderURL var="pageUrlPrevious">
                             <@hst.param name="page" value="${pageable.previousPage}"/>
                             <@hst.param name="pageSize" value="${pageable.pageSize}"/>
                         </@hst.renderURL>
-                        <li class="pagination__list__item pagination__list__item--previous"><a href="${pageUrlPrevious}" title="Previous"><span class="prev">Previous</span></a></li>
+                        <li class="pagination__list__item pagination__list__item--previous">
+                            <#outputformat "undefined"><a href="${pageUrlPrevious}" title="Previous"><span class="prev">Previous</span></a></#outputformat>
+                        </li>
                     </#if>
                 </#if>
                 <#if pageable.currentPage == pageNr>
                     <li class="pagination__list__item pagination__list__item--current"><span class="">${pageNr}</span></li>
                 <#else >
-                    <li class="pagination__list__item"><a href="${pageUrl}" title="Page ${pageNr}">${pageNr}</a></li>
+                    <li class="pagination__list__item">
+                        <#outputformat "undefined"><a href="${pageUrl}" title="Page ${pageNr}">${pageNr}</a></#outputformat>
+                    </li>
                 </#if>
                 <#if !pageNr_has_next>
                     <#if pageable.next>
@@ -32,12 +38,16 @@
                             <@hst.param name="page" value="${pageable.nextPage}"/>
                             <@hst.param name="pageSize" value="${pageable.pageSize}"/>
                         </@hst.renderURL>
-                        <li class="pagination__list__item pagination__list__item--next"><a href="${pageUrlNext}" title="Next"><span class="next">Next</span></a></li>
+                        <li class="pagination__list__item pagination__list__item--next">
+                            <#outputformat "undefined"><a href="${pageUrlNext}" title="Next"><span class="next">Next</span></a></#outputformat>
+                        </li>
                         <@hst.renderURL var="pageUrlLast">
                             <@hst.param name="page" value="${pageable.totalPages}"/>
                             <@hst.param name="pageSize" value="${pageable.pageSize}"/>
                         </@hst.renderURL>
-                        <li class="pagination__list__item pagination__list__item--last"><a href="${pageUrlLast}" title="Last"><span class="next">Last</span></a></li>
+                        <li class="pagination__list__item pagination__list__item--last">
+                            <#outputformat "undefined"><a href="${pageUrlLast}" title="Last"><span class="next">Last</span></a></#outputformat>
+                        </li>
                     </#if>
                 </#if>
             </#list>


### PR DESCRIPTION
Remove HTML output formatting on the pagination component which caused issues
with paging links. Add acceptance test for pagination link functionality.