### PR TITLE
[RPS-278] Empty Key Facts header

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/SitePage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/SitePage.java
@@ -57,7 +57,15 @@ public class SitePage extends AbstractSitePage {
     }
 
     public WebElement findElementWithTitle(String title) {
-        List<WebElement> elements = getWebDriver().findElements(By.xpath("//*[@title='" + title +"']"));
+        return findOptionalElement("//*[@title='" + title + "']");
+    }
+
+    public WebElement findElementWithText(String text) {
+        return findOptionalElement("//*[text()='" + text + "']");
+    }
+
+    private WebElement findOptionalElement(String xpath) {
+        List<WebElement> elements = getWebDriver().findElements(By.xpath(xpath));
 
         if (elements.size() < 1) {
             return null;

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/SiteSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/SiteSteps.java
@@ -134,6 +134,14 @@ public class SiteSteps extends AbstractSpringSteps {
         }
     }
 
+    @Then("^I should not see headers:$")
+    public void iShouldNotSeeHeaders(DataTable headersTable) throws Throwable {
+        List<String> headers = headersTable.asList(String.class);
+        for (String header : headers) {
+            assertNull("Header should not be displayed", sitePage.findElementWithText(header));
+        }
+    }
+
     @Then("^I should(?: also)? see multiple \"([^\"]+)\" with:")
     public void iShouldSeeMultipleItemsOf(String pageElementName, final DataTable elementItems) throws Throwable  {
         int i = 0;

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
@@ -51,6 +51,12 @@ public class TestContentUrls {
         add("attachment test dataset",
             "/publications/acceptance-tests/attachment-test/dataset");
 
+        // bare minimum documents
+        add("bare minimum publication",
+            "/publications/acceptance-tests/bare-minimum-publication");
+        add("bare minimum dataset",
+            "/publications/acceptance-tests/bare-minimum-publication/bare-minimum-dataset");
+
         // invalid urls
         add("invalid root", "/invalid");
         add("invalid document", "/publications/invalid");

--- a/acceptance-tests/src/test/resources/features/site/datasets.feature
+++ b/acceptance-tests/src/test/resources/features/site/datasets.feature
@@ -13,6 +13,14 @@ Scenario: Search individual data set by name
         | Dataset Date Range            | 01/02/2016 to 01/07/2017                                          |
         | Dataset Nominal Date          | 10/10/2017                                                        |
 
+Scenario: Headers don't display for empty fields
+    Given I navigate to the "bare minimum dataset" page
+    Then I should see page titled "Bare Minimum Dataset"
+    And I should not see headers:
+        | Geographical Granularity: |
+        | Geographic Coverage:      |
+        | Taxonomy                  |
+
 Scenario: View resource links and download attachments from dataset
     Given I navigate to the "publication with datasets Dataset" data set page
     Then I should also see "Dataset Resources" with:

--- a/acceptance-tests/src/test/resources/features/site/publication.feature
+++ b/acceptance-tests/src/test/resources/features/site/publication.feature
@@ -32,6 +32,18 @@ Scenario: Display taxonomy list
         | Publication Date Range | 01/11/2017 to 01/02/2018       |
         | Publication Taxonomy   | People, patients and geography |
 
+Scenario: Headers don't display for empty fields
+    Given I navigate to the "bare minimum publication" page
+    Then I should see page titled "Bare Minimum Publication"
+    And I should not see headers:
+        | Geographic Coverage:      |
+        | Geographical Granularity: |
+        | Date Range:               |
+        | Key Facts                 |
+        | Administrative Sources    |
+        | Related Links             |
+        | Taxonomy                  |
+
 Scenario: Display multiparagraph summary
     Given I navigate to "publication with datasets" page
     Then I should also see multiple "Publication Summary" with:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/bare-minimum-publication.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/bare-minimum-publication.yaml
@@ -1,0 +1,151 @@
+---
+/content/documents/corporate-website/publication-system/acceptance-tests/bare-minimum-publication:
+  /bare-minimum-dataset:
+    /bare-minimum-dataset[1]:
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-08T11:13:35.315Z
+      hippostdpubwf:lastModificationDate: 2018-01-08T11:13:35.315Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 8336a314-aea1-4c7b-85e0-0f9f02fae88c
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:dataset
+      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+      publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
+      publicationsystem:NominalDate: 2018-01-08T00:00:00Z
+      publicationsystem:Summary: Bare Minimum Dataset Summary
+      publicationsystem:Title: Bare Minimum Dataset
+    /bare-minimum-dataset[2]:
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-08T11:13:35.315Z
+      hippostdpubwf:lastModificationDate: 2018-01-08T11:13:54.739Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 8336a314-aea1-4c7b-85e0-0f9f02fae88c
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:dataset
+      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+      publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
+      publicationsystem:NominalDate: 2018-01-08T00:00:00Z
+      publicationsystem:Summary: Bare Minimum Dataset Summary
+      publicationsystem:Title: Bare Minimum Dataset
+    /bare-minimum-dataset[3]:
+      hippo:availability:
+      - live
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-08T11:13:35.315Z
+      hippostdpubwf:lastModificationDate: 2018-01-08T11:13:54.739Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2018-01-08T11:14:52.740Z
+      hippotranslation:id: 8336a314-aea1-4c7b-85e0-0f9f02fae88c
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:dataset
+      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+      publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
+      publicationsystem:NominalDate: 2018-01-08T00:00:00Z
+      publicationsystem:Summary: Bare Minimum Dataset Summary
+      publicationsystem:Title: Bare Minimum Dataset
+    hippo:name: Bare Minimum Dataset
+    jcr:mixinTypes:
+    - hippo:named
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+  /content:
+    /content[1]:
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-08T11:12:44.629Z
+      hippostdpubwf:lastModificationDate: 2018-01-08T11:12:44.630Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 7d329984-9f02-49e2-a9a7-9ce11e1c25b1
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2018-01-08T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: Bare Minimum Publication Summary
+      publicationsystem:Title: Bare Minimum Publication
+    /content[2]:
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-08T11:12:44.629Z
+      hippostdpubwf:lastModificationDate: 2018-01-08T11:13:05.238Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 7d329984-9f02-49e2-a9a7-9ce11e1c25b1
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2018-01-08T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: Bare Minimum Publication Summary
+      publicationsystem:Title: Bare Minimum Publication
+    /content[3]:
+      hippo:availability:
+      - live
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-08T11:12:44.629Z
+      hippostdpubwf:lastModificationDate: 2018-01-08T11:13:05.238Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2018-01-08T11:13:08.922Z
+      hippotranslation:id: 7d329984-9f02-49e2-a9a7-9ce11e1c25b1
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+      publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2018-01-08T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: Bare Minimum Publication Summary
+      publicationsystem:Title: Bare Minimum Publication
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+  hippo:name: Bare Minimum Publication
+  hippostd:foldertype:
+  - new-translated-folder
+  - new-document
+  hippotranslation:id: f49c72e8-d043-4fb8-9a45-41ed549af83f
+  hippotranslation:locale: en
+  jcr:mixinTypes:
+  - hippo:named
+  - hippotranslation:translated
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
@@ -12,11 +12,7 @@
     <dl class="media__body">
         <dt>Nominal Publication Date:</dt>
         <dd class="zeta" data-uipath="ps.publication.nominal-publication-date">
-            <#if publication.nominalPublicationDate??>
-                <@formatRestrictableDate value=publication.nominalPublicationDate/>
-            <#else>
-                (Not specified)
-            </#if>
+            <@formatRestrictableDate value=publication.nominalPublicationDate/>
         </dd>
     </dl>
 </#macro>
@@ -72,7 +68,7 @@
                     <div class="media">
                         <div class="media__icon media__icon--geographic-coverage"></div>
                         <dl class="media__body">
-                            <dt id="geographic-coverage">Geographic coverage:</dt>
+                            <dt id="geographic-coverage">Geographic Coverage:</dt>
                             <dd data-uipath="ps.publication.geographic-coverage">
                                 ${publication.geographicCoverage}
                             </dd>
@@ -84,7 +80,7 @@
                     <div class="media">
                         <div class="media__icon media__icon--granularity"></div>
                         <dl class="media__body">
-                            <dt>Geographical granularity</dt>
+                            <dt>Geographical Granularity:</dt>
                             <dd data-uipath="ps.publication.granularity">
                                 <#list publication.granularity as granularityItem><#if granularityItem?index != 0>, </#if>${granularityItem}</#list>
                             </dd>
@@ -96,7 +92,7 @@
                     <div class="media">
                         <div class="media__icon media__icon--date-range"></div>
                         <dl class="media__body">
-                            <dt>Date Range</dt>
+                            <dt>Date Range:</dt>
                             <dd data-uipath="ps.publication.date-range">
                                 <#if publication.coverageStart?? && publication.coverageEnd??>
                                     <@formatCoverageDates start=publication.coverageStart.time end=publication.coverageEnd.time/>
@@ -118,7 +114,7 @@
                 <h2><@fmt.message key="headers.summary"/></h2>
                 <@structuredText item=publication.summary uipath="ps.publication.summary" />
 
-                <#if publication.keyFacts?has_content>
+                <#if publication.keyFacts.elements?has_content>
                     <h2><@fmt.message key="headers.key-facts"/></h2>
                     <@structuredText item=publication.keyFacts uipath="ps.publication.key-facts" />
                 </#if>
@@ -164,7 +160,7 @@
                     </#if>
                 </div>
 
-                <#if publication.taxonomyList??>
+                <#if publication.taxonomyList?has_content>
                     <div class="panel panel--grey">
                         <h3>Taxonomy</h3>
                         <div data-uipath="ps.publication.taxonomy">

--- a/site/src/main/java/uk/nhs/digital/ps/beans/Publication.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/Publication.java
@@ -78,9 +78,9 @@ public class Publication extends BaseDocument {
                 List<Category> ancestors = (List<Category>) taxonomyTree.getCategoryByKey(key).getAncestors();
 
                 List<String> list = ancestors.stream()
-                    .map(category -> category.getInfo("en").getName())
+                    .map(category -> category.getInfo(Locale.UK).getName())
                     .collect(Collectors.toList());
-                list.add(taxonomyTree.getCategoryByKey(key).getInfo("en").getName());
+                list.add(taxonomyTree.getCategoryByKey(key).getInfo(Locale.UK).getName());
                 taxonomyList.add(list);
             }
         }

--- a/site/src/main/java/uk/nhs/digital/ps/beans/structuredText/StructuredText.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/structuredText/StructuredText.java
@@ -3,6 +3,7 @@ package uk.nhs.digital.ps.beans.structuredText;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class StructuredText {
 
@@ -24,8 +25,7 @@ public class StructuredText {
             .orElse(new Paragraph(""));
     }
 
-    protected List<Element> parse(String text) {
-        List<Element> elements = new ArrayList<>();
+    private List<Element> parse(String text) {
 
         text = text
             // eliminate all leading and trailing white space characters
@@ -36,15 +36,9 @@ public class StructuredText {
             // eliminate sequences of new line chars over two characters long
             .replaceAll("\n{3,}", "\n\n");
 
-        Arrays.asList(text.split("\n\n"))
-            .forEach(t -> {
-                if (BulletList.match(t)) {
-                    elements.add(new BulletList(t));
-                    return;
-                }
-                elements.add(new Paragraph(t));
-            });
-
-        return elements;
+        return Arrays.stream(text.split("\n\n"))
+            .filter(t -> !t.isEmpty())
+            .map(t -> BulletList.match(t) ? new BulletList(t) : new Paragraph(t))
+            .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Fixed a bug where the Key Facts header would display even when the
Key Facts field was empty. Added tests for the headers not displaying
when the fields are empty and fixed a few other small issues with the
site.