### PR TITLE
[RPS-270] CI Migration: report missed data sets

### DIFF
--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/MigrationReport.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/MigrationReport.java
@@ -15,22 +15,21 @@ import static java.nio.file.StandardOpenOption.*;
 public final class MigrationReport {
     private static final Logger log = LoggerFactory.getLogger(MigrationReport.class);
 
-    private static MigrationReport instance;
-
     private final ExecutionParameters executionParameters;
     private final ArrayList<String> errors = new ArrayList<>();
 
-    private MigrationReport(ExecutionParameters executionParameters) {
+    public MigrationReport(final ExecutionParameters executionParameters) {
         this.executionParameters = executionParameters;
     }
 
-    public static void init(ExecutionParameters executionParameters) {
-        instance = new MigrationReport(executionParameters);
+    public void add(String... output) {
+        addToLog(null, output);
     }
 
-    public static void add(Exception e, String... output) {
-        getInstance().addToLog(e, output);
+    public void add(Exception e, String... output) {
+        addToLog(e, output);
     }
+
     private void addToLog(Exception e, String... output) {
         String error = String.join("\n", output);
         if (e != null) {
@@ -43,10 +42,6 @@ public final class MigrationReport {
 
         log.error(error);
         errors.add(error);
-    }
-
-    public static MigrationReport getInstance() {
-        return instance;
     }
 
     public void writeToFile() {

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/PublicationSystemMigrator.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/PublicationSystemMigrator.java
@@ -25,7 +25,10 @@ public class PublicationSystemMigrator implements ApplicationRunner {
 
     private final ExecutionConfigurator executionConfigurator;
 
-    private ExecutionParameters executionParameters;
+    private final MigrationReport migrationReport;
+
+    private final ExecutionParameters executionParameters;
+
 
     public static void main(final String... args) {
         SpringApplication.run(PublicationSystemMigrator.class, args);
@@ -33,9 +36,11 @@ public class PublicationSystemMigrator implements ApplicationRunner {
 
     public PublicationSystemMigrator(final List<MigrationTask> migrationTasks,
                                      final ExecutionConfigurator executionConfigurator,
+                                     final MigrationReport migrationReport,
                                      final ExecutionParameters executionParameters) {
         this.migrationTasks = migrationTasks;
         this.executionConfigurator = executionConfigurator;
+        this.migrationReport = migrationReport;
         this.executionParameters = executionParameters;
     }
 
@@ -51,8 +56,6 @@ public class PublicationSystemMigrator implements ApplicationRunner {
 
         logExecutionParameters();
 
-        MigrationReport.init(executionParameters);
-
         try {
             migrationTasks.stream()
                 .peek(migrationTask -> {
@@ -65,7 +68,7 @@ public class PublicationSystemMigrator implements ApplicationRunner {
         } catch (final Exception e) {
             log.error("Migration has failed.", e);
         } finally {
-            MigrationReport.getInstance().writeToFile();
+            migrationReport.writeToFile();
             logExecutionParameters();
         }
 

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/config/MigratorConfiguration.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/config/MigratorConfiguration.java
@@ -2,6 +2,7 @@ package uk.nhs.digital.ps.migrator.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import uk.nhs.digital.ps.migrator.MigrationReport;
 import uk.nhs.digital.ps.migrator.task.*;
 import uk.nhs.digital.ps.migrator.task.importables.CcgImportables;
 import uk.nhs.digital.ps.migrator.task.importables.CompendiumImportables;
@@ -21,7 +22,9 @@ public class MigratorConfiguration {
                                      final SocialCareImportables socialCareImportables,
                                      final CcgImportables ccgImportables,
                                      final NhsOutcomesFrameworkImportables nhsOutcomesFrameworkImportables,
-                                     final CompendiumImportables compendiumImportables) {
+                                     final CompendiumImportables compendiumImportables,
+                                     final ImportableFileWriter importableFileWriter,
+                                     final MigrationReport migrationReport) {
 
         return asList(
             new UnzipNesstarExportFileTask(executionParameters),
@@ -31,7 +34,9 @@ public class MigratorConfiguration {
                 socialCareImportables,
                 ccgImportables,
                 nhsOutcomesFrameworkImportables,
-                compendiumImportables),
+                compendiumImportables,
+                importableFileWriter,
+                migrationReport),
             new GenerateTaxonomyTask(executionParameters)
         );
     }
@@ -42,13 +47,25 @@ public class MigratorConfiguration {
     }
 
     @Bean
+    public MigrationReport migrationReport(final ExecutionParameters executionParameters) {
+        return new MigrationReport(executionParameters);
+    }
+
+    @Bean
     public ExecutionConfigurator commandLineArgsParser(final ExecutionParameters executionParameters) {
         return new ExecutionConfigurator(executionParameters);
     }
 
     @Bean
-    public ImportableItemsFactory importableItemsFactory(final ExecutionParameters executionParameters) {
-        return new ImportableItemsFactory(executionParameters);
+    public ImportableItemsFactory importableItemsFactory(final ExecutionParameters executionParameters,
+                                                         final MigrationReport migrationReport)
+    {
+        return new ImportableItemsFactory(executionParameters, migrationReport);
+    }
+
+    @Bean
+    public ImportableFileWriter importableFileWriter(final MigrationReport migrationReport) {
+        return new ImportableFileWriter(migrationReport);
     }
 
     @Bean
@@ -68,7 +85,9 @@ public class MigratorConfiguration {
 
     @Bean
     public CompendiumImportables compendiumImportables(final ExecutionParameters executionParameters,
-                                                       final ImportableItemsFactory importableItemsFactory) {
-        return new CompendiumImportables(executionParameters, importableItemsFactory);
+                                                       final ImportableItemsFactory importableItemsFactory,
+                                                       final MigrationReport migrationReport
+    ) {
+        return new CompendiumImportables(executionParameters, importableItemsFactory, migrationReport);
     }
 }

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/Attachment.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/Attachment.java
@@ -28,10 +28,13 @@ public class Attachment {
     private final String uri;
     private final Path attachmentDownloadDir;
 
-    public Attachment(final Path attachmentDownloadDir, String title, String uri) {
+    private final MigrationReport migrationReport;
+
+    public Attachment(final Path attachmentDownloadDir, String title, String uri, final MigrationReport migrationReport) {
         this.attachmentDownloadDir = attachmentDownloadDir;
         this.title = title;
         this.uri = uri;
+        this.migrationReport = migrationReport;
     }
 
     public String getTitle() {
@@ -92,7 +95,7 @@ public class Attachment {
             return true;
         } catch (Exception e) {
             file.delete(); // Attempt to delete the file as it may be partially downloaded
-            MigrationReport.add(e, "Error occurred downloading attachment: " + title,
+            migrationReport.add(e, "Error occurred downloading attachment: " + title,
                 "From: " + encodedUri,
                 "This dataset will be missing this attachment", publishingPackage.toString());
             return false;

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/DataSet.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/DataSet.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 
 public class DataSet extends HippoImportableItem {
 
+    private final String pCode;
     private final String title;
     private final String summary;
     private final String nominalDate;
@@ -13,6 +14,7 @@ public class DataSet extends HippoImportableItem {
     private final String taxonomyKeys;
 
     public DataSet(final Folder parentFolder,
+                   final String pCode,
                    final String name,
                    final String title,
                    final String summary,
@@ -21,6 +23,8 @@ public class DataSet extends HippoImportableItem {
                    final List<ResourceLink> resourceLinks,
                    final String taxonomyKeys) {
         super(parentFolder, name);
+
+        this.pCode = pCode;
         this.title = title;
         this.summary = formatSummary(summary);
         this.nominalDate = nominalDate;
@@ -71,4 +75,7 @@ public class DataSet extends HippoImportableItem {
         return taxonomyKeys;
     }
 
+    public String getpCode() {
+        return pCode;
+    }
 }

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/nesstar/DataSetRepository.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/nesstar/DataSetRepository.java
@@ -2,6 +2,7 @@ package uk.nhs.digital.ps.migrator.model.nesstar;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toMap;
 
@@ -20,5 +21,9 @@ public class DataSetRepository {
 
     public PublishingPackage findById(final String id) {
         return datasetsByIds.get(id);
+    }
+
+    public Stream<PublishingPackage> stream() {
+        return datasetsByIds.values().stream();
     }
 }

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/ImportableFileWriter.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/ImportableFileWriter.java
@@ -25,7 +25,13 @@ public class ImportableFileWriter {
     private static final Logger logger = LoggerFactory.getLogger(ImportableFileWriter.class);
     private static Configuration cfg;
 
-    static void writeImportableFiles(final List<? extends HippoImportableItem> importableItems,
+    private final MigrationReport migrationReport;
+
+    public ImportableFileWriter(final MigrationReport migrationReport) {
+        this.migrationReport = migrationReport;
+    }
+
+    void writeImportableFiles(final List<? extends HippoImportableItem> importableItems,
                                      final Path targetDir) {
 
 
@@ -41,7 +47,7 @@ public class ImportableFileWriter {
         }
     }
 
-    private static void writeImportableFile(final HippoImportableItem importableItem,
+    private void writeImportableFile(final HippoImportableItem importableItem,
                                             final String fileName,
                                             final Path targetDir) {
 
@@ -68,7 +74,7 @@ public class ImportableFileWriter {
 
         } catch (final Exception e) {
             // If we fail with one file, make a note of the document that failed and carry on
-            MigrationReport.add(e, "Failed to write out item:", "Item will not be imported", importableItem.toString());
+            migrationReport.add(e, "Failed to write out item:", "Item will not be imported", importableItem.toString());
         }
     }
 

--- a/migrator/src/test/java/uk/nhs/digital/ps/migrator/model/hippo/DataSetTest.java
+++ b/migrator/src/test/java/uk/nhs/digital/ps/migrator/model/hippo/DataSetTest.java
@@ -21,14 +21,14 @@ public class DataSetTest {
         String input = testData[0];
         String expected = testData[1];
 
-        DataSet dataSet = new DataSet(null, "", "", input, null, null, null,null);
+        DataSet dataSet = new DataSet(null, "", "", "", input, null, null, null,null);
         assertThat(dataSet.getSummary(), is(expected));
     }
 
     @Test(expected = RuntimeException.class)
     @UseDataProvider("invalidSummaries")
     public void invalidSummaryFormatTest(String summary) {
-        new DataSet(null, "", "", summary, null, null, null,null);
+        new DataSet(null, "", "", "", summary, null, null, null,null);
     }
 
     @DataProvider


### PR DESCRIPTION
Added reporting on:
- Missed Datasets (e.g. when some are present in Nesstar export but
  were missed in manual mapping, such as Compendium).
- Duplicate datasets being written to Hippo import files.

Also, refactored MigrationReport so that it exposes instance methods
rather than static; it is now instantiated and injected from Spring
context.